### PR TITLE
fix: offline resolution reaches stage 8 — file:// registry fixture + scheme routing (#54)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,50 @@ jobs:
           files: coverage.out
           fail_ci_if_error: false
 
+  offline-resolve:
+    name: Offline resolve (no AWS)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Build strata
+        run: go build -o bin/strata ./cmd/strata
+
+      - name: Materialize the file:// fixture registry
+        run: go run ./internal/testregistry/mkregistry "$RUNNER_TEMP/strata-fixture"
+
+      # This job is the closing condition of #54: a checkout with no AWS
+      # credentials configured must be able to produce a lockfile. The runner has
+      # no AWS credentials, and the blank AWS_* values below keep an accidental
+      # future org-level secret from making this pass for the wrong reason.
+      - name: Resolve a profile end to end
+        env:
+          STRATA_REGISTRY_URL: file://${{ runner.temp }}/strata-fixture/registry
+          AWS_PROFILE: ""
+          AWS_ACCESS_KEY_ID: ""
+          AWS_SECRET_ACCESS_KEY: ""
+          AWS_REGION: ""
+        run: |
+          set -euo pipefail
+          ./bin/strata resolve \
+            "$RUNNER_TEMP/strata-fixture/profiles/offline-minimal.yaml" \
+            -o "$RUNNER_TEMP/offline.lock.yaml"
+
+          lock="$RUNNER_TEMP/offline.lock.yaml"
+          test -s "$lock"
+          grep -q 'id: python-3.13.2-linux-gnu-2.34-x86_64' "$lock"
+          grep -q 'id: jupyterlab-4.2.0-linux-gnu-2.34-x86_64' "$lock"
+          # Every layer must carry a bundle: an empty one is the stage-7 failure
+          # this job exists to prevent regressing.
+          ! grep -q 'bundle: ""' "$lock"
+          echo "--- $lock ---"
+          cat "$lock"
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Offline resolution reaches stage 8** (#54). `STRATA_REGISTRY_URL=file:///...`
+  was passed to `registry.NewS3Client` regardless of scheme, so it failed the
+  `s3://` check and `strata resolve`/`strata freeze` fell back to the embedded
+  recipe catalog with a warning on stderr. That catalog carries no `bundle` or
+  `rekor_entry` — nothing has been built from it — so resolution died in stage 7
+  with `BUNDLE_MISSING` for every profile, and a clone with no AWS credentials
+  could not produce a lockfile at all. Both paths now dispatch by scheme through
+  `newClientForURL`. A `file://` registry also no longer reaches for SSM when
+  probing the base OS, which would have traded the missing lockfile for an IMDS
+  timeout. Completes the two work items left unchecked in #36.
+
+### Added
+- **`internal/testregistry`**: repo-resident `file://` fixture registry that
+  makes resolution reach stage 8 with no AWS credentials, no network, and no
+  prior build — two layers with a real dependency edge, real `sha256` over real
+  bytes, bundles that exist on disk, and numeric `rekor_entry` values. Usable
+  from a test (`testregistry.New(t)`) or a shell
+  (`go run ./internal/testregistry/mkregistry <dir>`). `Materialize` verifies
+  each committed digest against the committed bytes, so a drifted fixture fails
+  with the manifest path rather than rotting silently.
+- **`make offline-resolve`**: materializes the fixture registry and resolves a
+  profile through it end to end. A new CI job runs the same sequence with the
+  real binary and blank `AWS_*`, so "a fresh clone can produce a lockfile" is
+  checked on every pull request rather than asserted.
+- README: the `STRATA_REGISTRY_URL=file:///var/strata-local` offline workflow,
+  including which commands accept a `file://` registry and which are still
+  S3-only, and why the embedded catalog cannot resolve on its own.
+
 ## [0.22.0] - 2026-03-27
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-.PHONY: build test cover lint vet check clean
+.PHONY: build test cover lint vet check clean offline-resolve
 
 BINARY  := strata
 GOFLAGS := -v
+FIXTURE := $(CURDIR)/bin/fixture
 
 build:
 	go build $(GOFLAGS) -o bin/$(BINARY) ./cmd/$(BINARY)
@@ -20,7 +21,18 @@ vet:
 
 check: vet lint test
 
+# offline-resolve proves a fresh clone can produce a lockfile with no AWS
+# credentials and no network: it materializes the file:// fixture registry and
+# resolves a profile through it end to end. CI runs the same sequence.
+offline-resolve: build
+	rm -rf $(FIXTURE)
+	go run ./internal/testregistry/mkregistry $(FIXTURE)
+	STRATA_REGISTRY_URL=file://$(FIXTURE)/registry \
+		bin/$(BINARY) resolve $(FIXTURE)/profiles/offline-minimal.yaml -o $(FIXTURE)/offline.lock.yaml
+	test -s $(FIXTURE)/offline.lock.yaml
+	@echo "offline-resolve: lockfile at $(FIXTURE)/offline.lock.yaml"
+
 clean:
-	rm -f bin/$(BINARY) coverage.out coverage.html
+	rm -rf bin/$(BINARY) coverage.out coverage.html $(FIXTURE)
 
 .DEFAULT_GOAL := build

--- a/README.md
+++ b/README.md
@@ -34,13 +34,62 @@ Early development. The `spec` package (core types) is complete. Resolver, agent,
 
 - Go 1.22+
 
+## Offline resolution (no AWS)
+
+`STRATA_REGISTRY_URL` accepts a `file://` URL as well as `s3://`. A local
+directory with the registry layout is then read like any other registry, with no
+AWS credentials and no network access involved.
+
+```sh
+export STRATA_REGISTRY_URL=file:///var/strata-local
+strata resolve profile.yaml -o profile.lock.yaml
+strata freeze  profile.yaml -o profile.lock.yaml
+```
+
+`resolve`, `freeze`, `freeze-layer`, `fold`, `capture`, `scan`, and `stratify`
+accept a `file://` registry. `build`, `index`, `probe`, and `remove` are still
+S3-only and reject one.
+
+The directory layout is the same as the S3 one:
+
+```
+/var/strata-local/
+  index/layers.yaml                                        # layer catalog
+  layers/<abi>/<arch>/<name>/<version>/manifest.yaml        # layer manifest
+  layers/<abi>/<arch>/<name>/<version>/layer.sqfs           # layer content
+  layers/<abi>/<arch>/<name>/<version>/bundle.json          # Sigstore bundle
+  formations/<name>/<version>/manifest.yaml
+  probes/<ami-id>/capabilities.yaml
+  locks/<environment-id>.yaml
+```
+
+Note that the *embedded* Tier 0 catalog cannot resolve offline on its own. It is
+built from the recipes in `cmd/strata/recipes/`, which carry no `sha256`,
+`bundle`, or `rekor_entry` because nothing has been built from them yet — so
+resolution against it stops in stage 7 with `BUNDLE_MISSING`. Signed layers in a
+registry, local or S3, are what stage 7 requires.
+
+To resolve something offline right now, in a fresh clone, with no registry of
+your own:
+
+```sh
+make offline-resolve
+```
+
+That materializes the test fixture registry under `bin/fixture/` and resolves a
+profile through it. CI runs the same sequence on every pull request. The fixture
+lives in `internal/testregistry/` and is reusable by any test that needs a
+lockfile; its two deliberate limits (`layer.sqfs` is not a real squashfs image,
+`bundle.json` is not a real signature) are documented in that package.
+
 ## Development
 
 ```sh
-make test     # test with race detector and coverage
-make lint     # golangci-lint
-make check    # vet + lint + test
-make build    # build ./cmd/strata
+make test             # test with race detector and coverage
+make lint             # golangci-lint
+make check            # vet + lint + test
+make build            # build ./cmd/strata
+make offline-resolve  # prove a lockfile can be produced with no AWS credentials
 ```
 
 ## License

--- a/cmd/strata/offline_resolve_test.go
+++ b/cmd/strata/offline_resolve_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/strata/internal/testregistry"
+	"github.com/scttfrdmn/strata/spec"
+)
+
+// This is the CLI half of #54: the property that closes the issue is not "the
+// resolver package can resolve" but "someone with a fresh clone and no AWS
+// credentials can run strata and get a lockfile". That path goes through
+// buildRegistryClient and buildProbeClient, which is where it was broken —
+// STRATA_REGISTRY_URL was handed to NewS3Client whatever its scheme, so a
+// file:// URL failed the s3:// check and fell silently back to the embedded
+// recipe catalog, which has no bundles and dies in stage 7.
+
+// clearAWSEnv blanks the credentials the AWS SDK would otherwise discover, so
+// that a test passing here cannot be passing because the machine running it
+// happens to be able to reach AWS.
+func clearAWSEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"AWS_PROFILE", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN",
+		"AWS_REGION", "AWS_DEFAULT_REGION", "AWS_SHARED_CREDENTIALS_FILE", "AWS_CONFIG_FILE",
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+// TestResolveCmdOfflineWritesLockfile runs the resolve command exactly as the
+// CLI does and asserts the artifact appears on disk.
+func TestResolveCmdOfflineWritesLockfile(t *testing.T) {
+	clearAWSEnv(t)
+
+	work := t.TempDir()
+	root, err := testregistry.Materialize(context.Background(), filepath.Join(work, "registry"))
+	if err != nil {
+		t.Fatalf("materializing fixture registry: %v", err)
+	}
+	t.Setenv("STRATA_REGISTRY_URL", testregistry.URI(root))
+
+	profile := testregistry.WriteProfile(t, work, testregistry.ProfileMinimal)
+	out := filepath.Join(work, "offline.lock.yaml")
+
+	cmd := newResolveCmd()
+	cmd.SetArgs([]string{profile, "-o", out})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("strata resolve: %v", err)
+	}
+
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("no lockfile written: %v", err)
+	}
+	lf, err := spec.ParseLockFileBytes(data)
+	if err != nil {
+		t.Fatalf("parsing written lockfile: %v", err)
+	}
+	if len(lf.Layers) != len(testregistry.LayerIDs) {
+		t.Fatalf("lockfile has %d layers, want %d", len(lf.Layers), len(testregistry.LayerIDs))
+	}
+	if lf.Base.AMIID == "" {
+		t.Error("lockfile has no base AMI ID")
+	}
+	for _, layer := range lf.Layers {
+		if layer.Bundle == "" || layer.SHA256 == "" {
+			t.Errorf("%s: bundle=%q sha256=%q — resolve should not emit an unattested layer",
+				layer.ID, layer.Bundle, layer.SHA256)
+		}
+	}
+}
+
+// TestResolveCmdOfflineFormation covers the formation profile through the same
+// CLI path.
+func TestResolveCmdOfflineFormation(t *testing.T) {
+	clearAWSEnv(t)
+
+	work := t.TempDir()
+	root, err := testregistry.Materialize(context.Background(), filepath.Join(work, "registry"))
+	if err != nil {
+		t.Fatalf("materializing fixture registry: %v", err)
+	}
+	t.Setenv("STRATA_REGISTRY_URL", testregistry.URI(root))
+
+	profile := testregistry.WriteProfile(t, work, testregistry.ProfileFormation)
+	out := filepath.Join(work, "formation.lock.yaml")
+
+	cmd := newResolveCmd()
+	cmd.SetArgs([]string{profile, "-o", out})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("strata resolve: %v", err)
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Fatalf("no lockfile written: %v", err)
+	}
+}
+
+// TestResolveCmdFileRegistryIsNotSilentlyIgnored is the negative control for the
+// defect that was fixed. Pointed at an empty file:// registry, resolve must fail
+// because that registry has no layers — not succeed against the embedded catalog
+// and not fail with an S3 URL complaint. A silent fallback is the failure mode
+// that hid this for a release: the warning went to stderr and the resolve
+// carried on against a different registry than the one that was asked for.
+func TestResolveCmdFileRegistryIsNotSilentlyIgnored(t *testing.T) {
+	clearAWSEnv(t)
+
+	work := t.TempDir()
+	empty := filepath.Join(work, "empty-registry")
+	if err := os.MkdirAll(empty, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Setenv("STRATA_REGISTRY_URL", "file://"+filepath.ToSlash(empty))
+
+	profile := testregistry.WriteProfile(t, work, testregistry.ProfileMinimal)
+	out := filepath.Join(work, "should-not-exist.lock.yaml")
+
+	cmd := newResolveCmd()
+	cmd.SetArgs([]string{profile, "-o", out})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("resolve succeeded against an empty file:// registry — it fell back to another catalog")
+	}
+	if strings.Contains(err.Error(), "invalid S3 URL") {
+		t.Errorf("file:// URL was routed to the S3 client: %v", err)
+	}
+	if !strings.Contains(err.Error(), "LAYER_NOT_FOUND") {
+		t.Errorf("want a layer-not-found failure from the empty registry, got: %v", err)
+	}
+	if _, statErr := os.Stat(out); statErr == nil {
+		t.Error("a failed resolve wrote a lockfile")
+	}
+}

