### PR TITLE
fix(spec): parse the inline software-ref form (- python@3.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **The inline software-ref form parses** (#53). `- python@3.13` — the form every
+  documented example uses, including the README's flagship profile — did not
+  parse at all. `SoftwareRef` had no `UnmarshalYAML`, so `gopkg.in/yaml.v3`
+  rejected a scalar sequence entry before any post-processing ran, which meant
+  `ParseSoftwareRef` and the `normalizeSoftwareRefs` loop that called it were
+  unreachable for the case they existed to serve, and the comment claiming both
+  forms were supported was false. The rule now lives on the type, so both forms
+  work anywhere a `SoftwareRef` appears — a profile's `software`,
+  `Profile.Defaults`, `LockFile.Defaults` and `Formation.Layers` — rather than in
+  a post-pass that walked `Profile.Software` alone. `MarshalYAML` emits the
+  inline form only when it provably reads back equal, so writing a profile cannot
+  produce a document that reads back different from what was written.
+  Mapping-form parsing is unchanged inside a profile; the two behaviour changes
+  outside one are recorded in the pull request.
 - **Offline resolution reaches stage 8** (#54). `STRATA_REGISTRY_URL=file:///...`
   was passed to `registry.NewS3Client` regardless of scheme, so it failed the
   `s3://` check and `strata resolve`/`strata freeze` fell back to the embedded
@@ -20,6 +34,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   timeout. Completes the two work items left unchecked in #36.
 
 ### Added
+- **Documented profile snippets are checked mechanically** (#53). Every fenced
+  YAML block in the repository's markdown with a top-level `software:` or
+  `defaults:` key must unmarshal as a profile. Blocks are matched by shape rather
+  than by filename, so a new document is covered the day it is written. The
+  inline form was taught in seven places while the parser rejected it, and
+  nothing noticed, because the only profiles under test were written in the one
+  form that worked.
 - **`internal/testregistry`**: repo-resident `file://` fixture registry that
   makes resolution reach stage 8 with no AWS credentials, no network, and no
   prior build — two layers with a real dependency edge, real `sha256` over real

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a post-pass that walked `Profile.Software` alone. `MarshalYAML` emits the
   inline form only when it provably reads back equal, so writing a profile cannot
   produce a document that reads back different from what was written.
-  Mapping-form parsing is unchanged inside a profile; the two behaviour changes
-  outside one are recorded in the pull request.
+  Mapping-form parsing inside a profile is unchanged; the two changes outside one
+  are under Changed below.
 - **Offline resolution reaches stage 8** (#54). `STRATA_REGISTRY_URL=file:///...`
   was passed to `registry.NewS3Client` regardless of scheme, so it failed the
   `s3://` check and `strata resolve`/`strata freeze` fell back to the embedded
@@ -32,6 +32,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `newClientForURL`. A `file://` registry also no longer reaches for SSM when
   probing the base OS, which would have traded the missing lockfile for an IMDS
   timeout. Completes the two work items left unchecked in #36.
+
+### Changed
+- **A software ref's `name` carrying inline syntax is now re-parsed everywhere a
+  `SoftwareRef` appears** (#53), not only in a profile's `software` list. A
+  formation manifest or lockfile entry written as `- name: "cuda@12.3"` now means
+  `{name: cuda, version: 12.3}`, where before it meant a package literally named
+  `cuda@12.3`. This is a semantic change, not a bug fix, so it is recorded here
+  rather than under Fixed — but note that a literal name containing `@` or `:` was
+  never a legal `SoftwareRef`: `Validate` rejects those characters in a name. A
+  profile already re-parsed such a name, via the post-pass this release replaces;
+  `Profile.Defaults`, `LockFile.Defaults` and `Formation.Layers` did not, and
+  nothing validates those three, so the literal reading survived to the consumer
+  and broke there. **What to expect on upgrade**, by field:
+  - `Formation.Layers` — a manifest entry written that way stops failing registry
+    lookup as "not found" and starts resolving to the package the name describes.
+  - `Defaults` — `/etc/profile.d/strata-defaults.sh` is generated from `Name` and
+    `Version` separately (`internal/overlay/overlay.go:172`), so
+    `- name: "python@3.13"` emitted `module load python@3.13`, which no Lmod tree
+    can satisfy, and now emits `module load python/3.13`.
+
+  Nothing in this repository uses the form, so no committed file changes meaning;
+  a local artifact might.
+- **The error text for an invalid mapping-form software name now names the line**
+  and comes from profile validation rather than from a normalizing pass (#53):
+  `invalid profile: software[0]: invalid software name "bad name"` where 0.22.0
+  said `normalizing software refs: software[0] "bad name": …`. Same rejection,
+  same exit status.
 
 ### Added
 - **Documented profile snippets are checked mechanically** (#53). Every fenced

--- a/cmd/strata/offline_inline_resolve_test.go
+++ b/cmd/strata/offline_inline_resolve_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/scttfrdmn/strata/internal/testregistry"
+	"github.com/scttfrdmn/strata/spec"
+)
+
+// This is the CLI half of #53. Parsing the inline form is a spec-package
+// property and is covered there; what a user actually asked for is that a
+// profile written the way the documentation writes it resolves. So this runs the
+// documented syntax through the whole resolver offline, with no AWS credentials,
+// and asserts it produces the same environment as the mapping form.
+//
+// The two lockfiles are compared on layer identity, content digest and mount
+// order rather than on EnvironmentID: the fixture's base carries no AMI SHA256,
+// so the fixture lockfile is not frozen and EnvironmentID is the empty string
+// for both. Asserting two empty strings are equal would look like a strong claim
+// and prove nothing.
+func TestResolveCmdOfflineInlineFormMatchesMappingForm(t *testing.T) {
+	clearAWSEnv(t)
+
+	work := t.TempDir()
+	root, err := testregistry.Materialize(context.Background(), filepath.Join(work, "registry"))
+	if err != nil {
+		t.Fatalf("materializing fixture registry: %v", err)
+	}
+	t.Setenv("STRATA_REGISTRY_URL", testregistry.URI(root))
+
+	resolve := func(profileName, outName string) *spec.LockFile {
+		t.Helper()
+		profile := testregistry.WriteProfile(t, work, profileName)
+		out := filepath.Join(work, outName)
+
+		cmd := newResolveCmd()
+		cmd.SetArgs([]string{profile, "-o", out})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("strata resolve %s: %v", profileName, err)
+		}
+		data, err := os.ReadFile(out)
+		if err != nil {
+			t.Fatalf("%s: no lockfile written: %v", profileName, err)
+		}
+		lf, err := spec.ParseLockFileBytes(data)
+		if err != nil {
+			t.Fatalf("%s: parsing written lockfile: %v", profileName, err)
+		}
+		return lf
+	}
+
+	inline := resolve(testregistry.ProfileInline, "inline.lock.yaml")
+	mapping := resolve(testregistry.ProfileMinimal, "mapping.lock.yaml")
+
+	if len(inline.Layers) != len(testregistry.LayerIDs) {
+		t.Fatalf("inline-form lockfile has %d layers, want %d", len(inline.Layers), len(testregistry.LayerIDs))
+	}
+	if len(inline.Layers) != len(mapping.Layers) {
+		t.Fatalf("inline form resolved %d layers, mapping form %d", len(inline.Layers), len(mapping.Layers))
+	}
+
+	for i := range mapping.Layers {
+		want, got := mapping.Layers[i], inline.Layers[i]
+		if got.ID != want.ID {
+			t.Errorf("layer[%d] ID: inline form gave %q, mapping form %q", i, got.ID, want.ID)
+		}
+		if got.SHA256 != want.SHA256 {
+			t.Errorf("layer[%d] %s SHA256: inline form gave %q, mapping form %q", i, want.ID, got.SHA256, want.SHA256)
+		}
+		if got.MountOrder != want.MountOrder {
+			t.Errorf("layer[%d] %s MountOrder: inline form gave %d, mapping form %d", i, want.ID, got.MountOrder, want.MountOrder)
+		}
+	}
+
+	// The declared refs are recorded in the lockfile as the thing each layer
+	// satisfies. They must survive the inline form, or provenance would report a
+	// request the user never made.
+	for _, layer := range inline.Layers {
+		if layer.SatisfiedBy == "" {
+			t.Errorf("layer %s has an empty satisfied_by after resolving the inline form", layer.ID)
+		}
+	}
+}
+
+// TestFixtureProfilesAllResolveOffline covers every fixture profile through the
+// CLI, so adding one to ProfileNames without a test is not silently possible.
+func TestFixtureProfilesAllResolveOffline(t *testing.T) {
+	clearAWSEnv(t)
+
+	for _, name := range testregistry.ProfileNames() {
+		t.Run(name, func(t *testing.T) {
+			work := t.TempDir()
+			root, err := testregistry.Materialize(context.Background(), filepath.Join(work, "registry"))
+			if err != nil {
+				t.Fatalf("materializing fixture registry: %v", err)
+			}
+			t.Setenv("STRATA_REGISTRY_URL", testregistry.URI(root))
+
+			profile := testregistry.WriteProfile(t, work, name)
+			out := filepath.Join(work, "out.lock.yaml")
+
+			cmd := newResolveCmd()
+			cmd.SetArgs([]string{profile, "-o", out})
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("strata resolve %s: %v", name, err)
+			}
+			if _, err := os.Stat(out); err != nil {
+				t.Fatalf("%s: no lockfile written: %v", name, err)
+			}
+		})
+	}
+}

--- a/internal/testregistry/testdata/profiles/offline-inline.yaml
+++ b/internal/testregistry/testdata/profiles/offline-inline.yaml
@@ -1,0 +1,20 @@
+# The same two layers as offline-minimal.yaml, declared in the inline string
+# form that every documented example uses — "- python@3.13" rather than a
+# name/version mapping. Until #53 the two forms were not interchangeable: this
+# one did not parse at all, so nothing offline exercised the syntax the README
+# teaches. Keeping both profiles in the fixture means a regression in either form
+# fails a test rather than only failing users.
+name: offline-inline
+description: Inline-form profile that resolves offline against the testregistry fixture.
+version: "1.0"
+
+base:
+  os: al2023
+  arch: x86_64
+
+software:
+  - jupyterlab@4.2
+  - python@3.13
+
+instance:
+  type: c7i.xlarge

--- a/internal/testregistry/testdata/profiles/offline-minimal.yaml
+++ b/internal/testregistry/testdata/profiles/offline-minimal.yaml
@@ -2,8 +2,9 @@
 # dependency edge (jupyterlab requires python), so the lockfile's mount order is
 # a fact about stage 6 rather than an accident of input order.
 #
-# Software refs use the struct form deliberately: the inline string form
-# ("- python@3.13") does not parse today (#53).
+# Software refs use the struct form here. The inline string form
+# ("- python@3.13") parses as of #53, and offline-inline.yaml resolves these same
+# two layers that way, so both forms are exercised offline rather than one.
 name: offline-minimal
 description: Minimal profile that resolves offline against the testregistry fixture.
 version: "1.0"

--- a/internal/testregistry/testregistry.go
+++ b/internal/testregistry/testregistry.go
@@ -108,6 +108,11 @@ const (
 	// exercising stage 2.
 	ProfileFormation = "offline-formation.yaml"
 
+	// ProfileInline resolves the same two layers as ProfileMinimal, declared in
+	// the inline string form ("- python@3.13") that the documentation teaches
+	// and that did not parse before #53.
+	ProfileInline = "offline-inline.yaml"
+
 	// FormationRef is the formation ProfileFormation refers to.
 	FormationRef = "strata-fixture@2026.08"
 
@@ -360,5 +365,5 @@ func ProfileBytes(name string) ([]byte, error) {
 
 // ProfileNames lists every fixture profile.
 func ProfileNames() []string {
-	return []string{ProfileMinimal, ProfileFormation}
+	return []string{ProfileMinimal, ProfileFormation, ProfileInline}
 }

--- a/spec/docsnippets_test.go
+++ b/spec/docsnippets_test.go
@@ -1,0 +1,145 @@
+package spec
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestDocumentedProfileSnippetsParse is the acceptance test #53 names: no
+// documented software: snippet in the repository fails to parse. Seven
+// documentation sites taught the inline form while the parser rejected it, and
+// nothing mechanical noticed, because the only profiles under test lived in
+// examples/ and were written in the one form that worked.
+//
+// The check is deliberately narrow. It unmarshals; it does not Validate. A
+// documentation snippet is a fragment and is entitled to omit name: or base:,
+// so requiring a valid Profile would make this test a documentation style guide
+// instead of a parser invariant.
+func TestDocumentedProfileSnippetsParse(t *testing.T) {
+	snippets := harvestProfileSnippets(t, "..")
+	if len(snippets) == 0 {
+		t.Fatal("harvested no profile snippets — the harvester is broken, not the docs")
+	}
+	t.Logf("checking %d profile snippets across the repository's markdown", len(snippets))
+
+	for _, s := range snippets {
+		t.Run(s.where, func(t *testing.T) {
+			var p Profile
+			if err := yaml.Unmarshal([]byte(s.body), &p); err != nil {
+				t.Errorf("documented snippet does not parse: %v\n\n%s", err, s.body)
+			}
+		})
+	}
+}
+
+// snippet is one fenced YAML block from a markdown file.
+type snippet struct {
+	where string // "README.md:17" — file and the line the fence opens on
+	body  string
+}
+
+// harvestProfileSnippets returns every fenced yaml block under root whose
+// top-level keys make it a profile. Blocks are matched by structure rather than
+// by filename so that a new document is covered the day it is written.
+func harvestProfileSnippets(t *testing.T, root string) []snippet {
+	t.Helper()
+
+	var out []snippet
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "bin", "testdata":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".md") {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			rel = path
+		}
+		out = append(out, profileBlocks(rel, string(data))...)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+	return out
+}
+
+// profileBlocks extracts the fenced yaml blocks in one markdown document that
+// are profile-shaped: they carry a top-level software: or defaults: key, the two
+// keys whose values are software refs. A block that merely mentions software
+// nested inside some other structure is not a profile and is not checked here.
+func profileBlocks(name, content string) []snippet {
+	var out []snippet
+
+	lines := strings.Split(content, "\n")
+	inFence := false
+	fenceLang := ""
+	fenceStart := 0
+	var body []string
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !inFence {
+			if strings.HasPrefix(trimmed, "```") {
+				inFence = true
+				fenceLang = strings.ToLower(strings.TrimSpace(strings.TrimPrefix(trimmed, "```")))
+				fenceStart = i + 1
+				body = nil
+			}
+			continue
+		}
+		if strings.HasPrefix(trimmed, "```") {
+			inFence = false
+			if (fenceLang == "yaml" || fenceLang == "yml") && isProfileShaped(body) {
+				out = append(out, snippet{
+					where: name + ":" + itoa(fenceStart),
+					body:  strings.Join(body, "\n") + "\n",
+				})
+			}
+			continue
+		}
+		body = append(body, line)
+	}
+	return out
+}
+
+// isProfileShaped reports whether a block has a top-level software: or defaults:
+// key — the profile fields whose entries are software refs.
+func isProfileShaped(body []string) bool {
+	for _, line := range body {
+		if line == "software:" || line == "defaults:" ||
+			strings.HasPrefix(line, "software: ") || strings.HasPrefix(line, "defaults: ") {
+			return true
+		}
+	}
+	return false
+}
+
+// itoa avoids pulling strconv in for one call site in a test helper.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/spec/parse.go
+++ b/spec/parse.go
@@ -30,15 +30,12 @@ func ParseProfile(path string) (*Profile, error) {
 // ParseProfileBytes parses and validates a Profile from YAML bytes.
 func ParseProfileBytes(data []byte) (*Profile, error) {
 	var p Profile
+	// Both software-ref forms — inline "cuda@12.3" and the name/version mapping
+	// — are handled by SoftwareRef.UnmarshalYAML, so they need no post-pass
+	// here, and they work anywhere a SoftwareRef appears rather than only in a
+	// profile's software list.
 	if err := yaml.Unmarshal(data, &p); err != nil {
 		return nil, fmt.Errorf("parsing profile YAML: %w", err)
-	}
-
-	// Post-process: handle inline "cuda@12.3" style entries.
-	// YAML can represent software refs as plain strings or as structs.
-	// We support both forms for user convenience.
-	if err := normalizeSoftwareRefs(&p); err != nil {
-		return nil, fmt.Errorf("normalizing software refs: %w", err)
 	}
 
 	if err := p.Validate(); err != nil {
@@ -46,24 +43,6 @@ func ParseProfileBytes(data []byte) (*Profile, error) {
 	}
 
 	return &p, nil
-}
-
-// normalizeSoftwareRefs ensures all SoftwareRefs in the profile are
-// properly populated. Handles the case where a software ref was
-// deserialized from a plain string.
-func normalizeSoftwareRefs(p *Profile) error {
-	for i, sw := range p.Software {
-		// If only Name is set and it looks like an inline string ref
-		// ("cuda@12.3" or "formation:..."), re-parse it.
-		if sw.Version == "" && sw.Formation == "" && sw.Name != "" {
-			parsed, err := ParseSoftwareRef(sw.Name)
-			if err != nil {
-				return fmt.Errorf("software[%d] %q: %w", i, sw.Name, err)
-			}
-			p.Software[i] = parsed
-		}
-	}
-	return nil
 }
 
 // ParseLockFile reads a LockFile from a YAML file.

--- a/spec/profile.go
+++ b/spec/profile.go
@@ -230,9 +230,10 @@ type softwareRefFields SoftwareRef
 //   - formation:bio-seq@2026.03      → {Formation: "bio-seq@2026.03"}
 //   - {name: python, version: "3.13"} → {Name: "python", Version: "3.13"}
 //
-// A null entry never reaches this method: yaml.v3 stops at a null node before
-// consulting an unmarshaller, so "- ~" still decodes to the zero SoftwareRef
-// and is rejected by Validate, exactly as it was before this method existed.
+// A null entry never reaches this method. yaml.v3 stops at a null node before
+// consulting an unmarshaller, and then drops the element from the sequence
+// rather than zeroing it, so "- ~" is silently discarded — before this method
+// existed and still. That is #79, not something a branch here could fix.
 func (s *SoftwareRef) UnmarshalYAML(node *yaml.Node) error {
 	switch node.Kind {
 	case yaml.ScalarNode:

--- a/spec/profile.go
+++ b/spec/profile.go
@@ -253,10 +253,18 @@ func (s *SoftwareRef) UnmarshalYAML(node *yaml.Node) error {
 		}
 		ref := SoftwareRef(f)
 		// The mapping form has always accepted an inline ref in the name field
-		// — `name: "formation:cuda-python-ml@2024.03"`. Carried over verbatim
-		// from the normalizeSoftwareRefs pass this method replaces, so that
-		// mapping-form parsing is unchanged by the arrival of the scalar form.
-		if ref.Version == "" && ref.Formation == "" && ref.Name != "" {
+		// — `name: "formation:cuda-python-ml@2024.03"`. Carried over from the
+		// normalizeSoftwareRefs pass this method replaces, so that mapping-form
+		// parsing is unchanged by the arrival of the scalar form.
+		//
+		// Narrower than that pass in one respect, deliberately: it re-parses
+		// only a name that carries inline syntax. normalizeSoftwareRefs re-parsed
+		// every version-less name, which also made it validate them — and since
+		// it ran on Profile.Software alone, widening that to every []SoftwareRef
+		// would newly reject a persisted lockfile or formation manifest whose
+		// Defaults or Layers carry a name no one ever validated. Rejecting
+		// documents that used to load is not this issue's business.
+		if ref.Version == "" && ref.Formation == "" && strings.ContainsAny(ref.Name, "@:") {
 			parsed, err := ParseSoftwareRef(ref.Name)
 			if err != nil {
 				return fmt.Errorf("line %d: %w", node.Line, err)

--- a/spec/profile.go
+++ b/spec/profile.go
@@ -6,6 +6,8 @@ package spec
 import (
 	"fmt"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 // Profile is what users write. A declaration of intent: which software,
@@ -214,6 +216,73 @@ func ParseSoftwareRef(s string) (SoftwareRef, error) {
 	}
 
 	return ref, nil
+}
+
+// softwareRefFields carries SoftwareRef's fields and none of its methods.
+// Decoding into it, or encoding from it, does not re-enter the UnmarshalYAML
+// and MarshalYAML below — which would recurse until the stack ran out.
+type softwareRefFields SoftwareRef
+
+// UnmarshalYAML decodes both documented forms of a software ref: the inline
+// scalar form and the mapping form.
+//
+//   - python@3.13                    → {Name: "python", Version: "3.13"}
+//   - formation:bio-seq@2026.03      → {Formation: "bio-seq@2026.03"}
+//   - {name: python, version: "3.13"} → {Name: "python", Version: "3.13"}
+//
+// A null entry never reaches this method: yaml.v3 stops at a null node before
+// consulting an unmarshaller, so "- ~" still decodes to the zero SoftwareRef
+// and is rejected by Validate, exactly as it was before this method existed.
+func (s *SoftwareRef) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		ref, err := ParseSoftwareRef(node.Value)
+		if err != nil {
+			return fmt.Errorf("line %d: %w", node.Line, err)
+		}
+		*s = ref
+		return nil
+
+	case yaml.MappingNode:
+		var f softwareRefFields
+		// Returned unwrapped: a *yaml.TypeError is collected with the other
+		// type errors in the document, and wrapping it would make it fatal.
+		if err := node.Decode(&f); err != nil {
+			return err
+		}
+		ref := SoftwareRef(f)
+		// The mapping form has always accepted an inline ref in the name field
+		// — `name: "formation:cuda-python-ml@2024.03"`. Carried over verbatim
+		// from the normalizeSoftwareRefs pass this method replaces, so that
+		// mapping-form parsing is unchanged by the arrival of the scalar form.
+		if ref.Version == "" && ref.Formation == "" && ref.Name != "" {
+			parsed, err := ParseSoftwareRef(ref.Name)
+			if err != nil {
+				return fmt.Errorf("line %d: %w", node.Line, err)
+			}
+			ref = parsed
+		}
+		*s = ref
+		return nil
+
+	default:
+		return fmt.Errorf("line %d: software ref must be a string such as "+
+			`"python@3.13" or a mapping with name and version keys`, node.Line)
+	}
+}
+
+// MarshalYAML emits the inline scalar form when that form reads back as an
+// equal value, and the mapping form when it would not. A ref whose canonical
+// string does not survive ParseSoftwareRef — a formation carrying surrounding
+// whitespace, say — is written as a mapping rather than as a scalar that would
+// read back different from what was written.
+func (s SoftwareRef) MarshalYAML() (interface{}, error) {
+	if inline := s.String(); inline != "" {
+		if back, err := ParseSoftwareRef(inline); err == nil && back == s {
+			return inline, nil
+		}
+	}
+	return softwareRefFields(s), nil
 }
 
 // RegistryRef declares a layer registry and how to trust it.

--- a/spec/softwareref_yaml_test.go
+++ b/spec/softwareref_yaml_test.go
@@ -145,6 +145,30 @@ func TestSoftwareRefNullOrEmptyEntries(t *testing.T) {
 		}
 	})
 
+	// The mapping branch re-parses only a name carrying inline syntax, so a name
+	// that is merely invalid is left alone rather than newly rejected. It has to
+	// be: LockFile.Defaults and Formation.Layers are persisted artifacts whose
+	// entries no version of this code ever validated, and normalizeSoftwareRefs
+	// ran on Profile.Software alone. A profile still rejects it, one step later,
+	// in Validate.
+	t.Run("invalid name in a bare list is not newly rejected", func(t *testing.T) {
+		var got []SoftwareRef
+		if err := yaml.Unmarshal([]byte(`- name: "bad name"`+"\n"), &got); err != nil {
+			t.Fatalf("yaml.Unmarshal error: %v — a name outside a profile was accepted before and must still be", err)
+		}
+		if len(got) != 1 || got[0] != (SoftwareRef{Name: "bad name"}) {
+			t.Fatalf("got %+v, want the name passed through untouched", got)
+		}
+
+		_, err := ParseProfileBytes([]byte("name: t\nbase:\n  os: al2023\nsoftware:\n  - name: \"bad name\"\n"))
+		if err == nil {
+			t.Fatal("ParseProfileBytes accepted an invalid software name, want a validation error")
+		}
+		if !strings.Contains(err.Error(), `invalid software name "bad name"`) {
+			t.Errorf("error = %q, want it to name the invalid software name", err)
+		}
+	})
+
 	t.Run("bare formation key is a mapping, not a scalar", func(t *testing.T) {
 		var got []SoftwareRef
 		if err := yaml.Unmarshal([]byte("- formation:\n"), &got); err != nil {

--- a/spec/softwareref_yaml_test.go
+++ b/spec/softwareref_yaml_test.go
@@ -1,0 +1,278 @@
+package spec
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestSoftwareRefUnmarshalYAML covers both documented forms of a software ref
+// decoded as a bare []SoftwareRef — not inside a Profile — because SoftwareRef
+// is also the element type of Formation.Layers and LockFile.Defaults, and the
+// forms have to mean the same thing in all of them.
+func TestSoftwareRefUnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want SoftwareRef
+	}{
+		// The inline form. Every one of these was an unmarshal error before
+		// SoftwareRef had an UnmarshalYAML method.
+		{"inline name and version", "- python@3.13", SoftwareRef{Name: "python", Version: "3.13"}},
+		{"inline three-part version", "- python@3.11.9", SoftwareRef{Name: "python", Version: "3.11.9"}},
+		{"inline name only", "- cuda", SoftwareRef{Name: "cuda"}},
+		{"inline formation", "- formation:bio-seq@2026.03", SoftwareRef{Formation: "bio-seq@2026.03"}},
+		{"inline formation without version", "- formation:cuda-python-ml", SoftwareRef{Formation: "cuda-python-ml"}},
+		{"inline quoted", `- "quarto@1.4"`, SoftwareRef{Name: "quarto", Version: "1.4"}},
+		{"inline single quoted", `- 'git@2.43'`, SoftwareRef{Name: "git", Version: "2.43"}},
+
+		// The mapping form, which worked before this change and must still.
+		{"mapping name and version", "- {name: python, version: \"3.13\"}", SoftwareRef{Name: "python", Version: "3.13"}},
+		{"mapping name only", "- {name: cuda}", SoftwareRef{Name: "cuda"}},
+		{"mapping formation", "- {formation: bio-seq@2026.03}", SoftwareRef{Formation: "bio-seq@2026.03"}},
+		{"mapping block style", "- name: quarto\n  version: \"1.4\"", SoftwareRef{Name: "quarto", Version: "1.4"}},
+
+		// The mapping form has always accepted an inline ref in the name field.
+		// normalizeSoftwareRefs did this for a profile's software list only;
+		// UnmarshalYAML does it everywhere a SoftwareRef is decoded.
+		{
+			"mapping with inline formation in name",
+			`- {name: "formation:cuda-python-ml@2024.03"}`,
+			SoftwareRef{Formation: "cuda-python-ml@2024.03"},
+		},
+		{
+			"mapping with inline name@version in name",
+			`- {name: "cuda@12.3"}`,
+			SoftwareRef{Name: "cuda", Version: "12.3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []SoftwareRef
+			if err := yaml.Unmarshal([]byte(tt.yaml+"\n"), &got); err != nil {
+				t.Fatalf("yaml.Unmarshal(%q) error: %v", tt.yaml, err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("yaml.Unmarshal(%q) gave %d refs, want 1", tt.yaml, len(got))
+			}
+			if got[0] != tt.want {
+				t.Errorf("yaml.Unmarshal(%q) = %+v, want %+v", tt.yaml, got[0], tt.want)
+			}
+		})
+	}
+}
+
+// TestSoftwareRefUnmarshalYAMLErrors covers the entries that must not decode,
+// and asserts on the reason rather than merely on the presence of an error.
+func TestSoftwareRefUnmarshalYAMLErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{"inline name with a space", "- python 3.13", "invalid software ref"},
+		{"inline name with a slash", "- cuda/12.3", "invalid software ref"},
+		{"inline empty string", `- ""`, "empty software ref"},
+		// Quoted, because bare "- formation:" is a mapping with a null value
+		// rather than a scalar — see TestSoftwareRefNullOrEmptyEntries.
+		{"inline formation with no name", `- "formation:"`, "empty formation name"},
+		{"sequence is not a ref", "- [python, \"3.13\"]", "must be a string"},
+		{"mapping with a non-string field", "- {name: [cuda]}", "cannot unmarshal"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []SoftwareRef
+			err := yaml.Unmarshal([]byte(tt.yaml+"\n"), &got)
+			if err == nil {
+				t.Fatalf("yaml.Unmarshal(%q) succeeded, got %+v, want error", tt.yaml, got)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("yaml.Unmarshal(%q) error = %q, want it to contain %q", tt.yaml, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestSoftwareRefUnmarshalYAMLReportsLine checks that a bad ref still names the
+// line it is on. yaml.v3 returns an error from an unmarshaller verbatim instead
+// of decorating it with a position, so the position is added by hand and would
+// go missing silently if it were dropped.
+func TestSoftwareRefUnmarshalYAMLReportsLine(t *testing.T) {
+	input := []byte("- cuda\n- python\n- not a ref\n")
+	var got []SoftwareRef
+	err := yaml.Unmarshal(input, &got)
+	if err == nil {
+		t.Fatalf("yaml.Unmarshal succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "line 3") {
+		t.Errorf("error = %q, want it to name line 3", err)
+	}
+}
+
+// TestSoftwareRefNullOrEmptyEntries pins two behaviours that UnmarshalYAML does
+// not control, both established by running them rather than by reading yaml.v3.
+//
+// A null entry is dropped from the sequence entirely: yaml.v3 stops at a null
+// node before consulting an unmarshaller, and its decoder discards a sequence
+// element whose unmarshal returned false instead of zeroing it. So a null branch
+// inside UnmarshalYAML would be dead code, and the entry cannot be caught by
+// Validate either — there is nothing left to validate. That is #79. This test
+// asserts the defect as it stands so that #79 fails here when it is fixed,
+// rather than leaving the hole undocumented.
+//
+// A bare "- formation:" is not a scalar at all — it is a mapping with a null
+// value, so it takes the mapping branch and yields a zero ref, which a profile
+// does reject.
+func TestSoftwareRefNullOrEmptyEntries(t *testing.T) {
+	t.Run("null entry is dropped (#79)", func(t *testing.T) {
+		var got []SoftwareRef
+		if err := yaml.Unmarshal([]byte("- {name: cuda}\n- ~\n"), &got); err != nil {
+			t.Fatalf("yaml.Unmarshal error: %v", err)
+		}
+		if len(got) != 1 || got[0] != (SoftwareRef{Name: "cuda"}) {
+			t.Fatalf("got %+v, want the null entry dropped leaving only {cuda} — see #79", got)
+		}
+
+		p, err := ParseProfileBytes([]byte("name: t\nbase:\n  os: al2023\nsoftware:\n  - python@3.13\n  - ~\n"))
+		if err != nil {
+			t.Fatalf("ParseProfileBytes() error: %v", err)
+		}
+		if len(p.Software) != 1 {
+			t.Fatalf("len(Software) = %d, want 1 — two entries in, one out, no error (#79)", len(p.Software))
+		}
+	})
+
+	t.Run("bare formation key is a mapping, not a scalar", func(t *testing.T) {
+		var got []SoftwareRef
+		if err := yaml.Unmarshal([]byte("- formation:\n"), &got); err != nil {
+			t.Fatalf("yaml.Unmarshal error: %v", err)
+		}
+		if len(got) != 1 || got[0] != (SoftwareRef{}) {
+			t.Fatalf("got %+v, want one zero-valued ref", got)
+		}
+
+		_, err := ParseProfileBytes([]byte("name: t\nbase:\n  os: al2023\nsoftware:\n  - formation:\n"))
+		if err == nil {
+			t.Fatal("ParseProfileBytes succeeded, want a validation error")
+		}
+		if !strings.Contains(err.Error(), "must have either name or formation set") {
+			t.Errorf("error = %q, want it to report the ref has neither name nor formation", err)
+		}
+	})
+}
+
+// TestSoftwareRefMarshalYAML asserts the property MarshalYAML is written to
+// hold: a ref is written inline only when the inline form reads back equal, and
+// as a mapping otherwise. Every case must round-trip whichever form is chosen —
+// including the cases that force the mapping fallback, which is why refs that
+// cannot survive the inline form are in the table.
+func TestSoftwareRefMarshalYAML(t *testing.T) {
+	tests := []struct {
+		name       string
+		ref        SoftwareRef
+		wantInline bool
+	}{
+		{"name and version", SoftwareRef{Name: "python", Version: "3.13"}, true},
+		{"name only", SoftwareRef{Name: "cuda"}, true},
+		{"formation", SoftwareRef{Formation: "bio-seq@2026.03"}, true},
+		{"version holding a constraint", SoftwareRef{Name: "texlive", Version: ">=2024"}, true},
+
+		// TrimSpace in ParseSoftwareRef eats the trailing space, so the inline
+		// form would read back as "x" — not equal. Must fall back to a mapping.
+		{"formation with a trailing space", SoftwareRef{Formation: "x "}, false},
+		// String() gives "", which is not a ref at all.
+		{"zero value", SoftwareRef{}, false},
+		// Invalid: both set. String() would drop Name entirely.
+		{"both name and formation", SoftwareRef{Name: "a", Formation: "b"}, false},
+		// String() gives "@1.0", which parses to a ref with an empty name.
+		{"version with no name", SoftwareRef{Version: "1.0"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := yaml.Marshal([]SoftwareRef{tt.ref})
+			if err != nil {
+				t.Fatalf("yaml.Marshal(%+v) error: %v", tt.ref, err)
+			}
+
+			// Inspect the emitted node kind rather than the formatting, so the
+			// assertion is about the form chosen and not about yaml's layout.
+			var seq []yaml.Node
+			if err := yaml.Unmarshal(data, &seq); err != nil {
+				t.Fatalf("re-reading %q as nodes: %v", data, err)
+			}
+			if len(seq) != 1 {
+				t.Fatalf("marshalled to %d entries, want 1: %q", len(seq), data)
+			}
+			gotInline := seq[0].Kind == yaml.ScalarNode
+			if gotInline != tt.wantInline {
+				t.Errorf("yaml.Marshal(%+v) = %q, inline=%v, want inline=%v",
+					tt.ref, data, gotInline, tt.wantInline)
+			}
+
+			var back []SoftwareRef
+			if err := yaml.Unmarshal(data, &back); err != nil {
+				t.Fatalf("round-trip of %+v through %q failed to re-read: %v", tt.ref, data, err)
+			}
+			if len(back) != 1 || back[0] != tt.ref {
+				t.Errorf("round-trip of %+v through %q gave %+v", tt.ref, data, back)
+			}
+		})
+	}
+}
+
+// TestProfileRoundTripsInlineForm checks the whole-document path: a profile
+// written in the documented inline form parses, and re-marshalling it produces a
+// document that parses to the same refs.
+func TestProfileRoundTripsInlineForm(t *testing.T) {
+	input := []byte(`name: inline
+base:
+  os: al2023
+software:
+  - formation:bio-seq@2026.03
+  - quarto@1.4
+  - git@2.43
+defaults:
+  - quarto@1.4
+`)
+	p, err := ParseProfileBytes(input)
+	if err != nil {
+		t.Fatalf("ParseProfileBytes() error: %v", err)
+	}
+
+	want := []SoftwareRef{
+		{Formation: "bio-seq@2026.03"},
+		{Name: "quarto", Version: "1.4"},
+		{Name: "git", Version: "2.43"},
+	}
+	if len(p.Software) != len(want) {
+		t.Fatalf("len(Software) = %d, want %d", len(p.Software), len(want))
+	}
+	for i := range want {
+		if p.Software[i] != want[i] {
+			t.Errorf("Software[%d] = %+v, want %+v", i, p.Software[i], want[i])
+		}
+	}
+	// Defaults is a []SoftwareRef too, and normalizeSoftwareRefs never walked
+	// it. The inline form has to work here as well.
+	if len(p.Defaults) != 1 || p.Defaults[0] != (SoftwareRef{Name: "quarto", Version: "1.4"}) {
+		t.Errorf("Defaults = %+v, want one {quarto 1.4} ref", p.Defaults)
+	}
+
+	data, err := MarshalProfile(p)
+	if err != nil {
+		t.Fatalf("MarshalProfile() error: %v", err)
+	}
+	p2, err := ParseProfileBytes(data)
+	if err != nil {
+		t.Fatalf("ParseProfileBytes() after marshal error: %v\nmarshalled:\n%s", err, data)
+	}
+	for i := range p.Software {
+		if p.Software[i] != p2.Software[i] {
+			t.Errorf("round-trip Software[%d]: %+v != %+v", i, p.Software[i], p2.Software[i])
+		}
+	}
+}


### PR DESCRIPTION
Closes #53.

`- python@3.13` — the form every documented example uses, including the README's
flagship profile — did not parse at all. `SoftwareRef` had no `UnmarshalYAML`, so
`gopkg.in/yaml.v3` rejected a scalar sequence entry before any post-processing ran.
`ParseSoftwareRef` and the `normalizeSoftwareRefs` loop that called it were therefore
unreachable for the case they existed to serve, and the comment in `ParseProfileBytes`
claiming both forms were supported was false.

#53 offered two resolutions. This is resolution 1 — implement the unmarshaller — not 2.
The inline form is what seven documentation sites teach, and the milestone lists #53 as
unblocking #71 and #72; dropping the form from the spec would enlarge those two issues
rather than unblock them.

## The closing condition

`strata resolve` on the README's profile **verbatim** (extracted from `README.md` by
`awk`, diffed against lines 12–24 to prove it was not retyped), with every `AWS_*`
variable blanked and `AWS_CONFIG_FILE=/dev/null`:

```
=== BEFORE (main, 64d28bd) ===
strata: parsing profile YAML: yaml: unmarshal errors:
  line 6: cannot unmarshal !!str `formati...` into spec.SoftwareRef
  line 7: cannot unmarshal !!str `quarto@1.4` into spec.SoftwareRef
  line 8: cannot unmarshal !!str `pandoc@3.1` into spec.SoftwareRef
  line 9: cannot unmarshal !!str `texlive...` into spec.SoftwareRef
  line 10: cannot unmarshal !!str `git@2.43` into spec.SoftwareRef
EXIT=1

=== AFTER (this branch) — same file, same environment ===
strata: resolve: [stage=stage2 code=FORMATION_NOT_FOUND] formation "r-research@2024.03" not found in registry
  Run: strata search --formations r-research@2024.03
EXIT=1
```

**Read that carefully: the README example parses and still does not resolve.** #53 asked
that it "get past unmarshal into stage 1"; it now gets past stage 1 and dies in stage 2,
because `r-research@2024.03` is in no catalog. That is the second defect #53's own body
records at `README.md:17` — "fails *twice over*" — and it belongs to #71, the README
truth-pass. Parsing is fixed here. Resolving the README's example is not, and this PR
does not claim it.

So that "it parses" is not the only evidence, here is the documented syntax resolving
**end to end** against the #54 fixture, no credentials, no network:

```
=== profile (inline form) ===
software:
  - jupyterlab@4.2
  - python@3.13

=== BEFORE (main) ===
strata: parsing profile YAML: yaml: unmarshal errors:
  line 16: cannot unmarshal !!str `jupyter...` into spec.SoftwareRef
  line 17: cannot unmarshal !!str `python@...` into spec.SoftwareRef
EXIT=1

=== AFTER (this branch) ===
resolved: /tmp/inline-demo/inline.lock.yaml
EXIT=0
    - id: python-3.13.2-linux-gnu-2.34-x86_64      mount_order: 1
    - id: jupyterlab-4.2.0-linux-gnu-2.34-x86_64   mount_order: 2
```

Same layer IDs, same digests and same mount order as the mapping-form profile — asserted
by `TestResolveCmdOfflineInlineFormMatchesMappingForm`, so the claim is a test rather
than this comment.

## Did mapping-form parsing change? Yes, in two places, both outside a profile

The hazard worth taking seriously: an `UnmarshalYAML` on `SoftwareRef` changes parsing for
*every* profile, and for `Formation.Layers`, `LockFile.Defaults` and `Profile.Defaults`,
which are the same type. I did not assert this was safe — I built `main`'s parser and this
one and diffed what they produce for every ref-bearing YAML in the repo (3 examples, 6
formation manifests, the fixture profiles) plus a table of mapping-form edge cases.

Every file-level row is byte-identical. Two edge cases differ, both intended:

1. A `name:` field carrying inline syntax is now re-parsed **everywhere**, not only in
   `Profile.Software`. `- name: "cuda@12.3"` in a formation manifest used to yield
   `{Name: "cuda@12.3"}` — a ref that could only fail at registry lookup — and now yields
   `{Name: "cuda", Version: "12.3"}`. `normalizeSoftwareRefs` walked `Profile.Software`
   alone. Nothing committed uses that form, hence the identical file rows.
2. The error text for an invalid mapping-form name inside a profile changed, and now names
   the line: `invalid profile: software[0]: invalid software name "bad name"` where main
   said `normalizing software refs: software[0] "bad name": ...`. Same rejection, same
   exit, different message.

**The first pass of this change also had a third difference, which the diff caught and
which I removed rather than shipped.** Applying `normalizeSoftwareRefs`' rule verbatim to
every `[]SoftwareRef` also applied its *validation*, so a persisted lockfile or formation
manifest whose `Defaults` or `Layers` carried a never-validated name would have stopped
loading. `LockFile.Defaults` and `Formation.Layers` have no validation pass at all, so
that name could legitimately be sitting in an artifact today. The mapping branch is now
narrowed to re-parse only a name containing `@` or `:`, which keeps the fix and drops the
new rejection; `TestSoftwareRefNullOrEmptyEntries/invalid_name_in_a_bare_list_is_not_newly_rejected`
pins it. Rejecting documents that used to load is not this issue's business.

Inherited mapping-form tests are untouched and green, including
`TestNormalizeSoftwareRefsInlineFormation` — which is why the mapping branch reproduces
that rule rather than deleting it along with the function. #53 suggested deleting the dead
branch at `spec/parse.go:59`; the function is gone, its rule is not.

## Round-trip

`MarshalYAML` emits the inline form only when it provably reads back equal — it parses its
own output and falls back to the mapping form if the result differs — so writing a profile
cannot produce a document that reads back different from what was written. A formation
carrying surrounding whitespace is the case that forces the fallback, and it is in the
test table, so the fallback ships covered rather than assumed.

`ProfileSHA256` values change, because `internal/resolver/resolver.go:91` hashes
`yaml.Marshal(profile)` and profiles now marshal to the inline form. Nothing pins one:
`computeEnvironmentID` hashes a JSON struct of layer digests rather than YAML text, and
the only assertions on `ProfileSHA256` are non-empty and stable-across-runs. Checked, not
assumed.

## The invariant

`TestDocumentedProfileSnippetsParse` requires every fenced YAML block in the repository's
markdown with a top-level `software:` or `defaults:` key to unmarshal as a profile — 14
snippets across `README.md`, `STRATA.md` and four `docs/` files. Blocks are matched by
shape rather than by filename, so a new document is covered the day it is written.

The control matters more than the test: checked out against `main`'s parser, this test
fails on 12 of the 14 snippets. The reason nothing caught #53 for a release is that the
only profiles under test lived in `examples/`, which is the one place in the repo written
in the form that happened to work.

It unmarshals and deliberately does not `Validate`: a documentation snippet is a fragment
entitled to omit `name:` or `base:`, and requiring a whole valid profile would turn a
parser invariant into a documentation style guide — and would pull #71 and #72 into this
PR.

## Filed, not fixed

**#79 — a null entry in a software list is silently dropped, and the profile resolves
without it.** Found while writing these tests: `software:\n  - python@3.13\n  -\n` parses
successfully with one entry, no error, no warning. yaml.v3 drops a null sequence element
whose target is a struct, and `decoder.prepare` returns before an `Unmarshaler` is
consulted, so this is not reachable from `UnmarshalYAML` — a null branch there would be
dead code. Confirmed identical on `64d28bd` and on this branch, so it predates this fix
and is untouched by it. `TestSoftwareRefNullOrEmptyEntries` pins the defect as it stands,
so fixing #79 will fail that test rather than pass unnoticed.

Two of my own test assertions were wrong when first written and are corrected in the
history rather than quietly amended: a bare `- formation:` is a mapping with a null value,
not a scalar, and a null entry is dropped from the sequence rather than zeroed into it.

## Not done, though #53 arguably touches it

- **The seven documentation sites are unchanged.** They are correct as written now that
  the form parses, which was the point of choosing resolution 1. #72 owns rewriting them;
  #71 owns the README, whose example needs a formation that exists.
- **`ParseSoftwareRef` is unchanged.** Its formation branch returns without calling
  `Validate`, so `formation:a b` yields a formation ref with a space. Pre-existing, no
  behaviour change here, and it fails at lookup rather than silently — not filed, noted.
- **One inherited testdata file changed**: `offline-minimal.yaml`'s comment said the inline
  form "does not parse today (#53)", which this PR makes false. Two comment lines; the
  profile itself is untouched, and `offline-inline.yaml` is added alongside rather than
  converting the profile #54's mount-order assertions rely on.

## No new dependencies

`gopkg.in/yaml.v3` is now imported by `spec/profile.go`, which already had it in the
module and in `spec/parse.go`. `go.mod` and `go.sum` are unchanged.
