### PR TITLE
fix: layer cache mounted unhashed content — validate digests, hash cache hits (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **The layer cache no longer mounts content it has not hashed** (#57). Three
+  defects composed into an arbitrary-content mount: the cache path was built from
+  an unvalidated lockfile field (`filepath.Join` *Cleans* `..` rather than
+  rejecting it, so `sha256: "../escaped"` named a file outside `--cache-dir`), a
+  cache hit was returned without being hashed, and an empty `sha256` both
+  disabled the post-download check and collided every hashless layer onto the
+  single filename `.sqfs`. Fixing any one of them left the bypass open, so they
+  are fixed as one invariant: **nothing is returned from the layer cache that has
+  not been hashed against a well-formed declared digest.** A digest must now be
+  exactly 64 lowercase hex characters, it is validated before any path is built
+  from it, and a cache hit is hashed before it is reused.
+
+  **What changes per consumer**, all four of them, since `fetchLayersToCache` is
+  shared:
+  - `strata run`, `strata export`, `strata fold` (`run.go:102`, `export.go:76`,
+    `fold.go:122`, `fold.go:172`) — a lockfile with a layer whose `sha256` is
+    absent, short, uppercase, `sha256:`-prefixed or path-like now fails before
+    any download, naming the layer and the digest, where it previously either
+    downloaded and failed on mismatch or, in the empty case, mounted unverified.
+    A lockfile that has not been through `strata freeze` therefore no longer runs
+    at all rather than running unverified — the check the three `IsFrozen()`
+    callers make at `publish.go:73`, `freeze.go:45` and `update.go:60` now also
+    holds at the boundary where layers are actually consumed.
+  - `strata run`/`export`/`fold` with a warm cache — a cached layer is hashed on
+    every use. This is a real cost on large environments and it reverses an
+    explicit acceptance criterion of closed #40 ("no re-download, no re-verify"),
+    whose stated premise was that "SHA256 verification prevents corruption
+    regardless of path". It does not: the verification was on the download path
+    only, and the path component was attacker-controlled, so the filename was
+    never evidence of the contents. A mismatch is a hard error naming both
+    digests; the file is left in place as evidence and the error says to remove
+    it to re-download.
+  - `internal/registry` `FetchLayerSqfs` on both the S3 and local clients, used
+    by `internal/build` to assemble a build environment — same two changes:
+    digest validated before the path is built, cache hit hashed before reuse.
+  - `strata-agent` is **unchanged** and was never exposed to the composition,
+    because `internal/agent/agent.go:231` hashes every fetched path
+    unconditionally. Its cache path is still built from an unvalidated digest,
+    which can still misplace a *write*; that is #81, filed separately because
+    fixing it requires correcting two tests that assert the current behaviour.
+
 ### Fixed
 - **Offline resolution reaches stage 8** (#54). `STRATA_REGISTRY_URL=file:///...`
   was passed to `registry.NewS3Client` regardless of scheme, so it failed the
@@ -20,6 +62,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   timeout. Completes the two work items left unchecked in #36.
 
 ### Added
+- **`spec.ValidateLayerDigest`, `spec.LayerCachePath`, `spec.FileDigest`,
+  `spec.VerifyFileDigest`** (#57): one place that decides what a layer digest is
+  allowed to look like and what a cache filename may be built from. The same
+  `filepath.Join(cacheDir, sha256+".sqfs")` construction appeared at four sites;
+  a rule that has to be restated four times is a rule that will be missed at one
+  of them. `VerifyFileDigest` returns a typed `*spec.DigestMismatchError` so a
+  caller can tell "these bytes are not that layer" from "that digest is not a
+  digest".
 - **`internal/testregistry`**: repo-resident `file://` fixture registry that
   makes resolution reach stage 8 with no AWS credentials, no network, and no
   prior build — two layers with a real dependency edge, real `sha256` over real

--- a/cmd/strata/layer_cache_integrity_test.go
+++ b/cmd/strata/layer_cache_integrity_test.go
@@ -1,0 +1,295 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/strata/internal/testregistry"
+	"github.com/scttfrdmn/strata/spec"
+)
+
+// This is the regression test for #57: the strata run layer cache was an
+// integrity bypass built from three defects that compose. The path was built
+// from an unvalidated lockfile field, a cache hit was never re-hashed, and an
+// empty digest both disabled verification and collided every hashless layer
+// onto the single filename ".sqfs".
+//
+// The unit under test is fetchLayersToCache, not the strata binary, because
+// fetchLayersToCache is what all four consumers share — run.go:102,
+// export.go:76, fold.go:122 and fold.go:172 — and every path it returns goes
+// straight to overlay assembly. Testing it here covers all four.
+//
+// Every rejection case below is paired with a control. A test that only asserts
+// "this is rejected" passes just as well when everything is rejected, and a
+// tightening that rejects everything is not a fix. The controls are what make
+// these measurements.
+
+// fixtureLockfile returns a lockfile whose layers are the fixture registry's
+// real layers: real digests over the real committed bytes, file:// sources that
+// exist. It is the honest input the rejection cases are measured against.
+func fixtureLockfile(t *testing.T) spec.LockFile {
+	t.Helper()
+	_, client := testregistry.New(t)
+	manifests, err := client.ListLayers(context.Background(), "", "", "")
+	if err != nil {
+		t.Fatalf("listing fixture layers: %v", err)
+	}
+	if len(manifests) == 0 {
+		t.Fatal("fixture registry has no layers — every assertion below would pass vacuously")
+	}
+	lf := spec.LockFile{}
+	for i, m := range manifests {
+		if m.SHA256 == "" || m.Source == "" {
+			t.Fatalf("fixture layer %q has sha256=%q source=%q", m.ID, m.SHA256, m.Source)
+		}
+		lf.Layers = append(lf.Layers, spec.ResolvedLayer{
+			LayerManifest: *m,
+			MountOrder:    i + 1,
+		})
+	}
+	return lf
+}
+
+// cacheDir returns a fresh, existing cache directory and the work directory
+// containing it. The work directory is what "outside the cache" means below.
+func cacheDir(t *testing.T) (work, cache string) {
+	t.Helper()
+	work = t.TempDir()
+	cache = filepath.Join(work, "cache")
+	if err := os.MkdirAll(cache, 0o700); err != nil {
+		t.Fatalf("mkdir cache: %v", err)
+	}
+	return work, cache
+}
+
+// TestLayerCacheAcceptsHonestLayers is the control for every rejection test in
+// this file: the fixture's real layers must still fetch, and must still be
+// reused on a second call, which is the path that now re-hashes. If this fails,
+// the tightening is rejecting valid material and nothing else here means
+// anything.
+func TestLayerCacheAcceptsHonestLayers(t *testing.T) {
+	lf := fixtureLockfile(t)
+	_, cache := cacheDir(t)
+
+	first, err := fetchLayersToCache(context.Background(), lf, cache)
+	if err != nil {
+		t.Fatalf("fetching the fixture's own layers: %v", err)
+	}
+	if len(first) != len(lf.Layers) {
+		t.Fatalf("fetched %d layers, want %d", len(first), len(lf.Layers))
+	}
+	for _, lp := range first {
+		if filepath.Dir(lp.Path) != cache {
+			t.Errorf("%s: path %q is outside the cache dir %q", lp.ID, lp.Path, cache)
+		}
+		if err := spec.VerifyFileDigest(lp.Path, lp.SHA256); err != nil {
+			t.Errorf("%s: returned path does not hash to its declared digest: %v", lp.ID, err)
+		}
+	}
+
+	// Second call takes the cache-hit branch for every layer.
+	second, err := fetchLayersToCache(context.Background(), lf, cache)
+	if err != nil {
+		t.Fatalf("second fetch (cache hits, now re-hashed): %v", err)
+	}
+	for i := range second {
+		if second[i].Path != first[i].Path {
+			t.Errorf("%s: cache hit returned %q, first fetch returned %q",
+				second[i].ID, second[i].Path, first[i].Path)
+		}
+	}
+}
+
+// TestLayerCacheRejectsTraversalDigest is the issue's composed bypass, with its
+// negative control.
+//
+// A lockfile declaring sha256 "../escaped" named a file outside --cache-dir,
+// because filepath.Join calls Clean, which resolves ".." rather than rejecting
+// it. On its own that was self-cleaning: the post-download hash check removed
+// the file. It was the unhashed cache hit that made it persist — if the escaped
+// path already existed, the layer was satisfied by whatever was there and
+// nothing was ever hashed.
+//
+// The control is the same lockfile with the planted file removed. Before the
+// fix the two arms behaved differently: with the file present the run reached
+// mount, and without it the run died fetching a source that never existed. That
+// difference is precisely the measurement that the planted content was what
+// satisfied the layer. After the fix the two arms must be indistinguishable —
+// the digest is rejected before anything on disk is consulted.
+func TestLayerCacheRejectsTraversalDigest(t *testing.T) {
+	errText := map[bool]string{}
+
+	for _, planted := range []bool{true, false} {
+		work, cache := cacheDir(t)
+
+		// The escaped path is cache/../escaped.sqfs.
+		escaped := filepath.Join(work, "escaped.sqfs")
+		if planted {
+			if err := os.WriteFile(escaped, []byte("planted content, hashes to nothing declared"), 0o600); err != nil {
+				t.Fatalf("planting: %v", err)
+			}
+		}
+
+		lf := spec.LockFile{Layers: []spec.ResolvedLayer{{
+			LayerManifest: spec.LayerManifest{
+				ID:     "victim",
+				SHA256: "../escaped",
+				// A source that does not exist: if the run gets as far as
+				// fetching, it fails, and the failure names the source. That is
+				// how the control distinguishes "rejected the digest" from
+				// "tried to download and could not".
+				Source: "file://" + filepath.Join(work, "nonexistent-source.sqfs"),
+			},
+			MountOrder: 1,
+		}}}
+
+		paths, err := fetchLayersToCache(context.Background(), lf, cache)
+		if err == nil {
+			t.Fatalf("planted=%v: fetchLayersToCache accepted a traversal digest and returned %+v", planted, paths)
+		}
+		if paths != nil {
+			t.Errorf("planted=%v: paths returned alongside an error: %+v", planted, paths)
+		}
+		if !strings.Contains(err.Error(), "layer digest") {
+			t.Errorf("planted=%v: want a digest rejection, got: %v", planted, err)
+		}
+		if strings.Contains(err.Error(), "nonexistent-source") {
+			t.Errorf("planted=%v: the digest reached the fetch stage before being rejected: %v", planted, err)
+		}
+		if planted {
+			if _, statErr := os.Stat(escaped); statErr != nil {
+				t.Errorf("the planted file outside the cache dir was touched: %v", statErr)
+			}
+		}
+		errText[planted] = err.Error()
+	}
+
+	if errText[true] != errText[false] {
+		t.Errorf("the outcome still depends on the planted file:\n  present: %s\n  absent:  %s",
+			errText[true], errText[false])
+	}
+}
+
+// TestLayerCacheRejectsPlantedCacheHit covers defect 2 on its own: a file at a
+// perfectly well-formed <64hex>.sqfs name inside the cache directory, whose
+// bytes are not the bytes that digest names. Validating the path does not help
+// here — the name is valid. Only hashing the hit does.
+//
+// The control is the same test with the correct bytes planted, which must
+// succeed: it is what proves the rejection above is about the contents and not
+// about cache hits in general.
+func TestLayerCacheRejectsPlantedCacheHit(t *testing.T) {
+	lf := fixtureLockfile(t)
+	lf.Layers = lf.Layers[:1]
+	layer := lf.Layers[0]
+
+	honest, err := os.ReadFile(strings.TrimPrefix(layer.Source, "file://"))
+	if err != nil {
+		t.Fatalf("reading the fixture layer's real bytes: %v", err)
+	}
+
+	t.Run("planted content is rejected", func(t *testing.T) {
+		_, cache := cacheDir(t)
+		cached := filepath.Join(cache, layer.SHA256+".sqfs")
+		if err := os.WriteFile(cached, []byte("not the layer these bytes are named after"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		paths, err := fetchLayersToCache(context.Background(), lf, cache)
+		if err == nil {
+			t.Fatalf("a cache hit whose contents are wrong was accepted: %+v", paths)
+		}
+		var mismatch *spec.DigestMismatchError
+		if !errors.As(err, &mismatch) {
+			t.Fatalf("want a *spec.DigestMismatchError, got: %v", err)
+		}
+		if mismatch.Want != layer.SHA256 {
+			t.Errorf("mismatch names declared digest %q, want %q", mismatch.Want, layer.SHA256)
+		}
+		// The file is left in place deliberately: it is the operator's
+		// evidence, and this is a read path. The error says to remove it.
+		if _, statErr := os.Stat(cached); statErr != nil {
+			t.Errorf("the rejected cache file was deleted: %v", statErr)
+		}
+		if !strings.Contains(err.Error(), "remove the file") {
+			t.Errorf("the error does not say how to recover: %v", err)
+		}
+	})
+
+	t.Run("honest content is accepted", func(t *testing.T) {
+		_, cache := cacheDir(t)
+		cached := filepath.Join(cache, layer.SHA256+".sqfs")
+		if err := os.WriteFile(cached, honest, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		paths, err := fetchLayersToCache(context.Background(), lf, cache)
+		if err != nil {
+			t.Fatalf("a cache hit with the right contents was rejected: %v", err)
+		}
+		if len(paths) != 1 || paths[0].Path != cached {
+			t.Fatalf("got %+v, want the cached path %q", paths, cached)
+		}
+	})
+}
+
+// TestLayerCacheRejectsEmptyDigest covers defect 3, both halves: an empty digest
+// disabled verification entirely (the post-download check was guarded by
+// `if layer.SHA256 != ""`), and it collided, because Join(cacheDir, ""+".sqfs")
+// is ".sqfs" for every hashless layer in every lockfile — so the first one
+// downloaded satisfied all the others through the cache-hit path.
+//
+// The control is the same two layers with their real digests, which must fetch
+// to two distinct files. Otherwise "no collision" could be true only because
+// nothing was fetched at all.
+func TestLayerCacheRejectsEmptyDigest(t *testing.T) {
+	fixture := fixtureLockfile(t)
+	if len(fixture.Layers) < 2 {
+		t.Fatalf("need two fixture layers to test the collision, have %d", len(fixture.Layers))
+	}
+	a, b := fixture.Layers[0], fixture.Layers[1]
+
+	t.Run("rejected", func(t *testing.T) {
+		_, cache := cacheDir(t)
+		hashless := spec.LockFile{Layers: []spec.ResolvedLayer{
+			{LayerManifest: spec.LayerManifest{ID: a.ID, Source: a.Source}, MountOrder: 1},
+			{LayerManifest: spec.LayerManifest{ID: b.ID, Source: b.Source}, MountOrder: 2},
+		}}
+
+		paths, err := fetchLayersToCache(context.Background(), hashless, cache)
+		if err == nil {
+			t.Fatalf("layers with no digest were accepted: %+v", paths)
+		}
+		if !strings.Contains(err.Error(), "empty") {
+			t.Errorf("want an empty-digest rejection, got: %v", err)
+		}
+
+		entries, readErr := os.ReadDir(cache)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if len(entries) != 0 {
+			t.Errorf("a rejected fetch wrote %d file(s) into the cache: %v", len(entries), entries)
+		}
+	})
+
+	t.Run("control: the same two layers with real digests do not collide", func(t *testing.T) {
+		_, cache := cacheDir(t)
+		honest := spec.LockFile{Layers: []spec.ResolvedLayer{a, b}}
+
+		paths, err := fetchLayersToCache(context.Background(), honest, cache)
+		if err != nil {
+			t.Fatalf("two honest layers: %v", err)
+		}
+		if len(paths) != 2 {
+			t.Fatalf("got %d paths, want 2", len(paths))
+		}
+		if paths[0].Path == paths[1].Path {
+			t.Errorf("two layers share one cache file: %q", paths[0].Path)
+		}
+	})
+}

--- a/cmd/strata/run.go
+++ b/cmd/strata/run.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -218,8 +216,16 @@ func setEnvVar(env []string, key, val string) []string {
 	return append(env, prefix+val)
 }
 
-// fetchLayersToCache downloads all layers in the lockfile to cacheDir,
-// verifying SHA256 after download. Layers already in cache are reused.
+// fetchLayersToCache downloads all layers in the lockfile to cacheDir and
+// returns their paths. Layers already in cache are reused.
+//
+// The invariant is single: nothing is returned from here that has not been
+// hashed against a well-formed declared digest. That means the digest is
+// validated before it is used to build a path, a cache hit is hashed before it
+// is reused, and a layer with no digest is rejected rather than passed through
+// unverified. Callers (strata run, strata export, strata fold) hand these paths
+// straight to overlay assembly, so a path returned from here is content the
+// process is about to execute.
 func fetchLayersToCache(ctx context.Context, lf spec.LockFile, cacheDir string) ([]overlay.LayerPath, error) {
 	if len(lf.Layers) == 0 {
 		return nil, nil
@@ -230,10 +236,23 @@ func fetchLayersToCache(ctx context.Context, lf spec.LockFile, cacheDir string) 
 
 	paths := make([]overlay.LayerPath, 0, len(lf.Layers))
 	for _, layer := range lf.Layers {
-		cachePath := filepath.Join(cacheDir, layer.SHA256+".sqfs")
+		// Validate the digest before anything is built from it. filepath.Join
+		// Cleans rather than rejects, so an unvalidated digest of "../x" names a
+		// file outside cacheDir, and an empty one names the same ".sqfs" for
+		// every hashless layer in every lockfile.
+		cachePath, err := spec.LayerCachePath(cacheDir, layer.SHA256)
+		if err != nil {
+			return nil, fmt.Errorf("layer %q: %w", layer.ID, err)
+		}
 
-		// Cache hit.
-		if _, err := os.Stat(cachePath); err == nil {
+		// Cache hit — hash it. The filename is not evidence of the contents:
+		// the cache directory is shared, long-lived, and writable by whatever
+		// else runs as this user, so a file at a well-formed name still has to
+		// prove it is the layer the lockfile asked for.
+		if _, statErr := os.Stat(cachePath); statErr == nil {
+			if err := spec.VerifyFileDigest(cachePath, layer.SHA256); err != nil {
+				return nil, fmt.Errorf("cached layer %q: %w (remove the file to re-download it)", layer.ID, err)
+			}
 			paths = append(paths, overlay.LayerPath{
 				ID:         layer.ID,
 				SHA256:     layer.SHA256,
@@ -274,16 +293,11 @@ func fetchLayersToCache(ctx context.Context, lf spec.LockFile, cacheDir string) 
 			return nil, fmt.Errorf("layer %q: unsupported source scheme in %q", layer.ID, layer.Source)
 		}
 
-		// Verify SHA256 after download.
-		if layer.SHA256 != "" {
-			actual, err := sha256File(cachePath)
-			if err != nil {
-				return nil, fmt.Errorf("hashing layer %q: %w", layer.ID, err)
-			}
-			if actual != layer.SHA256 {
-				os.Remove(cachePath) //nolint:errcheck
-				return nil, fmt.Errorf("layer %q SHA256 mismatch: manifest=%q file=%q", layer.ID, layer.SHA256, actual)
-			}
+		// Verify SHA256 after download. Unconditional: the digest was validated
+		// above, so there is no hashless case left to skip.
+		if err := spec.VerifyFileDigest(cachePath, layer.SHA256); err != nil {
+			os.Remove(cachePath) //nolint:errcheck
+			return nil, fmt.Errorf("layer %q: %w", layer.ID, err)
 		}
 
 		paths = append(paths, overlay.LayerPath{
@@ -357,20 +371,6 @@ func copyFile(src, dest string) error {
 		return err
 	}
 	return os.Rename(tmpPath, dest)
-}
-
-// sha256File computes the hex-encoded SHA256 of the named file.
-func sha256File(path string) (string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer f.Close() //nolint:errcheck
-	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // parseS3URIRun parses "s3://bucket/key" → (bucket, key, true).

--- a/internal/registry/localclient.go
+++ b/internal/registry/localclient.go
@@ -260,11 +260,19 @@ func (c *LocalClient) upsertLayerIndex(manifest *spec.LayerManifest) error {
 }
 
 // FetchLayerSqfs copies the squashfs file from the local registry to cacheDir.
-// If cacheDir already contains <sha256>.sqfs it is returned immediately.
-// The copied file is verified against manifest.SHA256 before being committed.
+// manifest.SHA256 must be a well-formed digest; it is validated before any path
+// is built from it. If cacheDir already contains <sha256>.sqfs it is reused, but
+// only after it hashes to that digest — the filename is not evidence of the
+// contents. The copied file is verified before being committed.
 func (c *LocalClient) FetchLayerSqfs(_ context.Context, manifest *spec.LayerManifest, cacheDir string) (string, error) {
-	cachePath := filepath.Join(cacheDir, manifest.SHA256+".sqfs")
-	if _, err := os.Stat(cachePath); err == nil {
+	cachePath, err := spec.LayerCachePath(cacheDir, manifest.SHA256)
+	if err != nil {
+		return "", fmt.Errorf("registry: layer %q: %w", manifest.ID, err)
+	}
+	if _, statErr := os.Stat(cachePath); statErr == nil {
+		if err := spec.VerifyFileDigest(cachePath, manifest.SHA256); err != nil {
+			return "", fmt.Errorf("registry: cached layer %q: %w (remove the file to re-download it)", manifest.ID, err)
+		}
 		return cachePath, nil
 	}
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {

--- a/internal/registry/s3client.go
+++ b/internal/registry/s3client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 
@@ -358,12 +357,20 @@ func (c *S3Client) upsertLayerIndex(ctx context.Context, manifest *spec.LayerMan
 }
 
 // FetchLayerSqfs downloads the squashfs file for manifest to cacheDir.
-// If cacheDir already contains a file named <sha256>.sqfs it is returned
-// immediately without re-downloading. The downloaded file is verified against
-// manifest.SHA256 before it is committed to the cache.
+// manifest.SHA256 must be a well-formed digest; it is validated before any path
+// is built from it. If cacheDir already contains a file named <sha256>.sqfs it
+// is reused, but only after it hashes to that digest — the filename is not
+// evidence of the contents. A downloaded file is verified before it is
+// committed to the cache.
 func (c *S3Client) FetchLayerSqfs(ctx context.Context, manifest *spec.LayerManifest, cacheDir string) (string, error) {
-	cachePath := filepath.Join(cacheDir, manifest.SHA256+".sqfs")
-	if _, err := os.Stat(cachePath); err == nil {
+	cachePath, err := spec.LayerCachePath(cacheDir, manifest.SHA256)
+	if err != nil {
+		return "", fmt.Errorf("registry: layer %q: %w", manifest.ID, err)
+	}
+	if _, statErr := os.Stat(cachePath); statErr == nil {
+		if err := spec.VerifyFileDigest(cachePath, manifest.SHA256); err != nil {
+			return "", fmt.Errorf("registry: cached layer %q: %w (remove the file to re-download it)", manifest.ID, err)
+		}
 		return cachePath, nil
 	}
 

--- a/spec/digest.go
+++ b/spec/digest.go
@@ -1,0 +1,105 @@
+package spec
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// LayerCacheExt is the file extension of a cached layer squashfs image.
+const LayerCacheExt = ".sqfs"
+
+// layerDigestLen is the length of a hex-encoded SHA256.
+const layerDigestLen = 2 * sha256.Size
+
+// ValidateLayerDigest reports whether digest is a well-formed layer digest:
+// exactly 64 lowercase hex characters.
+//
+// Lowercase is required rather than merely accepted. Every digest producer in
+// this module goes through hex.EncodeToString, which emits lowercase, and every
+// consumer compares raw strings with !=, so an uppercase digest can never match
+// a file this module hashed. Accepting one would only create a second cache
+// entry for the same bytes that is guaranteed to fail verification.
+//
+// An empty digest is an error, not a permitted "unverified" state: a layer with
+// no digest cannot be checked against anything, and the caller that is about to
+// read its bytes has no way to tell content from substituted content.
+func ValidateLayerDigest(digest string) error {
+	if digest == "" {
+		return fmt.Errorf("spec: layer digest is empty: a layer with no sha256 cannot be verified")
+	}
+	if len(digest) != layerDigestLen {
+		return fmt.Errorf("spec: layer digest %q is %d characters, want %d lowercase hex",
+			digest, len(digest), layerDigestLen)
+	}
+	for i := 0; i < len(digest); i++ {
+		c := digest[i]
+		if (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') {
+			continue
+		}
+		return fmt.Errorf("spec: layer digest %q has %q at offset %d, want %d lowercase hex",
+			digest, string(c), i, layerDigestLen)
+	}
+	return nil
+}
+
+// LayerCachePath returns the path of the cached squashfs for a layer with the
+// given digest, or an error if the digest is not well-formed.
+//
+// The validation is the point of the function. filepath.Join calls Clean, which
+// resolves ".." rather than rejecting it, so joining an unvalidated digest can
+// name a file outside cacheDir. Every site that builds a layer cache path must
+// go through here so that the filename is always the digest and nothing else.
+func LayerCachePath(cacheDir, digest string) (string, error) {
+	if err := ValidateLayerDigest(digest); err != nil {
+		return "", err
+	}
+	return filepath.Join(cacheDir, digest+LayerCacheExt), nil
+}
+
+// FileDigest returns the lowercase hex SHA256 of the file at path.
+func FileDigest(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close() //nolint:errcheck // read-only
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// DigestMismatchError reports a file whose contents do not hash to the digest
+// that was declared for it.
+type DigestMismatchError struct {
+	Path string // file that was hashed
+	Want string // declared digest
+	Got  string // digest of the bytes on disk
+}
+
+func (e *DigestMismatchError) Error() string {
+	return fmt.Sprintf("spec: %s: sha256 mismatch: declared=%s actual=%s", e.Path, e.Want, e.Got)
+}
+
+// VerifyFileDigest hashes the file at path and compares it to digest, which
+// must itself be well-formed. It returns a *DigestMismatchError when the bytes
+// on disk are not the bytes the digest names.
+func VerifyFileDigest(path, digest string) error {
+	if err := ValidateLayerDigest(digest); err != nil {
+		return err
+	}
+	actual, err := FileDigest(path)
+	if err != nil {
+		return err
+	}
+	if actual != digest {
+		return &DigestMismatchError{Path: path, Want: digest, Got: actual}
+	}
+	return nil
+}

--- a/spec/digest_test.go
+++ b/spec/digest_test.go
@@ -1,0 +1,133 @@
+package spec_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/strata/spec"
+)
+
+// valid is a real hex SHA256 (of the empty string) — 64 lowercase hex chars.
+const valid = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+func TestValidateLayerDigest(t *testing.T) {
+	cases := []struct {
+		name   string
+		digest string
+		ok     bool
+	}{
+		{"valid 64 hex", valid, true},
+		{"empty", "", false},
+		{"63 hex", valid[:63], false},
+		{"65 hex", valid + "a", false},
+		{"uppercase hex", strings.ToUpper(valid), false},
+		{"traversal", "../escaped", false},
+		{"traversal padded to 64", strings.Repeat("a", 54) + "/../../etc/x", false},
+		{"path separator", valid[:32] + "/" + valid[33:], false},
+		{"absolute", "/tmp/strata-probe/escaped", false},
+		{"sha256-prefixed", "sha256:" + valid[7:], false},
+		{"non-hex letter", strings.Repeat("g", 64), false},
+		{"trailing space", valid[:63] + " ", false},
+		{"extension included", valid + ".sqfs", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := spec.ValidateLayerDigest(tc.digest)
+			if tc.ok && err != nil {
+				t.Fatalf("ValidateLayerDigest(%q) = %v, want nil", tc.digest, err)
+			}
+			if !tc.ok && err == nil {
+				t.Fatalf("ValidateLayerDigest(%q) = nil, want an error", tc.digest)
+			}
+		})
+	}
+}
+
+// TestLayerCachePathRejectsEscape is the property that matters: a path is only
+// returned when the filename is the digest and nothing else. filepath.Join
+// resolves ".." instead of rejecting it, so a rejected digest is the only thing
+// standing between a lockfile field and a write outside the cache directory.
+func TestLayerCachePathRejectsEscape(t *testing.T) {
+	cacheDir := t.TempDir()
+
+	got, err := spec.LayerCachePath(cacheDir, valid)
+	if err != nil {
+		t.Fatalf("LayerCachePath with a valid digest: %v", err)
+	}
+	if want := filepath.Join(cacheDir, valid+".sqfs"); got != want {
+		t.Errorf("LayerCachePath = %q, want %q", got, want)
+	}
+
+	for _, bad := range []string{"", "../escaped", "a/b", strings.ToUpper(valid)} {
+		got, err := spec.LayerCachePath(cacheDir, bad)
+		if err == nil {
+			t.Errorf("LayerCachePath(%q) returned %q, want an error", bad, got)
+			continue
+		}
+		if got != "" {
+			t.Errorf("LayerCachePath(%q) returned path %q alongside an error", bad, got)
+		}
+	}
+}
+
+// TestLayerCachePathEmptyDigestDoesNotCollide covers the collision half of the
+// empty-digest defect: before validation, every hashless layer in every lockfile
+// mapped to the single filename ".sqfs", so the first one downloaded satisfied
+// all the others through the cache-hit path.
+func TestLayerCachePathEmptyDigestDoesNotCollide(t *testing.T) {
+	if _, err := spec.LayerCachePath(t.TempDir(), ""); err == nil {
+		t.Fatal("an empty digest produced a cache path — every hashless layer shares it")
+	}
+}
+
+func TestVerifyFileDigest(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "layer.sqfs")
+	if err := os.WriteFile(path, []byte{}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := spec.VerifyFileDigest(path, valid); err != nil {
+		t.Fatalf("VerifyFileDigest on matching content: %v", err)
+	}
+
+	if err := os.WriteFile(path, []byte("planted"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := spec.VerifyFileDigest(path, valid)
+	var mismatch *spec.DigestMismatchError
+	if !errors.As(err, &mismatch) {
+		t.Fatalf("VerifyFileDigest on planted content = %v, want *DigestMismatchError", err)
+	}
+	if mismatch.Want != valid || mismatch.Got == valid || mismatch.Path != path {
+		t.Errorf("mismatch error does not describe the failure: %+v", mismatch)
+	}
+
+	// A malformed digest must fail before the file is hashed, so that a
+	// mismatch error is never how a bad digest surfaces.
+	if err := spec.VerifyFileDigest(path, "../escaped"); err == nil {
+		t.Error("VerifyFileDigest accepted a malformed digest")
+	} else if errors.As(err, &mismatch) {
+		t.Errorf("malformed digest surfaced as a content mismatch: %v", err)
+	}
+}
+
+func TestFileDigestIsLowercaseHex(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "empty")
+	if err := os.WriteFile(path, []byte{}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := spec.FileDigest(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != valid {
+		t.Fatalf("FileDigest(empty file) = %q, want %q", got, valid)
+	}
+	if err := spec.ValidateLayerDigest(got); err != nil {
+		t.Fatalf("FileDigest produced a digest its own validator rejects: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #57.

The `strata run` layer cache mounted content it had never hashed. Three defects
composed, and fixing any one alone left the bypass open, so this fixes them as one
invariant: **nothing comes out of the layer cache that has not been hashed against a
well-formed declared digest.**

| defect | before | after |
| --- | --- | --- |
| path built from an unvalidated digest | `filepath.Join` *Cleans* `..`, so `sha256: "../escaped"` named a file outside `--cache-dir` | digest validated before any path exists |
| cache hit never re-hashed | `os.Stat` succeeded → path returned → mounted | hit is hashed against the declared digest |
| empty `sha256` | post-download check skipped, and every hashless layer collided on `.sqfs` | rejected; nothing is written |

## What changed

- **`spec/digest.go`** (new) — `ValidateLayerDigest` (exactly 64 lowercase hex),
  `LayerCachePath`, `FileDigest`, `VerifyFileDigest`, and a typed
  `*DigestMismatchError`. One shared helper because the same construction appears at
  four sites, and a rule restated four times is a rule that will be missed at one of
  them. `spec` is the only package all the call sites already import; no new
  dependency, direct or indirect (`go.mod`/`go.sum` unchanged).
- **`cmd/strata/run.go`** — `fetchLayersToCache` validates, hashes cache hits, and
  the post-download check is now unconditional: the `if layer.SHA256 != ""` guard had
  nothing left to guard. Its local `sha256File` is gone in favour of `spec.FileDigest`.
- **`internal/registry/{s3client,localclient}.go`** — `FetchLayerSqfs`, same two
  changes.
- **Lowercase is required, not merely accepted.** Every producer here goes through
  `hex.EncodeToString`; every consumer compares raw strings with `!=`. An uppercase
  digest can never match a file this module hashed, so accepting one would only create
  a second cache entry for the same bytes that is guaranteed to fail verification.

`cmd/strata-agent/s3_fetcher.go:73` has the identical construction and is **not**
converted here — see the "class 4" section below. It was never exposed to the
composition, because `internal/agent/agent.go:231` hashes every fetched path
unconditionally.

## Evidence — the corpus run, two binaries, provenance per half

Twelve invocations per half over eleven lockfiles generated from
`internal/testregistry`, same files consumed by both halves, fresh cache dir per case.

```
### half=before                                  ### half=after
### tree=/tmp/s06/before                         ### tree=.../strata
### head=d1bb3211b95b17...                       ### head=415b90e10547bb...
### binary_sha256=b81a35ecaaa0e1...              ### binary_sha256=8ce037a628fde8...
### run.go_cache_line=233: cachePath :=          ### run.go_cache_line=243: cachePath, err :=
###   filepath.Join(cacheDir, layer.SHA256...)   ###   spec.LayerCachePath(cacheDir, ...)
```

Distinct heads, distinct binary digests, distinct source lines: the two halves
demonstrably ran from different trees. Session 05's first corpus run was silently
invalid because one half ran from the wrong module, and provenance in the output is
the only thing that caught it.

**The composed bypass, and its control:**

```
 case=traversal-planted                            case=traversal-planted
   outside_cache=[escaped.sqfs,]                     outside_cache=[escaped.sqfs,]
-  run: mounting overlay: requires Linux           +  run: layer "victim": layer digest "../escaped"
                                                   +    is 10 characters, want 64 lowercase hex
 case=traversal-control
-  run: copying layer "victim": open               +  run: layer "victim": layer digest "../escaped"
-    <CORPUS>/nonexistent-source.sqfs: no such     +    is 10 characters, want 64 lowercase hex
```

Before: with the planted file present the run reached mount; with it absent the run
died fetching a source that never existed. **That difference is the measurement** — the
planted file, whose real hash matches nothing in the lockfile, is what satisfied the
layer. After: the two arms are byte-identical, because the digest is rejected before
anything on disk is consulted. Note `outside_cache=[escaped.sqfs]` and
`cache_contents=[]` in both halves: nothing was ever cached, and before the fix it
mounted anyway.

**Defect 2 alone** (valid filename, wrong bytes) — before reached mount, after:

```
run: cached layer "jupyterlab-4.2.0-...": <WORK>/cache/cbe9d80c...93.sqfs:
  sha256 mismatch: declared=cbe9d80c...93 actual=eb7f8235...f6 (remove the file to re-download it)
```

**Defect 3** — `empty-digest`, two layers, no digests. Before:
`cache_contents=[.sqfs]` for *both* layers and the run reached mount, i.e. the second
layer was satisfied by the first one's bytes. After: `cache_contents=[]`, rejected.

**Malformed digests no longer cause a download.** `uppercase-digest`, `short-digest`,
`prefixed-digest` and `absolute-digest` all fetched first and failed on mismatch
before; they are now rejected before any network or filesystem write. `absolute-digest`
is the interesting one: `Join(cacheDir, "/tmp/.../absolute-escape.sqfs")` used to try to
write to `<cache>/tmp/s06/corpus/absolute-escape.sqfs` and failed only because the
intermediate directories did not exist.

**No regression on honest material.** `honest` and `honest-twice` (the second run
being all cache hits) are byte-identical between halves, including the cache contents.
That is the control for the whole corpus: a tightening that rejected everything would
also produce a clean-looking diff on the rejection cases.

`--no-verify` was passed throughout. It only suppresses the "lockfile has no Rekor
entry" warning (`run.go:74`); it gates no hash check, so it does not affect the
measurement.

## Regression test, with controls

`cmd/strata/layer_cache_integrity_test.go` tests `fetchLayersToCache` directly,
because that is what all four consumers share — `run.go:102`, `export.go:76`,
`fold.go:122`, `fold.go:172` — and every path it returns goes straight to overlay
assembly.

Verified to fail against pre-fix code: copying `spec/digest.go` (a pure addition, no
behaviour) and this test file into a worktree at `main` `d1bb321`, with every call site
as `main` has it:

```
--- FAIL: TestLayerCacheRejectsTraversalDigest
    fetchLayersToCache accepted a traversal digest and returned
    [{ID:victim SHA256:../escaped Path:/var/.../001/escaped.sqfs MountOrder:1}]
--- FAIL: TestLayerCacheRejectsPlantedCacheHit/planted_content_is_rejected
    a cache hit whose contents are wrong was accepted
--- FAIL: TestLayerCacheRejectsEmptyDigest/rejected
    layers with no digest were accepted: [{ID:jupyterlab-... Path:.../cache/.sqfs}
                                          {ID:python-...    Path:.../cache/.sqfs}]
```

The third failure is the collision, visible: two different layers, one filename.
`TestLayerCacheAcceptsHonestLayers` passes there too, which is what makes the other
three meaningful.

## Class 4, which is what the forecast predicted

The forecast on #57 named class 4 — *moving a rule to a wider scope and carrying its
unstated preconditions with it* — as the most likely author failure, and it landed.

Applying the same validation to `cmd/strata-agent/s3_fetcher.go` broke two inherited
tests that assert `Fetch` succeeds with `SHA256: "abc123"` and `"deadbeef"`
(`cmd/strata-agent/agent_aws_test.go:154`, `:178`). Neither string can be a SHA256, so
what those tests pin is not "the fetcher caches" but "the fetcher accepts a digest that
cannot be one" — the defect's precondition, written down as an expectation. Correcting
them is a two-line change each and is the right fix; this branch is constrained not to
modify any test inherited from `main`, precisely so a tightening cannot be made to pass
by editing what it collides with. So the agent site is reverted and filed as **#81**
with the failing output as evidence, rather than half-fixed here.

I considered a weaker rule at that boundary — reject path separators, allow any
length — which both tests would have passed. I did not take it: I would not have
designed it that way if those tests did not exist, which is the tell that it was
rationalisation rather than a boundary distinction.

## Behaviour changes a reader should weigh

- **A cache hit is hashed on every use.** This reverses an explicit acceptance
  criterion of issue 40 (now closed) ("no re-download, no re-verify"), whose stated premise was
  that "SHA256 verification prevents corruption regardless of path". It does not: the
  verification was on the download path only and the path component was
  attacker-controlled, so the filename was never evidence of the contents. The cost is
  real on large environments. The alternative the issue offers — a store whose
  filename *is* load-bearing — is a design question, not a detail, and a marker file
  an attacker can also write is not a fix; that is why it is not invented here.
- **A cache-hit mismatch is a hard error and the file is left in place.** The
  post-download path removes on mismatch because it wrote that file; a pre-existing
  cache file is the operator's evidence, and silently healing it would turn an attack
  into a slow success. The error names both digests and says to remove the file.
- **An unfrozen lockfile no longer runs at all**, where it previously ran unverified.
  `CHANGELOG.md` states this per consumer.

## Verification

- `go build ./... && go vet ./...` clean; `gofmt -l .` empty.
- `go test -race -coverprofile=... -covermode=atomic ./...` — all packages pass, no
  `-run`, no `-short`, nothing skipped. `spec` 89.4%, `internal/registry` 69.2%.
- Local `golangci-lint` **2.13.0**: `0 issues.` CI pins **v2.11.3**
  (`.github/workflows/ci.yml:90`). The two are different linters and neither result is
  evidence for the other — that gap is **#75**.
- No test inherited from `main` is modified: `git diff --name-only main..HEAD | grep
  _test` returns only the two files added here, checked against `git cat-file -e
  main:<path>`. No test deleted, no `t.Skip` added.