--- a/cmd/strata/resolve.go
+++ b/cmd/strata/resolve.go
@@ -85,32 +85,47 @@ registry; otherwise the embedded Tier 0 catalog is used.`,
 	return cmd
 }
 
-// buildRegistryClient returns an S3Client if STRATA_REGISTRY_URL is set,
-// falling back to the embedded Tier 0 catalog as a MemoryStore.
-// If STRATA_REGISTRY_URL is set but the S3 client cannot be initialised
-// (e.g. bad URL, missing credentials) an error is printed to stderr and the
-// embedded catalog is used instead — offline fallback is intentional.
+// buildRegistryClient returns a registry client for STRATA_REGISTRY_URL,
+// falling back to the embedded Tier 0 catalog as a MemoryStore when the
+// variable is unset.
+//
+// The URL is dispatched by scheme through newClientForURL, so a "file://" URL
+// gets a LocalClient and an "s3://" URL gets an S3Client. Routing every URL to
+// NewS3Client, as this did before, made the documented offline workflow
+// (STRATA_REGISTRY_URL=file:///var/strata-local) fail its scheme check and fall
+// silently back to the embedded recipe catalog, which carries no bundles and so
+// dies in stage 7 for every profile (#54).
+//
+// If the client cannot be initialised (e.g. bad URL, missing credentials) an
+// error is printed to stderr and the embedded catalog is used instead —
+// offline fallback is intentional.
 func buildRegistryClient() registry.Client {
-	if url := os.Getenv("STRATA_REGISTRY_URL"); url != "" {
-		client, err := registry.NewS3Client(url)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "warning: S3 registry unavailable (%v); falling back to embedded catalog\n", err) //nolint:errcheck
-			return buildCatalog()
-		}
-		return client
+	url := os.Getenv("STRATA_REGISTRY_URL")
+	if url == "" {
+		return buildCatalog()
 	}
-	return buildCatalog()
+	client, err := newClientForURL(url)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: registry %q unavailable (%v); falling back to embedded catalog\n", url, err) //nolint:errcheck
+		return buildCatalog()
+	}
+	return client
 }
 
 // buildProbeClient returns a probe.Client for use by resolve/freeze.
 //
-// When STRATA_REGISTRY_URL is set and AWS credentials are available, it wires
-// a real SSMResolver with an S3-backed cache so that lockfiles contain real
-// AMI IDs. On any initialisation failure it falls back to the static offline
-// client. Pre-seed the S3 probe cache with "strata probe <os> <arch>" before
-// running strata resolve against a live registry.
+// When STRATA_REGISTRY_URL names an S3 registry and AWS credentials are
+// available, it wires a real SSMResolver with an S3-backed cache so that
+// lockfiles contain real AMI IDs. On any initialisation failure it falls back
+// to the static offline client. Pre-seed the S3 probe cache with
+// "strata probe <os> <arch>" before running strata resolve against a live
+// registry.
+//
+// A file:// registry is the offline path by definition, so it never reaches for
+// SSM: doing so would trade "no lockfile" for an IMDS timeout on a machine that
+// has no credentials to find.
 func buildProbeClient() *probe.Client {
-	if url := os.Getenv("STRATA_REGISTRY_URL"); url != "" {
+	if url := os.Getenv("STRATA_REGISTRY_URL"); url != "" && !strings.HasPrefix(url, "file://") {
 		reg, err := registry.NewS3Client(url)
 		if err == nil {
 			r, err := probe.NewSSMResolver(context.Background())

--- a/internal/resolver/offline_fixture_test.go
+++ b/internal/resolver/offline_fixture_test.go
@@ -1,0 +1,171 @@
+package resolver_test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/strata/internal/resolver"
+	"github.com/scttfrdmn/strata/internal/testregistry"
+	"github.com/scttfrdmn/strata/spec"
+)
+
+// These tests are the offline end-to-end path: profile in, lockfile out, with no
+// AWS credentials, no network, and no prior build. Before the testregistry
+// fixture existed there was no way to reach stage 8 at all — the embedded recipe
+// catalog carries no bundles, so every profile died in stage 7 (#54) — which
+// meant no defect in the trust, freeze, or publish paths could carry an
+// end-to-end regression test.
+//
+// The registry here is a real registry.LocalClient over real files, not a mock.
+// A mocked resolver would pass whether or not resolution actually works.
+
+func newFixtureResolver(t *testing.T) (*resolver.Resolver, string) {
+	t.Helper()
+	root, client := testregistry.New(t)
+	probeClient, err := testregistry.Probe()
+	if err != nil {
+		t.Fatalf("fixture probe client: %v", err)
+	}
+	r, err := resolver.New(resolver.Config{
+		Registry:      client,
+		Probe:         probeClient,
+		StrataVersion: "0.0.0-test",
+	})
+	if err != nil {
+		t.Fatalf("resolver.New: %v", err)
+	}
+	return r, root
+}
+
+func fixtureProfile(t *testing.T, name string) *spec.Profile {
+	t.Helper()
+	data, err := testregistry.ProfileBytes(name)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	p, err := spec.ParseProfileBytes(data)
+	if err != nil {
+		t.Fatalf("parsing fixture profile %s: %v", name, err)
+	}
+	return p
+}
+
+// TestOfflineResolveProducesLockfile is the regression test for #54: resolution
+// reaches stage 8 offline and the lockfile it produces is complete enough to be
+// re-parsed.
+func TestOfflineResolveProducesLockfile(t *testing.T) {
+	r, _ := newFixtureResolver(t)
+	profile := fixtureProfile(t, testregistry.ProfileMinimal)
+
+	lf, err := r.Resolve(context.Background(), profile)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if lf == nil {
+		t.Fatal("Resolve returned a nil lockfile and a nil error")
+	}
+	if len(lf.Layers) != len(testregistry.LayerIDs) {
+		t.Fatalf("lockfile has %d layers, want %d", len(lf.Layers), len(testregistry.LayerIDs))
+	}
+
+	for _, layer := range lf.Layers {
+		if layer.SHA256 == "" {
+			t.Errorf("%s: lockfile layer has no sha256", layer.ID)
+		}
+		if layer.RekorEntry == "" {
+			t.Errorf("%s: lockfile layer has no rekor_entry", layer.ID)
+		}
+		path, ok := strings.CutPrefix(layer.Bundle, "file://")
+		if !ok {
+			t.Errorf("%s: bundle %q is not a file:// URI", layer.ID, layer.Bundle)
+			continue
+		}
+		// The point of the fixture is that the bundle is a file that exists, not
+		// a placeholder string that merely satisfies a non-empty check (#61).
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("%s: bundle referenced by the lockfile does not exist: %v", layer.ID, err)
+		}
+	}
+
+	// Round-trip through the spec parser: a lockfile that cannot be re-read is
+	// not a usable artifact for the commands that consume one.
+	data, err := spec.MarshalLockFile(lf)
+	if err != nil {
+		t.Fatalf("MarshalLockFile: %v", err)
+	}
+	if _, err := spec.ParseLockFileBytes(data); err != nil {
+		t.Fatalf("ParseLockFileBytes on freshly resolved lockfile: %v", err)
+	}
+}
+
+// TestOfflineResolveMountOrderFollowsDependencies is the discriminating half of
+// the fixture: the profile lists jupyterlab before python, and jupyterlab
+// requires python, so a resolver that preserved input order would produce the
+// opposite order here. Asserting only "two layers resolved" would pass either way.
+func TestOfflineResolveMountOrderFollowsDependencies(t *testing.T) {
+	r, _ := newFixtureResolver(t)
+	profile := fixtureProfile(t, testregistry.ProfileMinimal)
+
+	if profile.Software[0].Name != "jupyterlab" {
+		t.Fatalf("fixture profile no longer lists jupyterlab first (got %q) — this test's premise is gone",
+			profile.Software[0].Name)
+	}
+
+	lf, err := r.Resolve(context.Background(), profile)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	got := make([]string, len(lf.Layers))
+	for i, layer := range lf.Layers {
+		got[i] = layer.ID
+		if layer.MountOrder != i+1 {
+			t.Errorf("layer %d (%s): mount_order = %d, want %d", i, layer.ID, layer.MountOrder, i+1)
+		}
+	}
+	for i, want := range testregistry.LayerIDs {
+		if got[i] != want {
+			t.Errorf("layer %d = %s, want %s (dependency order: python before jupyterlab)", i, got[i], want)
+		}
+	}
+}
+
+// TestOfflineResolveFormation puts stage 2 on the offline path: the same two
+// layers reached through a formation ref, including the formation's own
+// bundle and rekor_entry presence checks.
+func TestOfflineResolveFormation(t *testing.T) {
+	r, _ := newFixtureResolver(t)
+	profile := fixtureProfile(t, testregistry.ProfileFormation)
+
+	lf, err := r.Resolve(context.Background(), profile)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(lf.Layers) != len(testregistry.LayerIDs) {
+		t.Fatalf("lockfile has %d layers, want %d", len(lf.Layers), len(testregistry.LayerIDs))
+	}
+	for _, layer := range lf.Layers {
+		if layer.FromFormation != testregistry.FormationRef {
+			t.Errorf("%s: from_formation = %q, want %q", layer.ID, layer.FromFormation, testregistry.FormationRef)
+		}
+	}
+}
+
+// TestOfflineResolveNoPartialLockfileOnFailure checks the property #54's
+// evidence observed behaviourally — a failed resolution returns no lockfile at
+// all — against a stage-3 failure this fixture can produce on demand.
+func TestOfflineResolveNoPartialLockfileOnFailure(t *testing.T) {
+	r, _ := newFixtureResolver(t)
+	profile := fixtureProfile(t, testregistry.ProfileMinimal)
+	profile.Software = append(profile.Software, spec.SoftwareRef{Name: "no-such-layer", Version: "1.0"})
+
+	lf, err := r.Resolve(context.Background(), profile)
+	if err == nil {
+		t.Fatal("Resolve succeeded with an unresolvable software ref")
+	}
+	if lf != nil {
+		t.Errorf("Resolve returned a partial lockfile alongside an error: %+v", lf)
+	}
+}

--- a/internal/testregistry/helpers.go
+++ b/internal/testregistry/helpers.go
@@ -1,0 +1,82 @@
+package testregistry
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/scttfrdmn/strata/internal/probe"
+	"github.com/scttfrdmn/strata/internal/registry"
+	"github.com/scttfrdmn/strata/spec"
+)
+
+// TB is the subset of *testing.T this package needs. Declaring it here rather
+// than importing "testing" keeps the testing package out of the import graph of
+// mkregistry and of anything else that materializes a fixture outside a test.
+type TB interface {
+	Helper()
+	TempDir() string
+	Fatalf(format string, args ...any)
+}
+
+// New materializes the fixture registry into a fresh temporary directory and
+// returns its absolute root together with a client for it. The directory is
+// removed by the test framework when the test ends.
+func New(t TB) (root string, client *registry.LocalClient) {
+	t.Helper()
+	root, err := Materialize(context.Background(), filepath.Join(t.TempDir(), "registry"))
+	if err != nil {
+		t.Fatalf("materializing fixture registry: %v", err)
+	}
+	client, err = registry.NewLocalClient(URI(root))
+	if err != nil {
+		t.Fatalf("opening fixture registry at %s: %v", root, err)
+	}
+	return root, client
+}
+
+// URI returns the STRATA_REGISTRY_URL value for a materialized registry root.
+func URI(root string) string {
+	return uriFor(root)
+}
+
+// Base is the base OS the fixture layers are built for. Profiles that resolve
+// against the fixture must declare it, because layer lookup filters on the ABI
+// this OS provides (linux-gnu-2.34).
+const Base = "al2023"
+
+// BaseArch is the architecture the fixture layers are built for.
+const BaseArch = "x86_64"
+
+// Probe returns an offline probe.Client for the fixture's base OS: a static AMI
+// table and KnownBaseCapabilities, with an in-memory cache. It never touches
+// SSM or IMDS, so it behaves the same on a developer machine with credentials
+// and in CI without them.
+func Probe() (*probe.Client, error) {
+	amiID := "ami-" + Base + "-" + BaseArch
+	caps, err := probe.KnownBaseCapabilities(Base, BaseArch, amiID)
+	if err != nil {
+		return nil, fmt.Errorf("testregistry: base capabilities for %s/%s: %w", Base, BaseArch, err)
+	}
+	return &probe.Client{
+		Resolver: &probe.StaticResolver{AMIs: map[string]string{Base + "/" + BaseArch: amiID}},
+		Runner:   &probe.FakeRunner{Capabilities: map[string]*spec.BaseCapabilities{amiID: caps}},
+		Cache:    probe.NewMemoryCache(),
+	}, nil
+}
+
+// WriteProfile writes a fixture profile into dir and returns its path.
+// name is one of the Profile* constants.
+func WriteProfile(t TB, dir, name string) string {
+	t.Helper()
+	data, err := ProfileBytes(name)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, data, 0o644); err != nil {
+		t.Fatalf("writing profile %s: %v", p, err)
+	}
+	return p
+}

--- a/internal/testregistry/mkregistry/main.go
+++ b/internal/testregistry/mkregistry/main.go
@@ -1,0 +1,53 @@
+// Command mkregistry writes the testregistry fixture into a directory, so that
+// an offline resolve can be reproduced from a shell rather than only from a Go
+// test:
+//
+//	go run ./internal/testregistry/mkregistry /tmp/strata-fixture
+//	STRATA_REGISTRY_URL=file:///tmp/strata-fixture strata resolve profile.yaml
+//
+// It also writes the fixture profiles next to the registry, so that the command
+// above has something to resolve. It prints the STRATA_REGISTRY_URL value on
+// stdout.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/scttfrdmn/strata/internal/testregistry"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: mkregistry <dir>\n") //nolint:errcheck
+		os.Exit(2)
+	}
+	dir := os.Args[1]
+
+	root, err := testregistry.Materialize(context.Background(), filepath.Join(dir, "registry"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mkregistry: %v\n", err) //nolint:errcheck
+		os.Exit(1)
+	}
+
+	profileDir := filepath.Join(dir, "profiles")
+	if err := os.MkdirAll(profileDir, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "mkregistry: %v\n", err) //nolint:errcheck
+		os.Exit(1)
+	}
+	for _, name := range testregistry.ProfileNames() {
+		data, err := testregistry.ProfileBytes(name)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "mkregistry: %v\n", err) //nolint:errcheck
+			os.Exit(1)
+		}
+		if err := os.WriteFile(filepath.Join(profileDir, name), data, 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "mkregistry: %v\n", err) //nolint:errcheck
+			os.Exit(1)
+		}
+	}
+
+	fmt.Println(testregistry.URI(root))
+}

--- a/internal/testregistry/testdata/profiles/offline-formation.yaml
+++ b/internal/testregistry/testdata/profiles/offline-formation.yaml
@@ -1,0 +1,16 @@
+# Same two layers, reached through a formation ref instead of direct software
+# refs, so stage 2 (formation expansion, formation bundle/rekor presence) is on
+# the offline path too.
+name: offline-formation
+description: Formation-based profile that resolves offline against the testregistry fixture.
+version: "1.0"
+
+base:
+  os: al2023
+  arch: x86_64
+
+software:
+  - formation: strata-fixture@2026.08
+
+instance:
+  type: c7i.xlarge

--- a/internal/testregistry/testdata/profiles/offline-minimal.yaml
+++ b/internal/testregistry/testdata/profiles/offline-minimal.yaml
@@ -1,0 +1,22 @@
+# Resolves entirely against the fixture registry — two layers with a real
+# dependency edge (jupyterlab requires python), so the lockfile's mount order is
+# a fact about stage 6 rather than an accident of input order.
+#
+# Software refs use the struct form deliberately: the inline string form
+# ("- python@3.13") does not parse today (#53).
+name: offline-minimal
+description: Minimal profile that resolves offline against the testregistry fixture.
+version: "1.0"
+
+base:
+  os: al2023
+  arch: x86_64
+
+software:
+  - name: jupyterlab
+    version: "4.2"
+  - name: python
+    version: "3.13"
+
+instance:
+  type: c7i.xlarge

--- a/internal/testregistry/testdata/registry/formations/strata-fixture/2026.08/bundle.json
+++ b/internal/testregistry/testdata/registry/formations/strata-fixture/2026.08/bundle.json
@@ -1,18 +1,18 @@
 {
-  "_strata_fixture": "NOT A VALID SIGSTORE BUNDLE — no signature over this formation exists. Every field is synthetic. See internal/testregistry/testregistry.go.",
+  "_strata_fixture": "NOT A VALID SIGSTORE BUNDLE — no signature over this formation exists. Every field is synthetic: signature is ASCII text, logIndex is 2^53-1 and cannot exist in any real log (confirmed HTTP 404 on 2026-08-20), keyId is not the public-good Rekor log's key, and messageDigest is zero. Making any of these plausible would let this fixture pass a real verification for the wrong reason — see internal/testregistry/testregistry.go.",
   "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
   "verificationMaterial": {
     "tlogEntries": [
       {
-        "logIndex": "148923470",
+        "logIndex": "9007199254740991",
         "logId": {
-          "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+          "keyId": "c3RyYXRhLWZpeHR1cmUtTk9ULWEtcmVhbC1sb2ctSUQ="
         },
         "kindVersion": {
           "kind": "hashedrekord",
           "version": "0.0.1"
         },
-        "integratedTime": "1785283200"
+        "integratedTime": "0"
       }
     ]
   },

--- a/internal/testregistry/testdata/registry/formations/strata-fixture/2026.08/bundle.json
+++ b/internal/testregistry/testdata/registry/formations/strata-fixture/2026.08/bundle.json
@@ -1,0 +1,26 @@
+{
+  "_strata_fixture": "NOT A VALID SIGSTORE BUNDLE — no signature over this formation exists. Every field is synthetic. See internal/testregistry/testregistry.go.",
+  "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+  "verificationMaterial": {
+    "tlogEntries": [
+      {
+        "logIndex": "148923470",
+        "logId": {
+          "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+        },
+        "kindVersion": {
+          "kind": "hashedrekord",
+          "version": "0.0.1"
+        },
+        "integratedTime": "1785283200"
+      }
+    ]
+  },
+  "messageSignature": {
+    "messageDigest": {
+      "algorithm": "SHA2_256",
+      "digest": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    },
+    "signature": "c3RyYXRhLWZpeHR1cmUtbm90LWEtcmVhbC1zaWduYXR1cmU="
+  }
+}

--- a/internal/testregistry/testdata/registry/formations/strata-fixture/2026.08/manifest.yaml
+++ b/internal/testregistry/testdata/registry/formations/strata-fixture/2026.08/manifest.yaml
@@ -1,8 +1,13 @@
 # Fixture formation. bundle is filled in by testregistry.Materialize with the
-# absolute file:// URI of bundle.json in this directory. rekor_entry is a
-# numeric string on purpose: stage 7 parses it with strconv.ParseInt whenever a
-# Rekor client is configured, so "pending-initial-build" would not survive that
-# path (see #61).
+# absolute file:// URI of bundle.json in this directory.
+#
+# rekor_entry is testregistry.SentinelRekorEntry — numeric so that stage 7's
+# strconv.ParseInt succeeds and the value reaches the Rekor client, and 2^53-1 so
+# that the client cannot find it (confirmed HTTP 404 on 2026-08-20). Do not
+# change it to a realistic index: an earlier version of this fixture used
+# plausible indices and all of them resolved to real entries in the public log
+# belonging to other people, which VerifyEntry would have accepted as proof
+# (#59). Not a numeric-vs-placeholder question — an impossible-vs-plausible one.
 name: strata-fixture
 version: "2026.08"
 description: Fixture formation — python + jupyterlab, for offline resolution tests.
@@ -18,7 +23,7 @@ provides:
     version: 4.2.0
 validated_on:
   - al2023/x86_64
-rekor_entry: "148923470"
+rekor_entry: "9007199254740991"
 bundle: ""
 signed_by: strata-fixture@invalid.test
 built_at: 2026-08-01T00:00:00Z

--- a/internal/testregistry/testdata/registry/formations/strata-fixture/2026.08/manifest.yaml
+++ b/internal/testregistry/testdata/registry/formations/strata-fixture/2026.08/manifest.yaml
@@ -1,0 +1,24 @@
+# Fixture formation. bundle is filled in by testregistry.Materialize with the
+# absolute file:// URI of bundle.json in this directory. rekor_entry is a
+# numeric string on purpose: stage 7 parses it with strconv.ParseInt whenever a
+# Rekor client is configured, so "pending-initial-build" would not survive that
+# path (see #61).
+name: strata-fixture
+version: "2026.08"
+description: Fixture formation — python + jupyterlab, for offline resolution tests.
+layers:
+  - name: python
+    version: 3.13.2
+  - name: jupyterlab
+    version: 4.2.0
+provides:
+  - name: python
+    version: 3.13.2
+  - name: jupyterlab
+    version: 4.2.0
+validated_on:
+  - al2023/x86_64
+rekor_entry: "148923470"
+bundle: ""
+signed_by: strata-fixture@invalid.test
+built_at: 2026-08-01T00:00:00Z

--- a/internal/testregistry/testdata/registry/layers/linux-gnu-2.34/x86_64/jupyterlab/4.2.0/bundle.json
+++ b/internal/testregistry/testdata/registry/layers/linux-gnu-2.34/x86_64/jupyterlab/4.2.0/bundle.json
@@ -1,0 +1,26 @@
+{
+  "_strata_fixture": "NOT A VALID SIGSTORE BUNDLE — no signature over this content exists. messageDigest is the real SHA-256 of layer.sqfs; every other field is synthetic. See internal/testregistry/testregistry.go.",
+  "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+  "verificationMaterial": {
+    "tlogEntries": [
+      {
+        "logIndex": "148923472",
+        "logId": {
+          "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+        },
+        "kindVersion": {
+          "kind": "hashedrekord",
+          "version": "0.0.1"
+        },
+        "integratedTime": "1785283200"
+      }
+    ]
+  },
+  "messageSignature": {
+    "messageDigest": {
+      "algorithm": "SHA2_256",
+      "digest": "y+nYDHDDf/UpQ+F8MkZV6p43JD3RD4totNHRdIIyLpM="
+    },
+    "signature": "c3RyYXRhLWZpeHR1cmUtbm90LWEtcmVhbC1zaWduYXR1cmU="
+  }
+}

--- a/internal/testregistry/testdata/registry/layers/linux-gnu-2.34/x86_64/jupyterlab/4.2.0/bundle.json
+++ b/internal/testregistry/testdata/registry/layers/linux-gnu-2.34/x86_64/jupyterlab/4.2.0/bundle.json
@@ -1,18 +1,18 @@
 {
-  "_strata_fixture": "NOT A VALID SIGSTORE BUNDLE — no signature over this content exists. messageDigest is the real SHA-256 of layer.sqfs; every other field is synthetic. See internal/testregistry/testregistry.go.",
+  "_strata_fixture": "NOT A VALID SIGSTORE BUNDLE — no signature over this content exists. messageDigest is the real SHA-256 of layer.sqfs, so a digest comparison passes and the signature check is what fails. signature is ASCII text; logIndex is 2^53-1, chosen because it parses as int64 and cannot exist in any real log (confirmed HTTP 404 on 2026-08-20); keyId is not the public-good Rekor log's key. Making any of these plausible would let this fixture pass a real verification for the wrong reason — see internal/testregistry/testregistry.go.",
   "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
   "verificationMaterial": {
     "tlogEntries": [
       {
-        "logIndex": "148923472",
+        "logIndex": "9007199254740991",
         "logId": {
-          "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+          "keyId": "c3RyYXRhLWZpeHR1cmUtTk9ULWEtcmVhbC1sb2ctSUQ="
         },
         "kindVersion": {
           "kind": "hashedrekord",
           "version": "0.0.1"
         },
-        "integratedTime": "1785283200"
+        "integratedTime": "0"
       }
     ]
   },

--- a/internal/testregistry/testdata/registry/layers/linux-gnu-2.34/x86_64/jupyterlab/4.2.0/layer.sqfs
+++ b/internal/testregistry/testdata/registry/layers/linux-gnu-2.34/x86_64/jupyterlab/4.2.0/layer.sqfs
@@ -1,0 +1,6 @@
+STRATA TEST FIXTURE LAYER — NOT A REAL SQUASHFS IMAGE
+layer: jupyterlab-4.2.0-linux-gnu-2.34-x86_64
+This file exists so the fixture registry's manifest SHA256 values are real and
+verifiable offline. It is deliberately not a squashfs image: any code path that
+mounts a layer must fail loudly on it rather than appear to succeed.
+See internal/testregistry/testregistry.go.

--- a/internal/testregistry/testdata/registry/layers/linux-gnu-2.34/x86_64/jupyterlab/4.2.0/manifest.yaml
+++ b/internal/testregistry/testdata/registry/layers/linux-gnu-2.34/x86_64/jupyterlab/4.2.0/manifest.yaml
@@ -1,6 +1,11 @@
 # Fixture layer manifest. Requires python, which no base OS provides, so this
 # layer only resolves when the python fixture layer resolves alongside it —
 # that cross-layer edge is what gives stage 6 a non-trivial topological order.
+# rekor_entry is testregistry.SentinelRekorEntry — numeric so stage 7's
+# strconv.ParseInt succeeds and the value reaches the Rekor client, and 2^53-1 so
+# the client cannot find it (confirmed HTTP 404 on 2026-08-20). Do not change it
+# to a realistic index: plausible integers can name real public-log entries, and
+# VerifyEntry accepts existence as proof (#59).
 id: jupyterlab-4.2.0-linux-gnu-2.34-x86_64
 name: jupyterlab
 version: 4.2.0
@@ -10,7 +15,7 @@ size: 373
 content_manifest:
   /opt/strata/jupyterlab/4.2.0/bin/jupyter: a388035603ff3d32e6634df4a3180a11a7a7b6eeb0890838fcd82c0551caca31
   /opt/strata/share/strata-fixture/LICENSE: 44baabe7776eff447026502a05fcf2950dd5de0729329ebb6788529b2a538daa
-rekor_entry: "148923472"
+rekor_entry: "9007199254740991"
 bundle: ""
 signed_by: strata-fixture@invalid.test
 cosign_version: v3.0.5

--- a/internal/testregistry/testdata/registry/layers/linux-gnu-2.34/x86_64/jupyterlab/4.2.0/manifest.yaml
+++ b/internal/testregistry/testdata/registry/layers/linux-gnu-2.34/x86_64/jupyterlab/4.2.0/manifest.yaml
@@ -1,0 +1,34 @@
+# Fixture layer manifest. Requires python, which no base OS provides, so this
+# layer only resolves when the python fixture layer resolves alongside it —
+# that cross-layer edge is what gives stage 6 a non-trivial topological order.
+id: jupyterlab-4.2.0-linux-gnu-2.34-x86_64
+name: jupyterlab
+version: 4.2.0
+source: ""
+sha256: cbe9d80c70c37ff52943e17c324655ea9e37243dd10f8b68b4d1d17482322e93
+size: 373
+content_manifest:
+  /opt/strata/jupyterlab/4.2.0/bin/jupyter: a388035603ff3d32e6634df4a3180a11a7a7b6eeb0890838fcd82c0551caca31
+  /opt/strata/share/strata-fixture/LICENSE: 44baabe7776eff447026502a05fcf2950dd5de0729329ebb6788529b2a538daa
+rekor_entry: "148923472"
+bundle: ""
+signed_by: strata-fixture@invalid.test
+cosign_version: v3.0.5
+provides:
+  - name: jupyterlab
+    version: 4.2.0
+requires:
+  - name: glibc
+    min_version: "2.34"
+  - name: python
+    min_version: "3.11"
+arch: x86_64
+abi: linux-gnu-2.34
+built_at: 2026-08-01T00:00:00Z
+user_selectable: true
+install_layout: versioned
+has_modulefile: true
+recipe_sha256: 0000000000000000000000000000000000000000000000000000000000000000
+build_env_lock_id: strata-fixture-bootstrap
+bootstrap_build: true
+bootstrap_compiler: gcc-11.4.1-2.amzn2023.0.1.x86_64

--- a/internal/testregistry/testdata/registry/layers/linux-gnu-2.34/x86_64/python/3.13.2/bundle.json
+++ b/internal/testregistry/testdata/registry/layers/linux-gnu-2.34/x86_64/python/3.13.2/bundle.json
@@ -1,0 +1,26 @@
+{
+  "_strata_fixture": "NOT A VALID SIGSTORE BUNDLE — no signature over this content exists. messageDigest is the real SHA-256 of layer.sqfs; every other field is synthetic. See internal/testregistry/testregistry.go.",
+  "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+  "verificationMaterial": {
+    "tlogEntries": [
+      {
+        "logIndex": "148923471",
+        "logId": {
+          "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+        },
+        "kindVersion": {
+          "kind": "hashedrekord",
+          "version": "0.0.1"
+        },
+        "integratedTime": "1785283200"
+      }
+    ]
+  },
+  "messageSignature": {
+    "messageDigest": {
+      "algorithm": "SHA2_256",
+      "digest": "nTz7VRIOB2rOC+Sr6tpb2k4n0FgLfkXv6Kqht2oxMFk="
+    },
+    "signature": "c3RyYXRhLWZpeHR1cmUtbm90LWEtcmVhbC1zaWduYXR1cmU="
+  }
+}

--- a/internal/testregistry/testdata/registry/layers/linux-gnu-2.34/x86_64/python/3.13.2/bundle.json
+++ b/internal/testregistry/testdata/registry/layers/linux-gnu-2.34/x86_64/python/3.13.2/bundle.json
@@ -1,18 +1,18 @@
 {
-  "_strata_fixture": "NOT A VALID SIGSTORE BUNDLE — no signature over this content exists. messageDigest is the real SHA-256 of layer.sqfs; every other field is synthetic. See internal/testregistry/testregistry.go.",
+  "_strata_fixture": "NOT A VALID SIGSTORE BUNDLE — no signature over this content exists. messageDigest is the real SHA-256 of layer.sqfs, so a digest comparison passes and the signature check is what fails. signature is ASCII text; logIndex is 2^53-1, chosen because it parses as int64 and cannot exist in any real log (confirmed HTTP 404 on 2026-08-20); keyId is not the public-good Rekor log's key. Making any of these plausible would let this fixture pass a real verification for the wrong reason — see internal/testregistry/testregistry.go.",
   "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
   "verificationMaterial": {
     "tlogEntries": [
       {
-        "logIndex": "148923471",
+        "logIndex": "9007199254740991",
         "logId": {
-          "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+          "keyId": "c3RyYXRhLWZpeHR1cmUtTk9ULWEtcmVhbC1sb2ctSUQ="
         },
         "kindVersion": {
           "kind": "hashedrekord",
           "version": "0.0.1"
         },
-        "integratedTime": "1785283200"
+        "integratedTime": "0"
       }
     ]
   },

--- a/internal/testregistry/testdata/registry/layers/linux-gnu-2.34/x86_64/python/3.13.2/layer.sqfs
+++ b/internal/testregistry/testdata/registry/layers/linux-gnu-2.34/x86_64/python/3.13.2/layer.sqfs
@@ -1,0 +1,6 @@
+STRATA TEST FIXTURE LAYER — NOT A REAL SQUASHFS IMAGE
+layer: python-3.13.2-linux-gnu-2.34-x86_64
+This file exists so the fixture registry's manifest SHA256 values are real and
+verifiable offline. It is deliberately not a squashfs image: any code path that
+mounts a layer must fail loudly on it rather than appear to succeed.
+See internal/testregistry/testregistry.go.

--- a/internal/testregistry/testdata/registry/layers/linux-gnu-2.34/x86_64/python/3.13.2/manifest.yaml
+++ b/internal/testregistry/testdata/registry/layers/linux-gnu-2.34/x86_64/python/3.13.2/manifest.yaml
@@ -1,6 +1,11 @@
 # Fixture layer manifest. source and bundle are left empty on purpose: they are
 # absolute file:// URIs and are filled in by testregistry.Materialize, which also
 # checks sha256 and size against the committed layer.sqfs bytes.
+# rekor_entry is testregistry.SentinelRekorEntry — numeric so stage 7's
+# strconv.ParseInt succeeds and the value reaches the Rekor client, and 2^53-1 so
+# the client cannot find it (confirmed HTTP 404 on 2026-08-20). Do not change it
+# to a realistic index: plausible integers can name real public-log entries, and
+# VerifyEntry accepts existence as proof (#59).
 id: python-3.13.2-linux-gnu-2.34-x86_64
 name: python
 version: 3.13.2
@@ -11,7 +16,7 @@ content_manifest:
   /opt/strata/python/3.13.2/bin/python3: acb0ec226a8922341b1d6178ebdf6884db2ebe154b9ea63cadda1d917813b1b5
   /opt/strata/python/3.13.2/lib/libpython3.13.so: b5d218eaa9698d6261b9af4a65e83fafebb275de375e12bc1d2a4ce0b7f0450f
   /opt/strata/share/strata-fixture/LICENSE: 44baabe7776eff447026502a05fcf2950dd5de0729329ebb6788529b2a538daa
-rekor_entry: "148923471"
+rekor_entry: "9007199254740991"
 bundle: ""
 signed_by: strata-fixture@invalid.test
 cosign_version: v3.0.5

--- a/internal/testregistry/testdata/registry/layers/linux-gnu-2.34/x86_64/python/3.13.2/manifest.yaml
+++ b/internal/testregistry/testdata/registry/layers/linux-gnu-2.34/x86_64/python/3.13.2/manifest.yaml
@@ -1,0 +1,33 @@
+# Fixture layer manifest. source and bundle are left empty on purpose: they are
+# absolute file:// URIs and are filled in by testregistry.Materialize, which also
+# checks sha256 and size against the committed layer.sqfs bytes.
+id: python-3.13.2-linux-gnu-2.34-x86_64
+name: python
+version: 3.13.2
+source: ""
+sha256: 9d3cfb55120e076ace0be4abeada5bda4e27d0580b7e45efe8aaa1b76a313059
+size: 370
+content_manifest:
+  /opt/strata/python/3.13.2/bin/python3: acb0ec226a8922341b1d6178ebdf6884db2ebe154b9ea63cadda1d917813b1b5
+  /opt/strata/python/3.13.2/lib/libpython3.13.so: b5d218eaa9698d6261b9af4a65e83fafebb275de375e12bc1d2a4ce0b7f0450f
+  /opt/strata/share/strata-fixture/LICENSE: 44baabe7776eff447026502a05fcf2950dd5de0729329ebb6788529b2a538daa
+rekor_entry: "148923471"
+bundle: ""
+signed_by: strata-fixture@invalid.test
+cosign_version: v3.0.5
+provides:
+  - name: python
+    version: 3.13.2
+requires:
+  - name: glibc
+    min_version: "2.34"
+arch: x86_64
+abi: linux-gnu-2.34
+built_at: 2026-08-01T00:00:00Z
+user_selectable: true
+install_layout: versioned
+has_modulefile: true
+recipe_sha256: 0000000000000000000000000000000000000000000000000000000000000000
+build_env_lock_id: strata-fixture-bootstrap
+bootstrap_build: true
+bootstrap_compiler: gcc-11.4.1-2.amzn2023.0.1.x86_64

--- a/internal/testregistry/testregistry.go
+++ b/internal/testregistry/testregistry.go
@@ -1,0 +1,299 @@
+// Package testregistry materializes a valid file:// Strata registry from
+// repo-resident fixture data, so that resolution can reach stage 8 with no AWS
+// credentials, no network, and no prior build.
+//
+// The embedded Tier 0 catalog is *recipes*: it carries no sha256, bundle, or
+// rekor_entry, because nothing has been built. Resolution against it therefore
+// dies in stage 7 (BUNDLE_MISSING) for every profile. This package is the
+// offline substitute — a two-layer registry whose manifests carry a real
+// sha256 over real bytes, a bundle that exists on disk, and a numeric Rekor
+// entry that survives strconv.ParseInt.
+//
+// # Using it
+//
+// From a test:
+//
+//	root, client := testregistry.New(t)          // registry in t.TempDir()
+//	profile := testregistry.WriteProfile(t, dir, testregistry.ProfileMinimal)
+//
+// From a shell (CI, or a human reproducing an offline resolve):
+//
+//	go run ./internal/testregistry/mkregistry /tmp/strata-fixture
+//	STRATA_REGISTRY_URL=file:///tmp/strata-fixture strata resolve profile.yaml
+//
+// # What the fixture is not
+//
+// Two things about it are deliberately fake, and are labelled as such inside
+// the files themselves:
+//
+//   - layer.sqfs is not a squashfs image. It is a short text blob. Its sha256
+//     and size in the manifest are real, so anything that hashes or fetches a
+//     layer works against it; anything that *mounts* one fails loudly rather
+//     than appearing to succeed.
+//   - bundle.json is not a valid Sigstore bundle. No signature over this
+//     content exists. Its messageDigest is the real SHA-256 of layer.sqfs; every
+//     other field is synthetic. It satisfies stage 7's presence check, which is
+//     all stage 7 checks today. A test that needs real signature verification
+//     needs a real key, and that is not this fixture's job.
+//
+// Extending it is adding files under testdata/registry — Materialize is
+// data-driven and discovers whatever manifests are there. It verifies each
+// committed sha256 against the committed bytes, so a fixture that drifts fails
+// with a message naming the file rather than rotting silently.
+package testregistry
+
+import (
+	"context"
+	"crypto/sha256"
+	"embed"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/scttfrdmn/strata/internal/registry"
+	"github.com/scttfrdmn/strata/spec"
+)
+
+//go:embed testdata/registry testdata/profiles
+var fixture embed.FS
+
+const (
+	registryRoot = "testdata/registry"
+	profilesRoot = "testdata/profiles"
+
+	// ProfileMinimal resolves two layers via direct software refs.
+	ProfileMinimal = "offline-minimal.yaml"
+
+	// ProfileFormation resolves the same two layers via a formation ref,
+	// exercising stage 2.
+	ProfileFormation = "offline-formation.yaml"
+
+	// FormationRef is the formation ProfileFormation refers to.
+	FormationRef = "strata-fixture@2026.08"
+)
+
+// LayerIDs are the layer IDs in the fixture registry, in stage-6 dependency
+// order: python provides what jupyterlab requires, so python mounts first.
+var LayerIDs = []string{
+	"python-3.13.2-linux-gnu-2.34-x86_64",
+	"jupyterlab-4.2.0-linux-gnu-2.34-x86_64",
+}
+
+// Materialize writes the fixture registry into dir, which is created if it does
+// not exist, and returns dir as an absolute path.
+//
+// Manifests are committed with empty source and bundle fields because those are
+// absolute file:// URIs that depend on where the registry lands. Materialize
+// fills them in, verifies each layer manifest's sha256 and size against the
+// committed layer.sqfs bytes, and then builds index/layers.yaml with the same
+// registry.LocalClient.RebuildIndex that a real local registry uses.
+func Materialize(ctx context.Context, dir string) (string, error) {
+	root, err := filepath.Abs(dir)
+	if err != nil {
+		return "", fmt.Errorf("testregistry: resolving %q: %w", dir, err)
+	}
+	if err := copyTree(registryRoot, root); err != nil {
+		return "", err
+	}
+	if err := VerifyLayerDigests(root); err != nil {
+		return "", err
+	}
+	if err := rewriteLayerManifests(root); err != nil {
+		return "", err
+	}
+	if err := rewriteFormationManifests(root); err != nil {
+		return "", err
+	}
+
+	client, err := registry.NewLocalClient(uriFor(root))
+	if err != nil {
+		return "", fmt.Errorf("testregistry: opening materialized registry: %w", err)
+	}
+	if err := client.RebuildIndex(ctx); err != nil {
+		return "", fmt.Errorf("testregistry: building layer index: %w", err)
+	}
+
+	// A registry whose index does not list every fixture layer is not usable,
+	// and the resolver would report it as a missing layer several stages later.
+	for _, id := range LayerIDs {
+		found, err := indexHas(client, id)
+		if err != nil {
+			return "", err
+		}
+		if !found {
+			return "", fmt.Errorf("testregistry: layer %q missing from index/layers.yaml after rebuild", id)
+		}
+	}
+	return root, nil
+}
+
+// indexHas reports whether the rebuilt index lists a layer with the given ID.
+func indexHas(client *registry.LocalClient, id string) (bool, error) {
+	layers, err := client.ListLayers(context.Background(), "", "", "")
+	if err != nil {
+		return false, fmt.Errorf("testregistry: listing layers: %w", err)
+	}
+	for _, m := range layers {
+		if m.ID == id {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// copyTree writes every embedded file under src to the corresponding path
+// under dst.
+func copyTree(src, dst string) error {
+	return fs.WalkDir(fixture, src, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, p)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			if mkErr := os.MkdirAll(target, 0o755); mkErr != nil {
+				return fmt.Errorf("testregistry: creating %q: %w", target, mkErr)
+			}
+			return nil
+		}
+		data, err := fixture.ReadFile(p)
+		if err != nil {
+			return fmt.Errorf("testregistry: reading embedded %q: %w", p, err)
+		}
+		if err := os.WriteFile(target, data, 0o644); err != nil {
+			return fmt.Errorf("testregistry: writing %q: %w", target, err)
+		}
+		return nil
+	})
+}
+
+// VerifyLayerDigests checks every layer manifest under a materialized registry
+// root against the bytes next to it: the declared sha256 must hash the declared
+// layer.sqfs, the declared size must match it, and bundle.json must exist.
+//
+// Materialize runs this before it touches anything, so a fixture whose committed
+// digests have drifted from its committed bytes fails with a message naming the
+// manifest rather than surfacing several stages later as a mismatched layer.
+func VerifyLayerDigests(root string) error {
+	return eachManifest(filepath.Join(root, "layers"), func(manifestPath string, data []byte) error {
+		var m spec.LayerManifest
+		if err := yaml.Unmarshal(data, &m); err != nil {
+			return fmt.Errorf("testregistry: parsing %q: %w", manifestPath, err)
+		}
+		dir := filepath.Dir(manifestPath)
+		sqfs := filepath.Join(dir, "layer.sqfs")
+
+		blob, err := os.ReadFile(sqfs)
+		if err != nil {
+			return fmt.Errorf("testregistry: reading %q: %w", sqfs, err)
+		}
+		sum := sha256.Sum256(blob)
+		if got := hex.EncodeToString(sum[:]); got != m.SHA256 {
+			return fmt.Errorf("testregistry: fixture drift: %s declares sha256 %q but %s hashes to %q",
+				manifestPath, m.SHA256, sqfs, got)
+		}
+		if int64(len(blob)) != m.Size {
+			return fmt.Errorf("testregistry: fixture drift: %s declares size %d but %s is %d bytes",
+				manifestPath, m.Size, sqfs, len(blob))
+		}
+		if _, err := os.Stat(filepath.Join(dir, "bundle.json")); err != nil {
+			return fmt.Errorf("testregistry: %s: %w", manifestPath, err)
+		}
+		return nil
+	})
+}
+
+// rewriteLayerManifests fills in source and bundle for every layer manifest
+// under root. They are committed empty because they are absolute file:// URIs.
+func rewriteLayerManifests(root string) error {
+	return eachManifest(filepath.Join(root, "layers"), func(manifestPath string, data []byte) error {
+		var m spec.LayerManifest
+		if err := yaml.Unmarshal(data, &m); err != nil {
+			return fmt.Errorf("testregistry: parsing %q: %w", manifestPath, err)
+		}
+		dir := filepath.Dir(manifestPath)
+		m.Source = uriFor(filepath.Join(dir, "layer.sqfs"))
+		m.Bundle = uriFor(filepath.Join(dir, "bundle.json"))
+		return writeYAML(manifestPath, &m)
+	})
+}
+
+// rewriteFormationManifests fills in bundle for every formation manifest under
+// root.
+func rewriteFormationManifests(root string) error {
+	return eachManifest(filepath.Join(root, "formations"), func(manifestPath string, data []byte) error {
+		var f spec.Formation
+		if err := yaml.Unmarshal(data, &f); err != nil {
+			return fmt.Errorf("testregistry: parsing %q: %w", manifestPath, err)
+		}
+		bundle := filepath.Join(filepath.Dir(manifestPath), "bundle.json")
+		if _, err := os.Stat(bundle); err != nil {
+			return fmt.Errorf("testregistry: %s: %w", manifestPath, err)
+		}
+		f.Bundle = uriFor(bundle)
+		return writeYAML(manifestPath, &f)
+	})
+}
+
+// eachManifest calls fn for every manifest.yaml under dir. A missing dir is not
+// an error: a fixture is allowed to carry only layers, or only formations.
+func eachManifest(dir string, fn func(path string, data []byte) error) error {
+	err := filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || d.Name() != "manifest.yaml" {
+			return nil
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return fmt.Errorf("testregistry: reading %q: %w", p, err)
+		}
+		return fn(p, data)
+	})
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// writeYAML marshals v to path.
+func writeYAML(path string, v any) error {
+	data, err := yaml.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("testregistry: marshalling %q: %w", path, err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("testregistry: writing %q: %w", path, err)
+	}
+	return nil
+}
+
+// uriFor returns the file:// URI for an absolute filesystem path, using the
+// same construction as registry.LocalClient.
+func uriFor(absPath string) string {
+	return "file://" + filepath.ToSlash(absPath)
+}
+
+// ProfileBytes returns the contents of a fixture profile.
+// name is one of the Profile* constants.
+func ProfileBytes(name string) ([]byte, error) {
+	data, err := fixture.ReadFile(path.Join(profilesRoot, name))
+	if err != nil {
+		return nil, fmt.Errorf("testregistry: no fixture profile %q: %w", name, err)
+	}
+	return data, nil
+}
+
+// ProfileNames lists every fixture profile.
+func ProfileNames() []string {
+	return []string{ProfileMinimal, ProfileFormation}
+}

--- a/internal/testregistry/testregistry.go
+++ b/internal/testregistry/testregistry.go
@@ -6,8 +6,8 @@
 // rekor_entry, because nothing has been built. Resolution against it therefore
 // dies in stage 7 (BUNDLE_MISSING) for every profile. This package is the
 // offline substitute — a two-layer registry whose manifests carry a real
-// sha256 over real bytes, a bundle that exists on disk, and a numeric Rekor
-// entry that survives strconv.ParseInt.
+// sha256 over real bytes, a bundle that exists on disk, and a Rekor entry that
+// parses as an integer but cannot name a real log entry.
 //
 // # Using it
 //
@@ -36,10 +36,45 @@
 //     all stage 7 checks today. A test that needs real signature verification
 //     needs a real key, and that is not this fixture's job.
 //
+// # Why the fake fields are shaped the way they are
+//
+// Fixture data must be *maximally implausible to a real verifier*, not minimally
+// sufficient for the checks that happen to exist today. A fixture optimised to
+// pass the current checks will also pass whatever replaces them, which is the
+// failure mode this package nearly shipped with.
+//
+// The first version chose rekor_entry values that looked like real log indices,
+// reasoning only that stage 7 parses them with strconv.ParseInt when a Rekor
+// client is configured. All three resolved to HTTP 200 in the live public log —
+// real entries belonging to other people's artifacts — and the bundles carried
+// the genuine public-good Rekor log's key ID alongside them. Because
+// RekorHTTPClient.VerifyEntry treats existence as proof and discards the bundle
+// it was handed (#59), a resolve with a real Rekor client would have reported
+// this fixture as transparency-log verified, by borrowing a stranger's
+// attestation. Every synthetic field is now chosen so the strongest available
+// check fails on it:
+//
+//   - SentinelRekorEntry parses as int64 and cannot be a log index, so it reaches
+//     VerifyEntry and fails there rather than short-circuiting earlier.
+//   - SentinelLogKeyID replaces the real log's key ID, which the fixture had no
+//     business claiming.
+//   - SentinelSignature is ASCII, so it cannot accidentally be a valid signature.
+//   - Layer messageDigest values are the real SHA-256 of layer.sqfs, so a digest
+//     comparison passes and the *signature* check is what fails. Failing at the
+//     right step is more useful than failing early.
+//
+// TestFixtureIsNotTrustworthy enumerates the whole tree and asserts these hold
+// for every file, including files added later, and separately pins the properties
+// of the constants themselves so the invariant cannot be defeated by editing one.
+// If a correct tightening of verification appears to require loosening a check or
+// special-casing this fixture, the fixture is what is wrong.
+//
 // Extending it is adding files under testdata/registry — Materialize is
 // data-driven and discovers whatever manifests are there. It verifies each
 // committed sha256 against the committed bytes, so a fixture that drifts fails
-// with a message naming the file rather than rotting silently.
+// with a message naming the file rather than rotting silently. New layers must
+// use the Sentinel* values below; TestFixtureIsNotTrustworthy fails if they do
+// not.
 package testregistry
 
 import (
@@ -75,6 +110,36 @@ const (
 
 	// FormationRef is the formation ProfileFormation refers to.
 	FormationRef = "strata-fixture@2026.08"
+
+	// SentinelRekorEntry is the rekor_entry and bundle logIndex carried by every
+	// fixture manifest. It is 2^53-1: a valid int64, so it survives
+	// strconv.ParseInt in stage 7 and reaches the Rekor client, and far beyond any
+	// real log size, so the client cannot find it. Confirmed HTTP 404 against
+	// rekor.sigstore.dev on 2026-08-20, where 148923470-148923472 — the plausible
+	// indices this fixture used to carry — all returned HTTP 200 for other
+	// people's entries.
+	//
+	// Do not replace this with a realistic-looking index. A fixture that can be
+	// confirmed present in a real transparency log is a fixture that can launder a
+	// stranger's attestation into a passing test.
+	SentinelRekorEntry = "9007199254740991"
+
+	// SentinelLogKeyID is the logId.keyId in every fixture bundle: base64 of the
+	// ASCII "strata-fixture-NOT-a-real-log-ID". It replaces
+	// c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d, the real
+	// public-good Rekor log key ID, which this fixture previously claimed.
+	SentinelLogKeyID = "c3RyYXRhLWZpeHR1cmUtTk9ULWEtcmVhbC1sb2ctSUQ="
+
+	// SentinelSignature is the messageSignature.signature in every fixture bundle:
+	// base64 of the ASCII "strata-fixture-not-a-real-signature". ASCII text cannot
+	// be a valid ECDSA signature, so real verification fails on it immediately and
+	// legibly.
+	SentinelSignature = "c3RyYXRhLWZpeHR1cmUtbm90LWEtcmVhbC1zaWduYXR1cmU="
+
+	// SentinelIntegratedTime is the tlog integratedTime in every fixture bundle.
+	// Zero rather than a plausible recent timestamp: anything that renders it
+	// shows 1970 and is obviously looking at fixture data.
+	SentinelIntegratedTime = "0"
 )
 
 // LayerIDs are the layer IDs in the fixture registry, in stage-6 dependency

--- a/internal/testregistry/testregistry_test.go
+++ b/internal/testregistry/testregistry_test.go
@@ -2,10 +2,16 @@ package testregistry_test
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/scttfrdmn/strata/internal/testregistry"
 	"github.com/scttfrdmn/strata/spec"
@@ -119,6 +125,172 @@ func TestFixtureProfilesParse(t *testing.T) {
 			}
 		})
 	}
+}
+
+// realRekorLogKeyID is the key ID of the public-good Sigstore Rekor log, base64
+// of c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d. It is
+// here only so the fixture can assert it does *not* carry it. An earlier version
+// of this fixture did.
+const realRekorLogKeyID = "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+
+// TestFixtureIsNotTrustworthy asserts the fixture cannot pass a real
+// verification, and is the guard that makes that property survive people.
+//
+// It enumerates the tree rather than checking the files that exist today: a test
+// naming three known values does not constrain the fourth layer someone adds
+// next month with another plausible-looking Rekor index. Every manifest and
+// every bundle found under the materialized root must carry the Sentinel*
+// values.
+//
+// If a correct tightening of verification (#57, #59, #60, #61) makes this test
+// fail, the fixture is what needs new material — not the check.
+func TestFixtureIsNotTrustworthy(t *testing.T) {
+	// The constants themselves first. Enumeration below asserts equality against
+	// them, so a plausible value substituted *into* a constant would leave every
+	// other assertion here passing. These pin the properties that make them safe.
+	t.Run("sentinels cannot name real material", func(t *testing.T) {
+		idx, err := strconv.ParseInt(testregistry.SentinelRekorEntry, 10, 64)
+		if err != nil {
+			t.Fatalf("SentinelRekorEntry %q must parse as int64 so it reaches the Rekor client and fails there rather than earlier: %v",
+				testregistry.SentinelRekorEntry, err)
+		}
+		// The public log is O(10^8) entries. Anything below this bound could name
+		// a real entry belonging to someone else.
+		const impossible = int64(1) << 50
+		if idx < impossible {
+			t.Errorf("SentinelRekorEntry = %d, small enough to be a real log index; want >= %d", idx, impossible)
+		}
+		if testregistry.SentinelLogKeyID == realRekorLogKeyID {
+			t.Error("SentinelLogKeyID is the real public-good Rekor log key ID — the fixture must not claim inclusion in that log")
+		}
+		sig, err := base64.StdEncoding.DecodeString(testregistry.SentinelSignature)
+		if err != nil {
+			t.Fatalf("SentinelSignature is not base64: %v", err)
+		}
+		if !isPrintableASCII(sig) {
+			t.Error("SentinelSignature must decode to printable ASCII — that is what makes it impossible to mistake for a signature")
+		}
+	})
+
+	root, _ := testregistry.New(t)
+
+	manifests, bundles := 0, 0
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		switch d.Name() {
+		case "manifest.yaml":
+			manifests++
+			checkManifestRekor(t, p)
+		case "bundle.json":
+			bundles++
+			checkBundleIsFake(t, p)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking fixture: %v", err)
+	}
+
+	// A walk that found nothing would pass every assertion above vacuously,
+	// which is the same fail-open shape this test exists to prevent.
+	if manifests == 0 || bundles == 0 {
+		t.Fatalf("enumerated %d manifests and %d bundles under %s; both must be non-zero or this test proves nothing",
+			manifests, bundles, root)
+	}
+	t.Logf("checked %d manifests and %d bundles", manifests, bundles)
+}
+
+// checkManifestRekor asserts one manifest carries the sentinel Rekor entry. It
+// covers layer and formation manifests alike: both are read by a stage that will
+// eventually verify them.
+func checkManifestRekor(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Errorf("reading %s: %v", path, err)
+		return
+	}
+	var m struct {
+		RekorEntry string `yaml:"rekor_entry"`
+	}
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		t.Errorf("parsing %s: %v", path, err)
+		return
+	}
+	if m.RekorEntry != testregistry.SentinelRekorEntry {
+		t.Errorf("%s: rekor_entry = %q, want SentinelRekorEntry %q — a fixture must not carry an index that could name a real log entry",
+			path, m.RekorEntry, testregistry.SentinelRekorEntry)
+	}
+}
+
+// checkBundleIsFake asserts one bundle.json carries only sentinel trust material
+// and says so about itself.
+func checkBundleIsFake(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Errorf("reading %s: %v", path, err)
+		return
+	}
+	var b struct {
+		Note                 string `json:"_strata_fixture"`
+		VerificationMaterial struct {
+			TlogEntries []struct {
+				LogIndex string `json:"logIndex"`
+				LogID    struct {
+					KeyID string `json:"keyId"`
+				} `json:"logId"`
+				IntegratedTime string `json:"integratedTime"`
+			} `json:"tlogEntries"`
+		} `json:"verificationMaterial"`
+		MessageSignature struct {
+			Signature string `json:"signature"`
+		} `json:"messageSignature"`
+	}
+	if err := json.Unmarshal(data, &b); err != nil {
+		t.Errorf("parsing %s: %v", path, err)
+		return
+	}
+
+	if b.Note == "" {
+		t.Errorf("%s: no _strata_fixture note — a fake bundle must identify itself in its own bytes", path)
+	}
+	if b.MessageSignature.Signature != testregistry.SentinelSignature {
+		t.Errorf("%s: signature = %q, want SentinelSignature", path, b.MessageSignature.Signature)
+	}
+	if len(b.VerificationMaterial.TlogEntries) == 0 {
+		t.Errorf("%s: no tlogEntries to check", path)
+		return
+	}
+	for i, e := range b.VerificationMaterial.TlogEntries {
+		if e.LogIndex != testregistry.SentinelRekorEntry {
+			t.Errorf("%s: tlogEntries[%d].logIndex = %q, want SentinelRekorEntry %q",
+				path, i, e.LogIndex, testregistry.SentinelRekorEntry)
+		}
+		if e.LogID.KeyID != testregistry.SentinelLogKeyID {
+			t.Errorf("%s: tlogEntries[%d].logId.keyId = %q, want SentinelLogKeyID — the fixture must not claim a real log's key",
+				path, i, e.LogID.KeyID)
+		}
+		if e.IntegratedTime != testregistry.SentinelIntegratedTime {
+			t.Errorf("%s: tlogEntries[%d].integratedTime = %q, want SentinelIntegratedTime %q",
+				path, i, e.IntegratedTime, testregistry.SentinelIntegratedTime)
+		}
+	}
+}
+
+// isPrintableASCII reports whether b is non-empty printable ASCII.
+func isPrintableASCII(b []byte) bool {
+	for _, c := range b {
+		if c < 0x20 || c > 0x7e {
+			return false
+		}
+	}
+	return len(b) > 0
 }
 
 func stripFileURI(u string) (string, bool) {

--- a/internal/testregistry/testregistry_test.go
+++ b/internal/testregistry/testregistry_test.go
@@ -1,0 +1,130 @@
+package testregistry_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/strata/internal/testregistry"
+	"github.com/scttfrdmn/strata/spec"
+)
+
+// TestMaterializeProducesResolvableRegistry checks the three properties the
+// resolver depends on, which are exactly the three the embedded recipe catalog
+// lacks: a layer index, a real sha256, and a bundle that exists.
+func TestMaterializeProducesResolvableRegistry(t *testing.T) {
+	root, client := testregistry.New(t)
+
+	layers, err := client.ListLayers(context.Background(), "", "", "")
+	if err != nil {
+		t.Fatalf("ListLayers: %v", err)
+	}
+	if len(layers) != len(testregistry.LayerIDs) {
+		t.Fatalf("index lists %d layers, want %d", len(layers), len(testregistry.LayerIDs))
+	}
+
+	for _, m := range layers {
+		if m.SHA256 == "" {
+			t.Errorf("%s: empty sha256", m.ID)
+		}
+		if m.RekorEntry == "" {
+			t.Errorf("%s: empty rekor_entry", m.ID)
+		}
+		bundlePath, ok := stripFileURI(m.Bundle)
+		if !ok {
+			t.Errorf("%s: bundle %q is not a file:// URI", m.ID, m.Bundle)
+			continue
+		}
+		if _, err := os.Stat(bundlePath); err != nil {
+			t.Errorf("%s: bundle does not exist: %v", m.ID, err)
+		}
+		srcPath, ok := stripFileURI(m.Source)
+		if !ok {
+			t.Errorf("%s: source %q is not a file:// URI", m.ID, m.Source)
+			continue
+		}
+		if _, err := os.Stat(srcPath); err != nil {
+			t.Errorf("%s: layer.sqfs does not exist: %v", m.ID, err)
+		}
+	}
+
+	if !filepath.IsAbs(root) {
+		t.Errorf("Materialize returned relative root %q", root)
+	}
+}
+
+// TestMaterializeFormation checks the formation reaches the same standard as the
+// layers: stage 2 rejects a formation with an empty bundle or rekor_entry.
+func TestMaterializeFormation(t *testing.T) {
+	_, client := testregistry.New(t)
+
+	f, err := client.ResolveFormation(context.Background(), testregistry.FormationRef, testregistry.BaseArch)
+	if err != nil {
+		t.Fatalf("ResolveFormation(%s): %v", testregistry.FormationRef, err)
+	}
+	if f.Bundle == "" || f.RekorEntry == "" {
+		t.Errorf("formation has empty bundle (%q) or rekor_entry (%q)", f.Bundle, f.RekorEntry)
+	}
+	if len(f.Layers) != len(testregistry.LayerIDs) {
+		t.Errorf("formation lists %d layers, want %d", len(f.Layers), len(testregistry.LayerIDs))
+	}
+}
+
+// TestMaterializeDetectsFixtureDrift is the check that keeps the fixture
+// honest: if a committed sha256 stops describing the committed bytes, the
+// failure must name the file rather than surface later as a mysterious
+// verification error.
+func TestMaterializeDetectsFixtureDrift(t *testing.T) {
+	root, _ := testregistry.New(t)
+
+	sqfs := filepath.Join(root, "layers", "linux-gnu-2.34", "x86_64", "python", "3.13.2", "layer.sqfs")
+	data, err := os.ReadFile(sqfs)
+	if err != nil {
+		t.Fatalf("reading fixture blob: %v", err)
+	}
+	if err := os.WriteFile(sqfs, append(data, '!'), 0o644); err != nil {
+		t.Fatalf("mutating fixture blob: %v", err)
+	}
+
+	err = testregistry.VerifyLayerDigests(root)
+	if err == nil {
+		t.Fatal("VerifyLayerDigests accepted a blob whose bytes do not match the manifest sha256")
+	}
+	if !strings.Contains(err.Error(), "manifest.yaml") {
+		t.Errorf("drift error does not name the manifest: %v", err)
+	}
+}
+
+// TestFixtureProfilesParse keeps the fixture profiles from drifting away from
+// the spec, and pins them to the base OS whose ABI the fixture layers carry:
+// they are the input to every offline resolution test.
+func TestFixtureProfilesParse(t *testing.T) {
+	for _, name := range testregistry.ProfileNames() {
+		t.Run(name, func(t *testing.T) {
+			data, err := testregistry.ProfileBytes(name)
+			if err != nil {
+				t.Fatalf("%v", err)
+			}
+			p, err := spec.ParseProfileBytes(data)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if p.Base.OS != testregistry.Base {
+				t.Errorf("base.os = %q, want %q — fixture layers exist only for that ABI", p.Base.OS, testregistry.Base)
+			}
+			if p.Base.NormalizedArch() != testregistry.BaseArch {
+				t.Errorf("base.arch = %q, want %q", p.Base.NormalizedArch(), testregistry.BaseArch)
+			}
+		})
+	}
+}
+
+func stripFileURI(u string) (string, bool) {
+	const prefix = "file://"
+	if len(u) <= len(prefix) || u[:len(prefix)] != prefix {
+		return "", false
+	}
+	return u[len(prefix):], true
+}


### PR DESCRIPTION
Closes #54.

## What was wrong

Two things, and the fixture alone would not have fixed it.

**1. The `file://` scheme was dropped on the resolve path.** `buildRegistryClient` handed `STRATA_REGISTRY_URL` to `registry.NewS3Client` regardless of scheme, so `file:///var/strata-local` failed the `s3://` check, printed a warning to *stderr*, and fell back to the embedded recipe catalog:

