### PR TITLE
fix(trust): Rekor entry verification compares the entry to the bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,14 +38,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     for every layer in a realistic lockfile while verifying none of them.
     Fetching remote bundles so `--rekor` works against an s3-backed lockfile is
     #60. Without `--rekor`, `strata verify` is unchanged.
-  - `internal/resolver` stage 7 (`stages.go:386`) — no observable change today,
-    because no shipped code path sets `resolver.Config.Rekor` (all four
-    constructions leave it nil), so the branch is unreachable outside tests.
-    Where it becomes reachable, the direction changes: stage 7 holds a bundle
-    *URI* and never bundle bytes, so a configured client now receives no bundle
-    and resolution **fails closed** with `ErrNoBundle` instead of passing on the
-    strength of "something was logged at that index". Reaching real verification
-    from stage 7 requires fetching the bundle first — #55/#60.
+  - `internal/resolver` stage 7 (`stages.go:386`) — a behaviour change with no
+    reachable consumer today, which is the kind that arrives unannounced, so it
+    is stated here rather than left to the code. Where a Rekor client *is*
+    configured, the direction reverses: stage 7 holds a bundle *URI* and never
+    bundle bytes, so the client now receives no bundle and resolution **fails
+    closed** with `ErrNoBundle` where it previously passed on the strength of
+    "something was logged at that index". Configuring a client therefore turns
+    resolution from working into failing for every layer — correct, but total.
+
+    Nothing reaches it today, and for a stronger reason than "no caller does it":
+    `resolver.Config` lives in `internal/resolver`, so **no out-of-module
+    consumer can set `Rekor` at all**, and `pkg/strata` — the public API — does
+    not expose the knob. In-tree, all four `resolver.Config{}` constructions
+    leave it nil. So the branch runs only in tests.
+
+    Reaching real verification from stage 7 requires fetching the bundle first
+    (#55/#60); which way to take it is the decision filed as #85.
   - `internal/trust` as an API — `RekorClient.VerifyEntry`'s contract now requires
     a non-nil bundle. Any out-of-tree implementation that ignored the argument was
     conforming to the old documentation and no longer conforms to the new one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **Rekor entry verification compares the entry to the bundle** (#59).
+  `RekorHTTPClient.VerifyEntry` took a bundle, discarded it (`_ = bundle`), and
+  returned success for any log index the server could find an entry at. That is a
+  presence check wearing a verifier's name: it cannot distinguish this artifact's
+  entry from a stranger's, and a valid, findable, correctly-signed entry for
+  somebody else's artifact passed it. It now decodes the `hashedrekord` body and
+  compares the artifact digest, the signature, and — where both sides carry raw
+  key bytes — the key material, returning one exported sentinel per rejection
+  reason (`trust.ErrDigestMismatch`, `ErrSignatureMismatch`, `ErrNoBundle`, and
+  seven others) so a caller can tell *which* check refused. A nil bundle is now
+  `ErrNoBundle` rather than success.
+
+  What this function still does **not** do, stated so it is not mistaken for more
+  than it is: it does not check the log's signed inclusion promise and does not
+  verify the signature cryptographically. A bundle whose signature is invalid but
+  consistently recorded in the log passes. Tying the entry to the bundle is this
+  function's job; `CosignVerifier.Verify` does the cryptography.
+
+  **What changes per consumer**, all of them, enumerated from
+  `grep -rn 'VerifyEntry(' --include='*.go' . | grep -v _test.go`:
+  - `strata verify --rekor` — behaviour change, and the only shipped caller. It
+    now loads each layer's Sigstore bundle and passes it. Two new failure modes:
+    a layer whose log entry does not match its bundle fails, naming the reason
+    (previously it passed); and a layer whose `bundle` field is a URI that cannot
+    be read locally — `s3://…`, which is what registry manifests carry — is
+    reported as a failure naming the layer rather than checked against no bundle.
+    The second is deliberate: the alternative is a command that reports success
+    for every layer in a realistic lockfile while verifying none of them.
+    Fetching remote bundles so `--rekor` works against an s3-backed lockfile is
+    #60. Without `--rekor`, `strata verify` is unchanged.
+  - `internal/resolver` stage 7 (`stages.go:386`) — no observable change today,
+    because no shipped code path sets `resolver.Config.Rekor` (all four
+    constructions leave it nil), so the branch is unreachable outside tests.
+    Where it becomes reachable, the direction changes: stage 7 holds a bundle
+    *URI* and never bundle bytes, so a configured client now receives no bundle
+    and resolution **fails closed** with `ErrNoBundle` instead of passing on the
+    strength of "something was logged at that index". Reaching real verification
+    from stage 7 requires fetching the bundle first — #55/#60.
+  - `internal/trust` as an API — `RekorClient.VerifyEntry`'s contract now requires
+    a non-nil bundle. Any out-of-tree implementation that ignored the argument was
+    conforming to the old documentation and no longer conforms to the new one.
+    `FakeRekorClient` still returns nil unconditionally and is documented as
+    unable to observe whether a call site passes a bundle at all.
+  - `strata run`, `strata export`, `strata fold`, `strata build`, `strata publish`,
+    `strata resolve`, `strata freeze` and `strata-agent` are **unchanged**: none of
+    them calls `VerifyEntry`, on any path.
 - **The layer cache no longer mounts content it has not hashed** (#57). Three
   defects composed into an arbitrary-content mount: the cache path was built from
   an unvalidated lockfile field (`filepath.Join` *Cleans* `..` rather than

--- a/cmd/strata/verify.go
+++ b/cmd/strata/verify.go
@@ -163,7 +163,7 @@ func verifyRekorEntries(ctx context.Context, lf *spec.LockFile, client trust.Rek
 // tracked separately (#60).
 func loadLocalBundle(uri string) (*trust.Bundle, error) {
 	if uri == "" {
-		return nil, errors.New("Bundle field is empty: nothing to verify the log entry against")
+		return nil, errors.New("empty Bundle field: nothing to verify the log entry against")
 	}
 	path := uri
 	switch {

--- a/cmd/strata/verify.go
+++ b/cmd/strata/verify.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/spf13/cobra"
@@ -25,8 +26,11 @@ func newVerifyCmd() *cobra.Command {
 non-empty Bundle and RekorEntry fields and the lockfile itself must be signed.
 All failures are collected and reported together.
 
-With --rekor, each layer's RekorEntry is verified against the live Rekor
-transparency log. Requires network access to rekor.sigstore.dev.
+With --rekor, each layer's log entry is fetched from the live Rekor transparency
+log and compared against that layer's Sigstore bundle: same artifact digest, same
+signature, same key material. Requires network access to rekor.sigstore.dev, and
+requires each layer's bundle to be readable locally — a bundle still held as an
+s3:// URI is reported as a failure rather than skipped.
 
 With --packages, each pip package's SHA256 pin is verified against PyPI.
 Requires network access to pypi.org.`,
@@ -40,7 +44,8 @@ Requires network access to pypi.org.`,
 			failures := collectPresenceFailures(lf)
 
 			if rekorFlag && len(failures) == 0 {
-				failures = append(failures, verifyRekorEntries(context.Background(), lf)...)
+				failures = append(failures,
+					verifyRekorEntries(context.Background(), lf, &trust.RekorHTTPClient{})...)
 			}
 
 			if packagesFlag && len(lf.Packages) > 0 {
@@ -68,7 +73,7 @@ Requires network access to pypi.org.`,
 		},
 	}
 
-	cmd.Flags().BoolVar(&rekorFlag, "rekor", false, "verify each layer's Rekor entry against the live transparency log")
+	cmd.Flags().BoolVar(&rekorFlag, "rekor", false, "compare each layer's bundle against its entry in the live transparency log")
 	cmd.Flags().BoolVar(&packagesFlag, "packages", false, "verify pip SHA256 pins against PyPI (requires network)")
 	return cmd
 }
@@ -92,15 +97,23 @@ func collectPresenceFailures(lf *spec.LockFile) []string {
 	return failures
 }
 
-// verifyRekorEntries contacts the Rekor API to confirm each layer's log entry.
-// Results are collected in parallel.
-func verifyRekorEntries(ctx context.Context, lf *spec.LockFile) []string {
+// verifyRekorEntries confirms, for every layer, that the Rekor log entry named
+// by RekorEntry attests that layer's bundle. Results are collected in parallel.
+//
+// The bundle is loaded and passed: trust.RekorClient.VerifyEntry compares the log
+// entry body against it, and without one it can only establish that somebody
+// logged something at that index (#59). A layer whose bundle URI cannot be read
+// locally is reported as a failure naming the layer — verification that cannot be
+// performed is not verification that passed.
+//
+// client is a parameter so a test can observe what this function passes; it used
+// to construct its own RekorHTTPClient, which made the call site unobservable.
+func verifyRekorEntries(ctx context.Context, lf *spec.LockFile, client trust.RekorClient) []string {
 	type result struct {
 		msg string
 	}
 
 	results := make(chan result, len(lf.Layers))
-	rekorClient := &trust.RekorHTTPClient{}
 
 	var wg sync.WaitGroup
 	for _, layer := range lf.Layers {
@@ -114,7 +127,12 @@ func verifyRekorEntries(ctx context.Context, lf *spec.LockFile) []string {
 					layer.ID, layer.RekorEntry, err)}
 				return
 			}
-			if err := rekorClient.VerifyEntry(ctx, idx, nil); err != nil {
+			bundle, err := loadLocalBundle(layer.Bundle)
+			if err != nil {
+				results <- result{fmt.Sprintf("layer %s: %v", layer.ID, err)}
+				return
+			}
+			if err := client.VerifyEntry(ctx, idx, bundle); err != nil {
 				results <- result{fmt.Sprintf("layer %s: Rekor verification failed: %v", layer.ID, err)}
 				return
 			}
@@ -132,4 +150,36 @@ func verifyRekorEntries(ctx context.Context, lf *spec.LockFile) []string {
 		}
 	}
 	return failures
+}
+
+// loadLocalBundle reads and parses a layer's Sigstore bundle from a local path or
+// a file:// URI.
+//
+// Registry manifests carry s3:// bundle URIs, and fetching those is the caller's
+// job everywhere else in this codebase (see trust.VerifyLayer, which refuses URIs
+// outright). Rather than pass a nil bundle and let the Rekor check degrade into a
+// presence check, an unfetchable bundle is an error that names what is missing.
+// Fetching remote bundles so that --rekor works against an s3-backed lockfile is
+// tracked separately (#60).
+func loadLocalBundle(uri string) (*trust.Bundle, error) {
+	if uri == "" {
+		return nil, errors.New("Bundle field is empty: nothing to verify the log entry against")
+	}
+	path := uri
+	switch {
+	case strings.HasPrefix(uri, "file://"):
+		path = strings.TrimPrefix(uri, "file://")
+	case strings.Contains(uri, "://"):
+		return nil, fmt.Errorf("bundle %q must be fetched to disk before --rekor can verify against it", uri)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading bundle %q: %w", path, err)
+	}
+	bundle, err := trust.ParseBundle(data)
+	if err != nil {
+		return nil, fmt.Errorf("parsing bundle %q: %w", path, err)
+	}
+	return bundle, nil
 }

--- a/cmd/strata/verify_rekor_test.go
+++ b/cmd/strata/verify_rekor_test.go
@@ -1,0 +1,232 @@
+package main
+
+// Call-site tests for `strata verify --rekor` (#59).
+//
+// The defect being fixed is on the trust side, but it had a call-site half: this
+// function used to construct its own *trust.RekorHTTPClient internally, so
+// nothing could observe what it passed to VerifyEntry — which is exactly the
+// property that let a discarded bundle go unnoticed. The client is now a
+// parameter, and these tests assert what arrives through it.
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/scttfrdmn/strata/internal/trust"
+	"github.com/scttfrdmn/strata/spec"
+)
+
+// recordingRekor captures every VerifyEntry call so a test can assert on the
+// arguments rather than only on the outcome.
+type recordingRekor struct {
+	mu    sync.Mutex
+	calls []recordedCall
+	err   error // returned from VerifyEntry
+}
+
+type recordedCall struct {
+	logIndex int64
+	bundle   *trust.Bundle
+}
+
+func (r *recordingRekor) Log(context.Context, *trust.Bundle) (int64, error) {
+	return 0, errors.New("not used")
+}
+
+func (r *recordingRekor) VerifyEntry(_ context.Context, logIndex int64, bundle *trust.Bundle) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, recordedCall{logIndex: logIndex, bundle: bundle})
+	return r.err
+}
+
+func (r *recordingRekor) recorded() []recordedCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]recordedCall, len(r.calls))
+	copy(out, r.calls)
+	return out
+}
+
+// writeBundle writes a minimal parseable bundle to dir and returns its path.
+func writeBundle(t *testing.T, dir, name string, logIndex string, digest, sig []byte) string {
+	t.Helper()
+	b := &trust.Bundle{MediaType: trust.BundleMediaType}
+	b.VerificationMaterial.TlogEntries = []trust.TlogEntry{{LogIndex: logIndex}}
+	b.MessageSignature.MessageDigest.Algorithm = "SHA2_256"
+	b.MessageSignature.MessageDigest.Digest = digest
+	b.MessageSignature.Signature = sig
+
+	data, err := b.Marshal()
+	if err != nil {
+		t.Fatalf("marshalling bundle: %v", err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("writing bundle: %v", err)
+	}
+	return path
+}
+
+// TestVerifyRekorEntries_PassesTheBundle is the call-site half of #59: the
+// bundle named by the layer must reach VerifyEntry. Before the fix this function
+// passed no bundle at all, and the check could not fail for the right reason
+// because it had nothing to compare.
+func TestVerifyRekorEntries_PassesTheBundle(t *testing.T) {
+	dir := t.TempDir()
+	digest := []byte("32-bytes-of-digest-material-here")
+	sig := []byte("signature")
+	path := writeBundle(t, dir, "layer.bundle.json", "111", digest, sig)
+
+	lf := &spec.LockFile{
+		RekorEntry: "9",
+		Layers: []spec.ResolvedLayer{{LayerManifest: spec.LayerManifest{
+			ID:         "python-3.11.11",
+			Bundle:     path,
+			RekorEntry: "111",
+		}}},
+	}
+
+	client := &recordingRekor{}
+	failures := verifyRekorEntries(context.Background(), lf, client)
+	if len(failures) != 0 {
+		t.Fatalf("expected no failures, got %v", failures)
+	}
+
+	calls := client.recorded()
+	if len(calls) != 1 {
+		t.Fatalf("VerifyEntry called %d times, want 1", len(calls))
+	}
+	if calls[0].logIndex != 111 {
+		t.Errorf("logIndex = %d, want 111", calls[0].logIndex)
+	}
+	if calls[0].bundle == nil {
+		t.Fatal("VerifyEntry received a nil bundle: the call site is still asking the log " +
+			"whether something was recorded rather than whether this bundle was")
+	}
+	if got := string(calls[0].bundle.MessageSignature.MessageDigest.Digest); got != string(digest) {
+		t.Errorf("bundle digest = %q, want %q — a bundle arrived, but not this layer's", got, digest)
+	}
+}
+
+// TestVerifyRekorEntries_FileURI covers the file:// form of the same path.
+func TestVerifyRekorEntries_FileURI(t *testing.T) {
+	dir := t.TempDir()
+	path := writeBundle(t, dir, "b.json", "222", []byte("digest"), []byte("sig"))
+
+	lf := &spec.LockFile{
+		RekorEntry: "9",
+		Layers: []spec.ResolvedLayer{{LayerManifest: spec.LayerManifest{
+			ID: "gcc-13.2.0", Bundle: "file://" + path, RekorEntry: "222",
+		}}},
+	}
+
+	client := &recordingRekor{}
+	if failures := verifyRekorEntries(context.Background(), lf, client); len(failures) != 0 {
+		t.Fatalf("expected no failures, got %v", failures)
+	}
+	if calls := client.recorded(); len(calls) != 1 || calls[0].bundle == nil {
+		t.Fatalf("file:// bundle did not reach VerifyEntry: %+v", calls)
+	}
+}
+
+// TestVerifyRekorEntries_UnfetchableBundleIsAFailure pins the decision that an
+// s3:// bundle URI is a reported failure rather than a skipped check. Registry
+// manifests carry s3:// URIs, so the tempting alternative — pass nil and let the
+// Rekor call fall back to a presence check — would make `--rekor` report success
+// for every layer in a realistic lockfile while verifying none of them.
+//
+// The assertion is not only that a failure is reported: it is that VerifyEntry is
+// never reached. A verification that cannot be performed must not be attempted
+// against no bundle.
+func TestVerifyRekorEntries_UnfetchableBundleIsAFailure(t *testing.T) {
+	lf := &spec.LockFile{
+		RekorEntry: "9",
+		Layers: []spec.ResolvedLayer{{LayerManifest: spec.LayerManifest{
+			ID:         "python-3.11.11",
+			Bundle:     "s3://strata-test-layers/python-3.11.11/bundle.json",
+			RekorEntry: "333",
+		}}},
+	}
+
+	client := &recordingRekor{}
+	failures := verifyRekorEntries(context.Background(), lf, client)
+	if len(failures) != 1 {
+		t.Fatalf("expected 1 failure, got %d: %v", len(failures), failures)
+	}
+	if !strings.Contains(failures[0], "python-3.11.11") {
+		t.Errorf("failure should name the layer: %q", failures[0])
+	}
+	if !strings.Contains(failures[0], "fetched to disk") {
+		t.Errorf("failure should say what is missing: %q", failures[0])
+	}
+	if calls := client.recorded(); len(calls) != 0 {
+		t.Errorf("VerifyEntry was called with %d bundle(s) despite there being none to load: %+v",
+			len(calls), calls)
+	}
+}
+
+// TestVerifyRekorEntries_MissingFileIsAFailure: a bundle path that does not exist
+// is a failure naming the layer, not a pass.
+func TestVerifyRekorEntries_MissingFileIsAFailure(t *testing.T) {
+	lf := &spec.LockFile{
+		RekorEntry: "9",
+		Layers: []spec.ResolvedLayer{{LayerManifest: spec.LayerManifest{
+			ID: "absent", Bundle: filepath.Join(t.TempDir(), "nope.json"), RekorEntry: "444",
+		}}},
+	}
+	client := &recordingRekor{}
+	failures := verifyRekorEntries(context.Background(), lf, client)
+	if len(failures) != 1 || !strings.Contains(failures[0], "absent") {
+		t.Fatalf("expected 1 failure naming the layer, got %v", failures)
+	}
+	if calls := client.recorded(); len(calls) != 0 {
+		t.Errorf("VerifyEntry called despite an unreadable bundle: %+v", calls)
+	}
+}
+
+// TestVerifyRekorEntries_ClientErrorSurfaces: the sentinel the trust package
+// returns must reach the user's failure list, not be flattened to "failed".
+func TestVerifyRekorEntries_ClientErrorSurfaces(t *testing.T) {
+	dir := t.TempDir()
+	path := writeBundle(t, dir, "b.json", "555", []byte("digest"), []byte("sig"))
+
+	lf := &spec.LockFile{
+		RekorEntry: "9",
+		Layers: []spec.ResolvedLayer{{LayerManifest: spec.LayerManifest{
+			ID: "mismatched", Bundle: path, RekorEntry: "555",
+		}}},
+	}
+	client := &recordingRekor{err: trust.ErrDigestMismatch}
+	failures := verifyRekorEntries(context.Background(), lf, client)
+	if len(failures) != 1 {
+		t.Fatalf("expected 1 failure, got %d: %v", len(failures), failures)
+	}
+	if !strings.Contains(failures[0], trust.ErrDigestMismatch.Error()) {
+		t.Errorf("failure should carry the reason the entry was rejected: %q", failures[0])
+	}
+}
+
+// TestVerifyRekorEntries_BadIndexIsNotVerified: a non-numeric RekorEntry is a
+// failure and the client is never called with a nonsense index.
+func TestVerifyRekorEntries_BadIndexIsNotVerified(t *testing.T) {
+	lf := &spec.LockFile{
+		RekorEntry: "9",
+		Layers: []spec.ResolvedLayer{{LayerManifest: spec.LayerManifest{
+			ID: "pending", Bundle: "irrelevant", RekorEntry: "pending-initial-build",
+		}}},
+	}
+	client := &recordingRekor{}
+	failures := verifyRekorEntries(context.Background(), lf, client)
+	if len(failures) != 1 || !strings.Contains(failures[0], "not a valid log index") {
+		t.Fatalf("expected a log-index failure, got %v", failures)
+	}
+	if calls := client.recorded(); len(calls) != 0 {
+		t.Errorf("VerifyEntry called for an unparseable index: %+v", calls)
+	}
+}

--- a/internal/resolver/stages.go
+++ b/internal/resolver/stages.go
@@ -374,6 +374,15 @@ func (r *Resolver) verifyBundle(ctx context.Context, rl resolvedLayer) error {
 					rl.manifest.ID, rl.manifest.RekorEntry, err),
 			}
 		}
+		// Stage 7 holds a bundle *URI* (manifest.Bundle), never bundle bytes:
+		// resolution runs before anything is downloaded, and fetching is the
+		// caller's job everywhere else in this codebase (trust.VerifyLayer
+		// refuses URIs outright). So no bundle can be passed here, and since
+		// #59 a RekorClient that is given none returns trust.ErrNoBundle —
+		// configuring a real client makes resolution fail closed rather than
+		// pass on the strength of "something was logged at that index".
+		// Reaching real verification from stage 7 means fetching the bundle
+		// first; that is #55/#60's work, not this call's.
 		if err := r.cfg.Rekor.VerifyEntry(ctx, logIndex, nil); err != nil {
 			return &ResolutionError{
 				Stage:   "stage7",

--- a/internal/resolver/stages.go
+++ b/internal/resolver/stages.go
@@ -382,7 +382,8 @@ func (r *Resolver) verifyBundle(ctx context.Context, rl resolvedLayer) error {
 		// configuring a real client makes resolution fail closed rather than
 		// pass on the strength of "something was logged at that index".
 		// Reaching real verification from stage 7 means fetching the bundle
-		// first; that is #55/#60's work, not this call's.
+		// first; that is #55/#60's work, not this call's. The decision about
+		// which way to take it is #85.
 		if err := r.cfg.Rekor.VerifyEntry(ctx, logIndex, nil); err != nil {
 			return &ResolutionError{
 				Stage:   "stage7",

--- a/internal/trust/cosign.go
+++ b/internal/trust/cosign.go
@@ -3,7 +3,10 @@ package trust
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -231,8 +234,80 @@ func (c *RekorHTTPClient) Log(ctx context.Context, bundle *Bundle) (int64, error
 	return 0, fmt.Errorf("rekor log: could not extract logIndex from response")
 }
 
-// VerifyEntry confirms a bundle is present at logIndex in the Rekor log.
+// Sentinel errors returned by RekorHTTPClient.VerifyEntry. There is one per
+// distinct reason an entry fails to attest a bundle, because "the call returned
+// an error" is not a measurement: a rejection that fires from the wrong check
+// looks identical in the output. Callers and tests match with errors.Is.
+var (
+	// ErrNoBundle means VerifyEntry was called without the bundle whose
+	// contents the log entry is supposed to attest. Existence of an entry at a
+	// log index says only that somebody logged something there.
+	ErrNoBundle = errors.New("rekor verify: no bundle supplied")
+
+	// ErrEntryNotFound means the log holds no entry at the requested index.
+	ErrEntryNotFound = errors.New("rekor verify: no entry at log index")
+
+	// ErrLogIndexMismatch means the bundle names a different log index than the
+	// one being checked, so the two cannot be talking about the same entry.
+	ErrLogIndexMismatch = errors.New("rekor verify: bundle claims a different log index")
+
+	// ErrMalformedEntry means the entry body could not be decoded.
+	ErrMalformedEntry = errors.New("rekor verify: entry body is not decodable")
+
+	// ErrUnsupportedEntryKind means the entry is not a hashedrekord, which is
+	// the only kind this client knows how to compare against a bundle.
+	ErrUnsupportedEntryKind = errors.New("rekor verify: unsupported entry kind")
+
+	// ErrIncompleteBundle means the bundle carries no digest or no signature,
+	// so there is nothing to compare the entry against. Comparing empty to
+	// empty would succeed, which is the failure mode this check exists to stop.
+	ErrIncompleteBundle = errors.New("rekor verify: bundle has no digest or signature to compare")
+
+	// ErrDigestAlgorithm means the entry or the bundle names a hash algorithm
+	// other than SHA-256.
+	ErrDigestAlgorithm = errors.New("rekor verify: unsupported digest algorithm")
+
+	// ErrDigestMismatch means the entry attests a different artifact than the
+	// bundle does. This is the case where a real, valid, findable log entry
+	// belongs to somebody else's artifact.
+	ErrDigestMismatch = errors.New("rekor verify: entry attests a different artifact digest")
+
+	// ErrSignatureMismatch means the entry and the bundle agree on the artifact
+	// but carry different signatures over it.
+	ErrSignatureMismatch = errors.New("rekor verify: entry carries a different signature")
+
+	// ErrPublicKeyMismatch means the entry and the bundle carry different key
+	// material. Checked only when both sides supply raw key bytes.
+	ErrPublicKeyMismatch = errors.New("rekor verify: entry carries different key material")
+)
+
+// VerifyEntry confirms that the Rekor log entry at logIndex attests bundle:
+// that an entry exists there, and that its body names the same artifact digest,
+// the same signature, and (where both sides carry raw key bytes) the same key as
+// the bundle presented alongside it.
+//
+// bundle is required. Existence alone establishes only that something was logged
+// at that index — not that it was this artifact, nor that it was signed by the
+// expected key. An index without a bundle is unverifiable and returns
+// ErrNoBundle rather than success (#59).
+//
+// The comparison covers the hashedrekord fields this repository itself writes in
+// Log: spec.data.hash (algorithm and hex value) and spec.signature (content and
+// public key). It does not check the log's own signed inclusion promise or the
+// signer's identity — a bundle whose signature is cryptographically invalid but
+// consistently recorded in the log still passes this function. Full signature
+// verification is CosignVerifier.Verify's job; this function's job is to tie the
+// log entry to the bundle.
 func (c *RekorHTTPClient) VerifyEntry(ctx context.Context, logIndex int64, bundle *Bundle) error {
+	if bundle == nil {
+		return fmt.Errorf("%w: log index %d proves only that something was logged there", ErrNoBundle, logIndex)
+	}
+	// A bundle that names a different index is not evidence about this one,
+	// whatever the log returns.
+	if claimed, ok := bundle.RekorLogIndex(); ok && claimed != logIndex {
+		return fmt.Errorf("%w: bundle names %d, caller asked about %d", ErrLogIndexMismatch, claimed, logIndex)
+	}
+
 	url := fmt.Sprintf("%s/api/v1/log/entries?logIndex=%d", c.rekorBaseURL(), logIndex)
 	resp, err := getJSON(ctx, url)
 	if err != nil {
@@ -254,12 +329,92 @@ func (c *RekorHTTPClient) VerifyEntry(ctx context.Context, logIndex int64, bundl
 			continue
 		}
 		if entry.LogIndex == logIndex {
-			// Entry exists in the log. For full verification, the body would be
-			// decoded and compared against the bundle. For now, existence is sufficient
-			// for the unit layer of trust; the cosign CLI performs the full check.
-			_ = bundle
-			return nil
+			return matchEntryBody(entry.Body, bundle, logIndex)
 		}
 	}
-	return fmt.Errorf("rekor verify: entry at logIndex %d not found", logIndex)
+	return fmt.Errorf("%w: %d", ErrEntryNotFound, logIndex)
+}
+
+// matchEntryBody compares a base64-encoded hashedrekord entry body against the
+// bundle it is supposed to attest. Every return path names the specific field
+// that disagreed, so that a caller can tell which check rejected the entry.
+func matchEntryBody(bodyB64 string, bundle *Bundle, logIndex int64) error {
+	rawBody, err := base64.StdEncoding.DecodeString(bodyB64)
+	if err != nil {
+		return fmt.Errorf("%w: entry %d body is not base64: %v", ErrMalformedEntry, logIndex, err)
+	}
+	var body hashedRekorBody
+	if err := json.Unmarshal(rawBody, &body); err != nil {
+		return fmt.Errorf("%w: entry %d body is not JSON: %v", ErrMalformedEntry, logIndex, err)
+	}
+	if body.Kind != "hashedrekord" {
+		return fmt.Errorf("%w: entry %d is kind %q; this client compares hashedrekord entries only",
+			ErrUnsupportedEntryKind, logIndex, body.Kind)
+	}
+
+	// An empty digest or signature on the bundle side would make every
+	// comparison below vacuous, so it is rejected before any of them run.
+	if len(bundle.MessageSignature.MessageDigest.Digest) == 0 || len(bundle.MessageSignature.Signature) == 0 {
+		return fmt.Errorf("%w: digest=%d bytes signature=%d bytes",
+			ErrIncompleteBundle,
+			len(bundle.MessageSignature.MessageDigest.Digest),
+			len(bundle.MessageSignature.Signature))
+	}
+
+	if !isSHA256(body.Spec.Data.Hash.Algorithm) {
+		return fmt.Errorf("%w: entry %d names %q", ErrDigestAlgorithm, logIndex, body.Spec.Data.Hash.Algorithm)
+	}
+	if alg := bundle.MessageSignature.MessageDigest.Algorithm; alg != "" && !isSHA256(alg) {
+		return fmt.Errorf("%w: bundle names %q", ErrDigestAlgorithm, alg)
+	}
+
+	// The Rekor body carries the digest as a hex string; the bundle carries raw
+	// bytes. Log writes the same bridge (fmt.Sprintf("%x", …)).
+	wantDigest := hex.EncodeToString(bundle.MessageSignature.MessageDigest.Digest)
+	if gotDigest := strings.ToLower(body.Spec.Data.Hash.Value); gotDigest != wantDigest {
+		return fmt.Errorf("%w: entry %d attests sha256:%s, bundle attests sha256:%s",
+			ErrDigestMismatch, logIndex, gotDigest, wantDigest)
+	}
+
+	if !bytes.Equal(body.Spec.Signature.Content, bundle.MessageSignature.Signature) {
+		return fmt.Errorf("%w: entry %d signature is %d bytes, bundle signature is %d bytes",
+			ErrSignatureMismatch, logIndex,
+			len(body.Spec.Signature.Content), len(bundle.MessageSignature.Signature))
+	}
+
+	// Key material is compared only when both sides carry raw bytes. A cosign v3
+	// key-based bundle may carry a Hint instead, which is not the same encoding
+	// and is not guessed at here; the digest and signature comparisons above
+	// already tie the entry to this artifact and this signature.
+	if want := bundleRawKey(bundle); len(want) > 0 && len(body.Spec.Signature.PublicKey.Content) > 0 {
+		if !bytes.Equal(body.Spec.Signature.PublicKey.Content, want) {
+			return fmt.Errorf("%w: entry %d key is %d bytes, bundle key is %d bytes",
+				ErrPublicKeyMismatch, logIndex, len(body.Spec.Signature.PublicKey.Content), len(want))
+		}
+	}
+
+	return nil
+}
+
+// isSHA256 reports whether a hash-algorithm name from a Rekor body or a sigstore
+// bundle denotes SHA-256. Rekor writes "sha256"; sigstore bundles write
+// "SHA2_256".
+func isSHA256(alg string) bool {
+	switch strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(alg)) {
+	case "sha256", "sha2256":
+		return true
+	}
+	return false
+}
+
+// bundleRawKey returns the raw certificate or public key bytes a bundle carries,
+// or nil when it carries neither (a hint-only bundle).
+func bundleRawKey(bundle *Bundle) []byte {
+	switch {
+	case bundle.VerificationMaterial.Certificate != nil && len(bundle.VerificationMaterial.Certificate.RawBytes) > 0:
+		return bundle.VerificationMaterial.Certificate.RawBytes
+	case bundle.VerificationMaterial.PublicKey != nil && len(bundle.VerificationMaterial.PublicKey.RawBytes) > 0:
+		return bundle.VerificationMaterial.PublicKey.RawBytes
+	}
+	return nil
 }

--- a/internal/trust/fake.go
+++ b/internal/trust/fake.go
@@ -94,6 +94,13 @@ func (c *FakeRekorClient) Log(_ context.Context, bundle *Bundle) (int64, error) 
 }
 
 // VerifyEntry always succeeds for testing purposes.
+//
+// It ignores the bundle, including a nil one, which RekorHTTPClient rejects with
+// ErrNoBundle since #59. So a test that drives a call site through this fake
+// cannot observe whether that site passes a bundle at all — which is how the
+// stage-7 resolver call site stayed unmeasured while VerifyEntry discarded its
+// bundle. A test that means to assert what a call site passes needs a recording
+// client, not this one.
 func (c *FakeRekorClient) VerifyEntry(_ context.Context, _ int64, _ *Bundle) error {
 	return nil
 }

--- a/internal/trust/rekor_entry_test.go
+++ b/internal/trust/rekor_entry_test.go
@@ -1,0 +1,467 @@
+package trust_test
+
+// Corpus for RekorHTTPClient.VerifyEntry (#59).
+//
+// A verifier that verifies nothing and a verifier that verifies correctly both
+// return success on honest input, so honest input cannot tell them apart. What
+// distinguishes them is material a correct implementation rejects — and a
+// rejection that fires from a different check than the one under test looks
+// identical in the output. So every case below asserts the *specific* sentinel
+// error, never merely "an error occurred".
+//
+// The server is a local httptest stub, not rekor.sigstore.dev: this runs in CI's
+// Test job, offline, with no dependence on the contents of the public log. The
+// entry-body shape it serves is the one this repository's own Log method writes
+// (internal/trust/cosign.go). That is an assumption about Rekor's canonicalized
+// hashedrekord encoding, not a measurement of it.
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/strata/internal/testregistry"
+	"github.com/scttfrdmn/strata/internal/trust"
+)
+
+// ---- stub Rekor ----
+
+// rekorStub serves GET /api/v1/log/entries?logIndex=N from a fixed table of
+// base64 entry bodies. An index absent from the table produces an empty object,
+// which is what the real API returns for an index that does not exist.
+func rekorStub(t *testing.T, bodies map[int64]string) *trust.RekorHTTPClient {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		idx, err := strconv.ParseInt(r.URL.Query().Get("logIndex"), 10, 64)
+		w.Header().Set("Content-Type", "application/json")
+		if err != nil {
+			http.Error(w, "bad logIndex", http.StatusBadRequest)
+			return
+		}
+		body, ok := bodies[idx]
+		if !ok {
+			fmt.Fprint(w, `{}`) //nolint:errcheck
+			return
+		}
+		fmt.Fprintf(w, `{"%040x":{"logIndex":%d,"body":%q}}`, idx, idx, body) //nolint:errcheck
+	}))
+	t.Cleanup(srv.Close)
+	return &trust.RekorHTTPClient{BaseURL: srv.URL}
+}
+
+// ---- entry bodies ----
+
+// entryBody is the hashedrekord shape RekorHTTPClient.Log writes and
+// VerifyEntry reads. Declared here rather than reused because the production
+// type is unexported: a test that shares the encoder with the code under test
+// cannot detect an encoding disagreement, and this one is meant to.
+type entryBody struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Spec       struct {
+		Data struct {
+			Hash struct {
+				Algorithm string `json:"algorithm"`
+				Value     string `json:"value"`
+			} `json:"hash"`
+		} `json:"data"`
+		Signature struct {
+			Content   []byte `json:"content"`
+			PublicKey struct {
+				Content []byte `json:"content"`
+			} `json:"publicKey"`
+		} `json:"signature"`
+	} `json:"spec"`
+}
+
+// body builds a base64-encoded entry body.
+func body(t *testing.T, kind, algorithm, hexDigest string, sig, key []byte) string {
+	t.Helper()
+	var b entryBody
+	b.APIVersion = "0.0.1"
+	b.Kind = kind
+	b.Spec.Data.Hash.Algorithm = algorithm
+	b.Spec.Data.Hash.Value = hexDigest
+	b.Spec.Signature.Content = sig
+	b.Spec.Signature.PublicKey.Content = key
+
+	raw, err := json.Marshal(&b)
+	if err != nil {
+		t.Fatalf("marshalling entry body: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(raw)
+}
+
+// ---- bundles ----
+
+// testBundle builds a bundle claiming logIndex over digest, signed by sig.
+func testBundle(logIndex int64, digest, sig, key []byte) *trust.Bundle {
+	b := &trust.Bundle{MediaType: trust.BundleMediaType}
+	b.VerificationMaterial.TlogEntries = []trust.TlogEntry{{
+		LogIndex:    strconv.FormatInt(logIndex, 10),
+		KindVersion: &trust.KindVersion{Kind: "hashedrekord", Version: "0.0.1"},
+	}}
+	b.MessageSignature.MessageDigest.Algorithm = "SHA2_256"
+	b.MessageSignature.MessageDigest.Digest = digest
+	b.MessageSignature.Signature = sig
+	if len(key) > 0 {
+		b.VerificationMaterial.PublicKey = &trust.RawMaterial{RawBytes: key}
+	}
+	return b
+}
+
+func sha256Of(s string) []byte {
+	sum := sha256.Sum256([]byte(s))
+	return sum[:]
+}
+
+// ---- the corpus ----
+
+// TestVerifyEntry_Corpus drives one input per rejection reason plus the honest
+// case. The wantErr column is the whole point: it asserts *which* check fired.
+func TestVerifyEntry_Corpus(t *testing.T) {
+	const idx int64 = 42
+
+	artifact := sha256Of("the artifact this bundle attests")
+	stranger := sha256Of("somebody else's artifact, logged at the same index")
+	sig := []byte("signature-over-the-artifact-digest")
+	otherSig := []byte("a different signature entirely......")
+	key := []byte("public-key-raw-bytes")
+	otherKey := []byte("a different public key")
+
+	hexArtifact := hex.EncodeToString(artifact)
+
+	cases := []struct {
+		name    string
+		bodies  map[int64]string
+		bundle  *trust.Bundle
+		wantErr error // nil means the entry must verify
+		why     string
+	}{
+		{
+			name:    "honest: entry built from the bundle",
+			bodies:  map[int64]string{idx: body(t, "hashedrekord", "sha256", hexArtifact, sig, key)},
+			bundle:  testBundle(idx, artifact, sig, key),
+			wantErr: nil,
+			why:     "digest, signature and key all agree",
+		},
+		{
+			name:    "no bundle supplied",
+			bodies:  map[int64]string{idx: body(t, "hashedrekord", "sha256", hexArtifact, sig, key)},
+			bundle:  nil,
+			wantErr: trust.ErrNoBundle,
+			why:     "an index with no bundle is unverifiable; this is the pre-#59 success path",
+		},
+		{
+			name:    "stranger's entry: valid, findable, different artifact",
+			bodies:  map[int64]string{idx: body(t, "hashedrekord", "sha256", hex.EncodeToString(stranger), sig, key)},
+			bundle:  testBundle(idx, artifact, sig, key),
+			wantErr: trust.ErrDigestMismatch,
+			why:     "the case the old existence check passed: borrowing somebody else's attestation",
+		},
+		{
+			name:    "same artifact, different signature",
+			bodies:  map[int64]string{idx: body(t, "hashedrekord", "sha256", hexArtifact, otherSig, key)},
+			bundle:  testBundle(idx, artifact, sig, key),
+			wantErr: trust.ErrSignatureMismatch,
+			why:     "digest agreement alone does not tie the entry to this signature",
+		},
+		{
+			name:    "same artifact and signature, different key",
+			bodies:  map[int64]string{idx: body(t, "hashedrekord", "sha256", hexArtifact, sig, otherKey)},
+			bundle:  testBundle(idx, artifact, sig, key),
+			wantErr: trust.ErrPublicKeyMismatch,
+			why:     "key material is compared when both sides carry raw bytes",
+		},
+		{
+			name:    "bundle names a different log index",
+			bodies:  map[int64]string{idx: body(t, "hashedrekord", "sha256", hexArtifact, sig, key)},
+			bundle:  testBundle(idx+1, artifact, sig, key),
+			wantErr: trust.ErrLogIndexMismatch,
+			why:     "a bundle about another entry is not evidence about this one",
+		},
+		{
+			name:    "no entry at the index",
+			bodies:  map[int64]string{},
+			bundle:  testBundle(idx, artifact, sig, key),
+			wantErr: trust.ErrEntryNotFound,
+			why:     "absence must not read as agreement",
+		},
+		{
+			name:    "entry is not a hashedrekord",
+			bodies:  map[int64]string{idx: body(t, "intoto", "sha256", hexArtifact, sig, key)},
+			bundle:  testBundle(idx, artifact, sig, key),
+			wantErr: trust.ErrUnsupportedEntryKind,
+			why:     "an entry this client cannot compare must not pass as compared",
+		},
+		{
+			name:    "entry body is not base64",
+			bodies:  map[int64]string{idx: "!!!not base64!!!"},
+			bundle:  testBundle(idx, artifact, sig, key),
+			wantErr: trust.ErrMalformedEntry,
+			why:     "an undecodable body is not a verified body",
+		},
+		{
+			name:    "entry body is base64 of non-JSON",
+			bodies:  map[int64]string{idx: base64.StdEncoding.EncodeToString([]byte("not json"))},
+			bundle:  testBundle(idx, artifact, sig, key),
+			wantErr: trust.ErrMalformedEntry,
+			why:     "same, one layer in",
+		},
+		{
+			name:    "empty bundle digest and signature against an empty entry",
+			bodies:  map[int64]string{idx: body(t, "hashedrekord", "sha256", "", nil, nil)},
+			bundle:  testBundle(idx, nil, nil, nil),
+			wantErr: trust.ErrIncompleteBundle,
+			why:     "empty == empty would otherwise verify, which is how this class of defect is written",
+		},
+		{
+			name:    "entry names a non-SHA256 algorithm",
+			bodies:  map[int64]string{idx: body(t, "hashedrekord", "sha512", hexArtifact, sig, key)},
+			bundle:  testBundle(idx, artifact, sig, key),
+			wantErr: trust.ErrDigestAlgorithm,
+			why:     "a digest comparison across algorithms is not a comparison",
+		},
+		{
+			name:    "hint-only bundle: key comparison is documented as skipped",
+			bodies:  map[int64]string{idx: body(t, "hashedrekord", "sha256", hexArtifact, sig, otherKey)},
+			bundle:  hintOnlyBundle(idx, artifact, sig),
+			wantErr: nil,
+			why:     "documented limit, asserted rather than left implicit: digest and signature still tie the entry to the artifact",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := rekorStub(t, tc.bodies)
+			err := c.VerifyEntry(context.Background(), idx, tc.bundle)
+
+			switch {
+			case tc.wantErr == nil && err != nil:
+				t.Fatalf("VerifyEntry() = %v, want nil (%s)", err, tc.why)
+			case tc.wantErr == nil:
+				t.Logf("verified: %s", tc.why)
+			case err == nil:
+				t.Fatalf("VerifyEntry() = nil, want %v (%s)", tc.wantErr, tc.why)
+			case !errors.Is(err, tc.wantErr):
+				// The point of the sentinels: a rejection for the wrong reason
+				// is a failure, not a pass.
+				t.Fatalf("VerifyEntry() rejected for the wrong reason:\n  got:  %v\n  want: %v\n  (%s)",
+					err, tc.wantErr, tc.why)
+			default:
+				t.Logf("rejected as %v — %s", tc.wantErr, tc.why)
+			}
+		})
+	}
+}
+
+// hintOnlyBundle is a cosign v3 key-based bundle that carries a key hint rather
+// than raw key bytes, so there is nothing for the key comparison to compare.
+func hintOnlyBundle(logIndex int64, digest, sig []byte) *trust.Bundle {
+	b := testBundle(logIndex, digest, sig, nil)
+	b.VerificationMaterial.PublicKey = &trust.RawMaterial{Hint: "aGludA=="}
+	return b
+}
+
+// TestVerifyEntry_DiscardsNothing is the mechanical form of the issue's closing
+// condition: the bundle parameter must be able to change the outcome. Two calls
+// differing only in the bundle must not both succeed.
+func TestVerifyEntry_DiscardsNothing(t *testing.T) {
+	const idx int64 = 7
+	mine := sha256Of("mine")
+	theirs := sha256Of("theirs")
+	sig := []byte("sig")
+
+	c := rekorStub(t, map[int64]string{
+		idx: body(t, "hashedrekord", "sha256", hex.EncodeToString(mine), sig, nil),
+	})
+
+	if err := c.VerifyEntry(context.Background(), idx, testBundle(idx, mine, sig, nil)); err != nil {
+		t.Fatalf("matching bundle: VerifyEntry() = %v, want nil", err)
+	}
+	err := c.VerifyEntry(context.Background(), idx, testBundle(idx, theirs, sig, nil))
+	if err == nil {
+		t.Fatal("unrelated bundle verified against the same log entry: the bundle is still being discarded")
+	}
+	if !errors.Is(err, trust.ErrDigestMismatch) {
+		t.Fatalf("unrelated bundle rejected for the wrong reason: %v", err)
+	}
+}
+
+// ---- the repo's own fixture, consumed by a real verifier for the first time ----
+
+// TestVerifyEntry_RejectsRepoFixture drives internal/testregistry's committed
+// bundles through VerifyEntry.
+//
+// The fixture was built for this issue and its package doc predicts the step each
+// bundle fails at. Nothing had ever run a real verifier over it, so the
+// prediction was unmeasured. The two bundle kinds fail for *different* documented
+// reasons and the test asserts each separately:
+//
+//   - layer bundles carry the real SHA-256 of layer.sqfs, "so a digest comparison
+//     passes and the signature check is what fails";
+//   - the formation bundle carries a zero digest, so it fails one step earlier.
+//
+// The stub serves, at the fixture's own log index, an entry that is honest about
+// the artifact — which is the strongest form of the historical hazard: the
+// fixture's first version carried plausible indices that really did resolve in
+// the public log, to real entries for other people's artifacts.
+func TestVerifyEntry_RejectsRepoFixture(t *testing.T) {
+	root, err := testregistry.Materialize(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("materializing fixture registry: %v", err)
+	}
+
+	idx, err := strconv.ParseInt(testregistry.SentinelRekorEntry, 10, 64)
+	if err != nil {
+		t.Fatalf("SentinelRekorEntry is not an int64: %v", err)
+	}
+
+	layers, formations := findFixtureBundles(t, root)
+	if len(layers) == 0 || len(formations) == 0 {
+		t.Fatalf("fixture bundles not found: %d layer, %d formation", len(layers), len(formations))
+	}
+
+	for _, path := range layers {
+		t.Run("layer/"+filepath.Base(filepath.Dir(path)), func(t *testing.T) {
+			bundle := parseBundleFile(t, path)
+
+			// Measured, not assumed: the doc claim is that the digest is the real
+			// SHA-256 of the sibling layer.sqfs. Without this, "the digest step
+			// passes" below would be true only because the stub entry was built
+			// from the bundle's own digest — a tautology dressed as a measurement.
+			artifact, err := os.ReadFile(filepath.Join(filepath.Dir(path), "layer.sqfs"))
+			if err != nil {
+				t.Fatalf("reading the artifact this bundle attests: %v", err)
+			}
+			realSum := sha256.Sum256(artifact)
+			if !bytes.Equal(realSum[:], bundle.MessageSignature.MessageDigest.Digest) {
+				t.Fatalf("fixture bundle digest is not the digest of layer.sqfs:\n  bundle: %x\n  file:   %x\n"+
+					"internal/testregistry's package doc claims it is, and the signature-step "+
+					"assertion below depends on it", bundle.MessageSignature.MessageDigest.Digest, realSum[:])
+			}
+
+			// An entry that agrees with the fixture about the artifact — that same
+			// real digest — and carries a plausible signature over it. Everything a
+			// presence check can see is in order.
+			digest := hex.EncodeToString(bundle.MessageSignature.MessageDigest.Digest)
+			c := rekorStub(t, map[int64]string{
+				idx: body(t, "hashedrekord", "sha256", digest, sha256Of("a real signature, not the fixture's"), nil),
+			})
+
+			err = c.VerifyEntry(context.Background(), idx, bundle)
+			if err == nil {
+				t.Fatal("fixture layer bundle verified against a transparency-log entry: " +
+					"a fixture that can pass real verification can launder a stranger's attestation")
+			}
+			if !errors.Is(err, trust.ErrSignatureMismatch) {
+				t.Fatalf("fixture layer bundle rejected, but not at the step its package doc claims:\n"+
+					"  got:  %v\n  want: %v", err, trust.ErrSignatureMismatch)
+			}
+			t.Logf("rejected at the signature step, as internal/testregistry's package doc predicts: %v", err)
+		})
+	}
+
+	for _, path := range formations {
+		t.Run("formation/"+filepath.Base(filepath.Dir(path)), func(t *testing.T) {
+			bundle := parseBundleFile(t, path)
+
+			c := rekorStub(t, map[int64]string{
+				idx: body(t, "hashedrekord", "sha256", hex.EncodeToString(sha256Of("some real artifact")),
+					sha256Of("a real signature"), nil),
+			})
+
+			err := c.VerifyEntry(context.Background(), idx, bundle)
+			if err == nil {
+				t.Fatal("fixture formation bundle verified against a transparency-log entry")
+			}
+			// The formation bundle's messageDigest is 32 zero bytes, not the
+			// digest of anything, so the digest comparison is what rejects it.
+			if !errors.Is(err, trust.ErrDigestMismatch) {
+				t.Fatalf("fixture formation bundle rejected for an unexpected reason:\n  got:  %v\n  want: %v",
+					err, trust.ErrDigestMismatch)
+			}
+			t.Logf("rejected at the digest step: %v", err)
+		})
+	}
+}
+
+// TestVerifyEntry_FixtureIndexIsUnfindable pins the other half of the fixture's
+// design: its log index cannot name a real entry, so against a log that does not
+// hold it the rejection is ErrEntryNotFound and never a pass.
+func TestVerifyEntry_FixtureIndexIsUnfindable(t *testing.T) {
+	root, err := testregistry.Materialize(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("materializing fixture registry: %v", err)
+	}
+	layers, _ := findFixtureBundles(t, root)
+	bundle := parseBundleFile(t, layers[0])
+
+	idx, err := strconv.ParseInt(testregistry.SentinelRekorEntry, 10, 64)
+	if err != nil {
+		t.Fatalf("SentinelRekorEntry is not an int64: %v", err)
+	}
+
+	// An empty log: every index is absent.
+	c := rekorStub(t, map[int64]string{})
+	err = c.VerifyEntry(context.Background(), idx, bundle)
+	if !errors.Is(err, trust.ErrEntryNotFound) {
+		t.Fatalf("VerifyEntry() = %v, want %v", err, trust.ErrEntryNotFound)
+	}
+}
+
+// findFixtureBundles returns the layer and formation bundle paths under a
+// materialized fixture registry, discovered rather than hardcoded so that a
+// fixture gaining a layer is covered without editing this test.
+func findFixtureBundles(t *testing.T, root string) (layers, formations []string) {
+	t.Helper()
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || d.Name() != "bundle.json" {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, p)
+		if relErr != nil {
+			return relErr
+		}
+		switch {
+		case strings.HasPrefix(rel, "layers"+string(filepath.Separator)):
+			layers = append(layers, p)
+		case strings.HasPrefix(rel, "formations"+string(filepath.Separator)):
+			formations = append(formations, p)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking fixture registry: %v", err)
+	}
+	return layers, formations
+}
+
+func parseBundleFile(t *testing.T, path string) *trust.Bundle {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	b, err := trust.ParseBundle(data)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+	return b
+}

--- a/internal/trust/trust.go
+++ b/internal/trust/trust.go
@@ -198,7 +198,12 @@ type RekorClient interface {
 	// log index. The returned index is stored in LayerManifest.RekorEntry.
 	Log(ctx context.Context, bundle *Bundle) (logIndex int64, err error)
 
-	// VerifyEntry confirms that a bundle is present and unmodified in the
-	// Rekor log at logIndex. Returns nil iff the entry is valid.
+	// VerifyEntry confirms that the entry in the Rekor log at logIndex attests
+	// bundle — the same artifact digest and the same signature, not merely that
+	// an entry exists there. Returns nil iff the entry matches the bundle.
+	//
+	// bundle is required. An implementation given none cannot distinguish this
+	// artifact's entry from a stranger's and must report that rather than return
+	// success; RekorHTTPClient returns ErrNoBundle.
 	VerifyEntry(ctx context.Context, logIndex int64, bundle *Bundle) error
 }


### PR DESCRIPTION
Closes #59

## The defect

`RekorHTTPClient.VerifyEntry` took a bundle and threw it away:

```go
_ = bundle   // internal/trust/cosign.go:260 on main (2b97a5d)
```

It fetched the entry at `logIndex`, found *an* entry, and returned nil. That is a
presence check wearing a verifier's name. Its failure mode is not "misses some
bad bundles" — it is that a real, valid, correctly-signed Rekor entry belonging to
**somebody else's artifact** passed, as long as the index resolved.

## The fix

`VerifyEntry` now decodes the `hashedrekord` body and compares it to the bundle:
artifact digest (hex on the Rekor side, raw bytes on the bundle side — `Log`
already bridges this with `%x`), signature, and key material where both sides
carry raw bytes. A nil bundle is `ErrNoBundle`, not success.

**One exported sentinel per rejection reason** — ten of them. This is the part
that makes the tests mean anything: a rejection that fires from a different check
than the one under test looks identical in the output, so `errors.Is` against a
specific sentinel is the only way to assert that the check being exercised is the
check that fired.

What it still does **not** do, stated so it is not mistaken for more: no inclusion-promise
check, no cryptographic signature verification. A bundle whose signature is invalid
but consistently recorded in the log passes this function. Tying the entry to the
bundle is its job; `CosignVerifier.Verify` does the cryptography.

## The gate answered before any code was written

**Does the `Offline resolve (no AWS)` CI job configure a Rekor client at all? No —
and it cannot.** Stage 7 only calls `VerifyEntry` inside `if r.cfg.Rekor != nil`,
and no shipped path sets that field (all four `resolver.Config{}` constructions
leave it nil). Nothing in CI executed the function under repair; `RekorHTTPClient`
had **0.0% coverage on `VerifyEntry`**, measured in a clean worktree of `main`.

So "make CI reach the code" was part of this issue, and it is the **Test** job's
part: a hermetic `httptest` Rekor stub. Wiring the offline-resolve job to reach it
is not in scope and would be dishonest to attempt — stage 7 has no bundle bytes to
verify against, which is filed as #85.

## The corpus

An empty before/after diff over honest material is *expected* here — a verifier
that verifies nothing and one that verifies correctly both succeed on honest
input. So the corpus is built from material a correct implementation must reject,
and each row asserts *which* check refused:

| Input | Sentinel asserted |
| --- | --- |
| entry built from the bundle | *(verifies)* |
| no bundle supplied | `ErrNoBundle` |
| valid findable entry, **different artifact** | `ErrDigestMismatch` |
| same artifact, different signature | `ErrSignatureMismatch` |
| same artifact and signature, different key | `ErrPublicKeyMismatch` |
| bundle names a different log index | `ErrLogIndexMismatch` |
| no entry at the index | `ErrEntryNotFound` |
| entry is not a `hashedrekord` | `ErrUnsupportedEntryKind` |
| body not base64 / base64 of non-JSON | `ErrMalformedEntry` (×2) |
| empty bundle digest+signature vs empty entry | `ErrIncompleteBundle` |
| entry names a non-SHA256 algorithm | `ErrDigestAlgorithm` |
| hint-only bundle, mismatched entry key | *(verifies — documented limit, asserted)* |

13 rows, 2 expecting success, 11 expecting a named sentinel, covering all 10
exported sentinels (`ErrMalformedEntry` twice). Counted with
`grep -c '^\t\t\tname: '`, `grep -c 'wantErr: nil'`, `grep -c 'wantErr: trust\.'`,
`grep -o 'trust\.Err[A-Za-z]*' | sort -u`.

### Plus the repo's own fixture, run through a real verifier for the first time

`internal/testregistry`'s bundles were built for this issue and its package doc
predicts the step each kind fails at. Nothing had ever measured that. Both
predictions now hold, and they are **different steps**:

- **layer** bundles → `ErrSignatureMismatch`. Their `messageDigest` really is the
  SHA-256 of the sibling `layer.sqfs`, so the digest comparison passes and the
  ASCII sentinel signature is what fails. The test hashes `layer.sqfs` itself and
  asserts the match, because otherwise "the digest step passes" would be a
  tautology of the stub having been built from the bundle's own digest.
- the **formation** bundle → `ErrDigestMismatch`, one step earlier: its digest is
  32 zero bytes.
- the fixture's log index against a log that does not hold it →
  `ErrEntryNotFound`.

The fixture needed **no change**. The warning about arguing before loosening a
check never had to fire.

## Call site

`verifyRekorEntries` now takes a `trust.RekorClient` instead of constructing one
internally — the property that made the discarded bundle unobservable — and loads
each layer's bundle from a local path or `file://` URI. A bundle still held as an
`s3://` URI is a **reported failure naming the layer**, not a skipped check: the
alternative is a `--rekor` that reports success for every layer in a realistic
lockfile while verifying none of them. Fetching remote bundles is #60.

Asserted through a recording client: the bundle arrives and it is *this layer's*;
`VerifyEntry` is never called when there is no bundle to pass; the sentinel
survives into the user-facing failure list.

## Measurements

Provenance: tree `/Users/scttfrdmn/src/strata-recon/strata`, branch
`fix/59-rekor-verifyentry`, three commits on `main` @ `2b97a5d`.

```
$ go test -race -coverprofile=coverage.out -covermode=atomic ./...   # the Test job's command
ok  github.com/scttfrdmn/strata/internal/trust   3.004s  coverage: 51.6% of statements
(all 20 packages ok)
$ gofmt -l . && go vet ./...        # clean
$ golangci-lint run ./...           # 0 issues, local 2.13.0
```

`internal/trust`, before half measured inside a clean `git worktree` of `main` so
the profile resolves against its own sources:

| | before (`2b97a5d`) | after |
| --- | --- | --- |
| `RekorHTTPClient.VerifyEntry` | **0.0%** | 84.2% |
| `matchEntryBody` | *(did not exist)* | 95.7% |
| package | 34.9% | 51.6% |

I first ran `go tool cover -func` on the before-profile from the *post-fix* tree
and it reported 38.5% with `VerifyEntry` at a line number that only exists after
the change — the tool resolves a profile against whatever sources are in the
current module. The numbers above are the re-measurement.

Local linter is **2.13.0**; CI pins **v2.11.3** (`ci.yml:90`). Neither is evidence
for the other — that gap is #75.

## Not in this PR

Filed with evidence, unmilestoned, left alone:

- **#85** — stage 7 cannot Rekor-verify because it holds a bundle URI, not bundle
  bytes. It now fails closed with `ErrNoBundle` where it used to pass; the branch
  is unreachable today because `cfg.Rekor` is always nil. Which way to take it is
  a decision, not a cleanup.
- **#86** — `TestStage7_RekorVerification` claims in its comment that "a failing
  client causes REKOR_VERIFICATION_FAILED" and never constructs a failing client.
  Correcting it means editing an inherited test file, which this session's
  constraints forbid.

No inherited `*_test.go` file is modified; `git diff --name-only main...HEAD -- '*_test.go'`
lists only the two new files.

## What the issue arguably covers and this does not

- `--rekor` against a real s3-backed lockfile still cannot verify anything, because
  no bundle is fetchable. It now says so per layer instead of passing. That is #60.
- The stub's entry-body shape is inferred from this repository's own `Log` method,
  not from a live Rekor response read this session. If Rekor's canonicalized
  `hashedrekord` encoding differs, the test is self-consistent and wrong about
  Rekor. Stated as an assumption, in the test file's header comment too.