```
$ STRATA_REGISTRY_URL=file:///tmp/fx/registry strata resolve profile.yaml -o out.lock
warning: S3 registry unavailable (registry: invalid S3 URL "file:///tmp/fx/registry" (expected s3://<bucket>)); falling back to embedded catalog
strata: resolve: [stage=stage7 code=BUNDLE_MISSING] layer "python-3.13.2-..." has no Sigstore bundle
```

`newClientForURL` (`cmd/strata/freeze_layer.go:291`) has dispatched `file://` → `LocalClient` since #36; the resolve path just never used it. This is #36's first unchecked work item — "verify `buildFederatedClient` exercises the `file://` path end-to-end" — and the reason it stayed unchecked is that the failure is a warning on stderr followed by a *different* error, so it reads as a bundle problem rather than a routing problem.

**2. There was nothing to point it at.** The embedded Tier 0 catalog is recipes, with no `sha256`/`bundle`/`rekor_entry`, so stage 7 kills every profile. Nothing in the tree could produce a signed local registry.

## What this adds

`internal/testregistry` — a repo-resident `file://` fixture registry, as fixture *data* rather than the ~40-line `mkregistry.sh` this replaces.

- Two layers: `python-3.13.2` and `jupyterlab-4.2.0`, both `linux-gnu-2.34/x86_64`, with real `sha256` over real committed bytes, bundles that exist on disk, and sentinel `rekor_entry` values chosen so that no real verification can pass on them (see **Trust material** below — the first version of this fixture got that badly wrong).
- `jupyterlab` **requires** `python`, and `offline-minimal.yaml` lists jupyterlab *first*. Stage 6 has to reorder them, so the mount-order assertion discriminates between a working topological sort and input order. The obvious one-layer fixture would not.
- A formation, `strata-fixture@2026.08`, so stage 2 is on the offline path too.
- `Materialize` verifies every committed digest against the committed bytes **before** touching anything, so fixture drift fails with the manifest path rather than surfacing later as a mismatched layer. `TestMaterializeDetectsFixtureDrift` covers that check.

### How the other issues consume it

This is the precondition named in #54 for #57, #59, #64, #66, and the examples-resolve test in #70, so it is deliberately not shaped around the one test in this PR:

- **From a test** — `root, client := testregistry.New(t)` returns a materialized root and a real `*registry.LocalClient`; `testregistry.Probe()` returns an offline `probe.Client` (static AMI table, `KnownBaseCapabilities`, in-memory cache) that never touches SSM or IMDS, so it behaves identically with and without credentials; `testregistry.WriteProfile(t, dir, name)` drops a profile next to it. `internal/resolver/offline_fixture_test.go` and `cmd/strata/offline_resolve_test.go` are two independent consumers at different levels, which is the check that the API is not shaped for one caller.
- **From a shell** — `go run ./internal/testregistry/mkregistry <dir>` for CI and for anything that needs to drive the real binary rather than a test binary.
- **Extending it** is adding files under `testdata/registry/`. `Materialize` discovers manifests by walking; it has no list of layers to update. A test needing arm64, a third layer, or a conflicting pair adds data, not code.
- **`VerifyLayerDigests(root)`** is exported so a test that mutates a materialized registry (planting content, corrupting a hash — #57's shape) can assert the fixture was sound before it started.
- **#64 (freeze)**: the fixture's real `sha256` values get `strata freeze` past its per-layer check to the *next* failure, `lf.Base.AMISHA256 == ""` (`spec/lockfile.go:117`), which resolve never populates. That is #64's defect, now reachable.

### Two deliberate limits

Both are stated inside the files themselves, not just here:

- `layer.sqfs` is **not a squashfs image**, it is a short text blob. Anything that hashes or fetches a layer works against it; anything that *mounts* one fails loudly. Faking the `hsqs` magic would have bought a false green for exactly the `strata run` paths in #55/#56.
- `bundle.json` is **not a valid Sigstore bundle** — no signature over this content exists. Its `messageDigest` is the real SHA-256 of `layer.sqfs`; every other field is a sentinel chosen so the strongest available check fails on it. It satisfies stage 7's *presence* check, which is all stage 7 checks today. `strata verify` against a fixture lockfile therefore does not pass, and I did not make it pass: real signature verification needs a real key, and #59 is where that gets decided.

## Trust material: what nearly shipped

**This is the part worth reading in six months.** The fixture's first version carried `rekor_entry` values chosen to look like real Rekor log indices — `148923470`, `148923471`, `148923472` — on the reasoning that stage 7 parses them with `strconv.ParseInt` when a Rekor client is configured, so a `pending-initial-build`-style placeholder (#62) would not survive that path. That reasoning stopped one step too early: it never asked what `VerifyEntry` does with the number.

`[RUN]` against the live public log:

```
148923470 -> HTTP 200    148923471 -> HTTP 200    148923472 -> HTTP 200
9007199254740991 -> HTTP 404
```

All three named **real entries in the public-good Sigstore transparency log, belonging to other people's artifacts.** And a sweep of the whole class — rather than the three values already noticed — turned up a fourth field nobody had mentioned:

```
"keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
      -> c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d
```

That is the **real public-good Rekor log's key ID** — the live log signs its tree head `— rekor.sigstore.dev wNI9aj…`, same key hint. Plus a plausible `integratedTime` of 2026-07-29. Twelve sites across four fields, together forming a coherent claim of inclusion in the genuine transparency log under that log's own identity.

Why that matters: `RekorHTTPClient.VerifyEntry` (`internal/trust/cosign.go:255-260`) returns `nil` on **existence at an index alone**, with `_ = bundle` — it discards the material it was asked to verify. That is #59. So a resolver configured with a real Rekor client would have reported this fixture as transparency-log verified, by borrowing a stranger's attestation. Three layers deep in a test fixture, with a green build.

`[RUN]` The CLI does not reach it today — `strata verify bin/fixture/offline.lock.yaml --rekor` fails first with `lockfile has no RekorEntry (not signed)`, because `verify.go:42` gates `--rekor` behind the presence checks and nothing signs lockfiles yet (#64). That is an accident of an unfinished feature, not a guard. `resolver.Config.Rekor` has no such gate.

**Worse than the thing it was avoiding.** `pending-initial-build` is non-numeric, so on the Rekor path it dies cleanly at `INVALID_REKOR_ENTRY`. A plausible integer parses, resolves, and returns success. Optimising the fixture to look *more* real, in order to be honest about stage 7 being presence-only, pushed it in exactly the wrong direction.

### The principle, now in the package doc

**Fixture data must be maximally implausible to a real verifier, not minimally sufficient for the checks that happen to exist.** A fixture optimised to pass today's checks will also pass whatever replaces them — which is the whole hazard, since #57/#59/#60/#61 are all about replacing them.

Every synthetic field is now chosen so the strongest available check fails on it:

| Field | Value | Under real verification |
|---|---|---|
| `SentinelRekorEntry` | `9007199254740991` (2^53-1) | Parses as int64 so it *reaches* `VerifyEntry`, impossible so it fails *there* — not short-circuited earlier |
| `SentinelLogKeyID` | base64 of ASCII `strata-fixture-NOT-a-real-log-ID` | The fixture no longer claims a real log's identity |
| `SentinelSignature` | base64 of ASCII `strata-fixture-not-a-real-signature` | ASCII cannot accidentally be a valid ECDSA signature |
| `SentinelIntegratedTime` | `0` | Renders as 1970 — obviously fixture data |
| layer `messageDigest` | real SHA-256 of `layer.sqfs` | Digest comparison **passes**, signature check fails. Failing at the right step beats failing early |

### `TestFixtureIsNotTrustworthy`

The guard that makes the property survive people, with the two parts that are easy to leave out:

- **It enumerates**, walking the materialized tree rather than asserting the values that exist today — so the fourth layer someone adds next month with another plausible index fails too. `[RUN]` `checked 3 manifests and 3 bundles`.
- **It fails on a zero-file walk.** A walk that found nothing would satisfy every assertion vacuously, which is the same fail-open shape as the rest of this finding.
- **It pins the constants**, not just equality against them: `SentinelRekorEntry` must parse as int64 *and* be ≥ 2^50; `SentinelLogKeyID` must not equal the real log key (hardcoded in the test as a negative); `SentinelSignature` must decode to printable ASCII. Without this, editing one constant defeats the enumeration.

`[RUN]` Seven hazards reintroduced one at a time, each reverted after:

```
plausible rekor_entry in manifest       FAILS (guard bites)
plausible logIndex in bundle            FAILS
real Rekor log keyId in bundle          FAILS
plausible integratedTime                FAILS
bundle stops declaring itself fake      FAILS
constant edited to plausible index      FAILS
constant edited to real log key         FAILS
unmutated                               PASSES
```

**If a correct tightening of verification makes this test fail, the fixture is what needs new material — not the check.** Loosening a check or special-casing the fixture to keep it green would reinstall exactly what this commit removed.

## CI

New `offline-resolve` job: build the binary → materialize the fixture → `strata resolve` with blank `AWS_*` → assert the lockfile exists, names both layers, and has no `bundle: ""`. `make offline-resolve` is the same sequence locally. This is the part that makes #54's closing condition mechanical rather than asserted.

## Notes for review

- **No new dependencies.**
- **No existing test file modified**, verified from the diff rather than asserted: every `_test.go` path in `git diff main...HEAD` is checked against `git cat-file -e main:<path>`, and all three are new. `--diff-filter=MDRT` on `*_test.go` is empty.
- **The pre-tool test-file guard fired twice**, both times on files I had created earlier in the same session, and both times because its predicate asked an adjacent question rather than the intended one: first "does this path exist on disk", then "is this path tracked in git" — which my own file became the moment I committed it. Neither is "is this inherited from `main`". I stopped both times rather than working around it, including declining the available bypass of putting the new test in a fresh untracked file. The predicate now tests `main` membership and refuses when it cannot determine the repository at all, since all earlier versions *permitted* on the unanswerable case. Recorded in the session report as a harness finding.
- **Each of the five commits builds and is green on its own** — verified in a scratch worktree, per-commit `go build ./...` and `go test ./...`.
- **`internal/testregistry` duplicates the offline probe wiring** in `cmd/strata`'s `buildStaticProbeClient`, because a test cannot import `package main`. Deduplicating means moving that wiring into `internal/probe`, which is a change to a shipped package for a test's benefit and is not this PR.
- **Local lint is `golangci-lint` 2.13.0; CI pins v2.11.3** (#76). Local green does not imply CI green, so the CI run is the claim, not `make check`.
- **Filed, not fixed: #77** — `build`, `index`, `probe`, and `remove` still reject `file://`, and `search` ignores `STRATA_REGISTRY_URL` entirely. Nine commands, five schemes-dispatch, four don't. It is the same class of defect as the one fixed here and it is tempting to fix in passing; it is a separate PR.

## Out of scope, stated plainly

`#54`'s "what closes this" lists two alternatives, and this PR takes the first (in-tree fixture) and not the second (a documented offline mode that reaches stage 8 with the *embedded recipe catalog*). Resolving against the embedded catalog still fails with `stage7 BUNDLE_MISSING`, unchanged. Making that work means either signing the recipe catalog or letting stage 7 pass unsigned layers under a flag — the second is a trust decision and the opposite of #61, so it is not something to slip into a fixture PR.

Also untouched: the three profiles in `examples/` still do not resolve (#70), and the README's flagship example still uses the software-ref form that does not parse (#53). The fixture profiles live in `internal/testregistry/testdata/profiles/` for that reason — building this PR's test on `examples/*.yaml` would have required fixing #70 inside it.

