### PR TITLE
fix(run): verify every layer before mounting it (#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **`strata run` verifies every layer before mounting it, and `--no-verify` now
+  disables something** (#55). `strata run` accepted a `--no-verify` flag and
+  never verified a signature in either state: the flag's only effect was to
+  suppress one warning, which fired on an empty `rekor_entry` *field in the
+  lockfile*. A field is not evidence about a file, and the two paths — with and
+  without the flag — mounted identical content. Layers are now verified after
+  they are on disk and before anything is mounted, because the bytes about to be
+  mounted are what has to be verified.
+
+  Each layer must now clear four checks that need no network and no cosign — its
+  bundle must be readable (an unfetched `s3://` bundle URI is a failure, not a
+  skip), parse, carry a Rekor entry, and **attest the digest the lockfile pins**
+  — and then its signature must verify with cosign against a new `--key`. All
+  failures are reported together, each naming its layer and reason, and the mount
+  is refused.
+
+  The digest-match check is not one `trust.VerifyLayer` performs, and it is here
+  deliberately: cosign ties bundle to artifact itself, so `VerifyLayer` can omit
+  it, but on a machine without cosign that omission would make "a valid bundle
+  for somebody else's layer" indistinguishable from "verified". `--no-verify`
+  still mounts unverified content, and now says so on stderr — a silent skip is
+  indistinguishable from a check that ran and passed, which is the condition this
+  issue was filed about.
+
+  **What changes per consumer**, resolved from
+  `grep -rn 'no-verify' --include='*.go' --include='*.md' . `:
+  - **`strata run` without `--key` and without `--no-verify` now fails where it
+    previously mounted.** This is a breaking change for every existing
+    invocation, and it is the point of the fix: the previous behaviour was an
+    unverified mount reported as a normal one. The refusal names the missing
+    prerequisite and the flag that overrides it. Passing `--key <cosign.pub>`
+    verifies; passing `--no-verify` mounts unverified, loudly.
+  - `strata capture` (`capture.go:133`) and `strata stratify`
+    (`stratify.go:160`) — output unchanged, but their existing advice ("use
+    `strata run --no-verify` to use unsigned layers") stops being decorative and
+    becomes required. Before this fix an unsigned captured layer mounted without
+    the flag.
+  - `docs/userspace.md:63` — the documented `--no-verify` example is unchanged
+    and still correct.
+  - `strata verify --rekor` — no behaviour change. It shares `loadLocalBundle`
+    with this path; two of that helper's messages were reworded to stop naming
+    `--rekor`, which would have been false in `strata run`'s output. The function
+    still neither fetches nor mutates, and still returns every failure rather
+    than logging it.
+  - `strata export`, `strata fold`, `strata build`, `strata publish`,
+    `strata resolve`, `strata freeze` and `strata-agent` are **unchanged**: none
+    of them mounts layers through `strata run`'s path. The agent's own
+    verification fail-open is a separate defect (#56).
 - **Rekor entry verification compares the entry to the bundle** (#59).
   `RekorHTTPClient.VerifyEntry` took a bundle, discarded it (`_ = bundle`), and
   returned success for any log index the server could find an entry at. That is a

--- a/cmd/strata/run.go
+++ b/cmd/strata/run.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -18,11 +19,12 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/scttfrdmn/strata/internal/overlay"
+	"github.com/scttfrdmn/strata/internal/trust"
 	"github.com/scttfrdmn/strata/spec"
 )
 
 func newRunCmd() *cobra.Command {
-	var lockfilePath, cacheDir string
+	var lockfilePath, cacheDir, keyRef string
 	var noVerify bool
 	var envOverrides []string
 
@@ -34,8 +36,16 @@ resulting environment. Works for both privileged (OverlayFS) and
 unprivileged (FUSE) contexts.
 
 Layer files are cached in the user cache directory and reused on
-subsequent runs. Pass --no-verify to skip signature verification
-on air-gapped systems.`,
+subsequent runs.
+
+Every layer is verified before anything is mounted: its bundle must be
+readable, parse, carry a Rekor entry, and attest the digest the lockfile
+pins, and its signature must verify with cosign against --key. A layer
+that fails any of those is not mounted.
+
+Pass --no-verify to mount unverified layers on air-gapped systems. It
+reports, on stderr, that verification was skipped — before this was a
+flag that disabled nothing, because nothing was enabled.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if lockfilePath == "" {
@@ -47,18 +57,19 @@ on air-gapped systems.`,
 			if cacheDir == "" {
 				cacheDir = defaultCacheDir()
 			}
-			return runRun(cmd.Context(), lockfilePath, args, noVerify, cacheDir, envOverrides)
+			return runRun(cmd.Context(), lockfilePath, args, noVerify, cacheDir, keyRef, envOverrides)
 		},
 	}
 
 	cmd.Flags().StringVar(&lockfilePath, "lockfile", "", "path to the lockfile (required)")
-	cmd.Flags().BoolVar(&noVerify, "no-verify", false, "skip signature verification (use on air-gapped systems)")
+	cmd.Flags().BoolVar(&noVerify, "no-verify", false, "mount layers without verifying their signatures (use on air-gapped systems)")
+	cmd.Flags().StringVar(&keyRef, "key", "", "cosign public key for layer signature verification (required unless --no-verify)")
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "", "layer cache directory (default: ~/.cache/strata/layers)")
 	cmd.Flags().StringArrayVar(&envOverrides, "env", nil, "additional environment variables (KEY=VAL)")
 	return cmd
 }
 
-func runRun(ctx context.Context, lockfilePath string, args []string, noVerify bool, cacheDir string, envOverrides []string) error {
+func runRun(ctx context.Context, lockfilePath string, args []string, noVerify bool, cacheDir, keyRef string, envOverrides []string) error {
 	// 1. Read lockfile.
 	data, err := os.ReadFile(lockfilePath)
 	if err != nil {
@@ -69,10 +80,13 @@ func runRun(ctx context.Context, lockfilePath string, args []string, noVerify bo
 		return fmt.Errorf("run: parsing lockfile: %w", err)
 	}
 
-	// 2. Signature verification — best-effort warning (not fatal) since strata
-	//    run is primarily for unprivileged/HPC use where cosign may be absent.
-	if !noVerify && lf.RekorEntry == "" {
-		fmt.Fprintln(os.Stderr, "run: warning: lockfile has no Rekor entry — not signed")
+	// 2. Signature verification happens in step 6, after the layers are on disk:
+	//    the bytes about to be mounted are what has to be verified, and a
+	//    lockfile field is not evidence about a file. This used to be a warning
+	//    here that fired only on an empty RekorEntry, which is what made
+	//    --no-verify a flag that disabled nothing (#55).
+	if lf.RekorEntry == "" {
+		fmt.Fprintln(os.Stderr, "run: warning: lockfile has no Rekor entry — not signed") //nolint:errcheck
 	}
 
 	// 3. Warn if the lockfile has package entries — packages are installed by
@@ -102,14 +116,19 @@ func runRun(ctx context.Context, lockfilePath string, args []string, noVerify bo
 		return fmt.Errorf("run: %w", err)
 	}
 
-	// 6. Create temp working directory.
+	// 6. Verify what is about to be mounted, and refuse to mount it otherwise.
+	if err := verifyRunLayers(ctx, &lf, layerPaths, noVerify, keyRef); err != nil {
+		return err
+	}
+
+	// 7. Create temp working directory.
 	workDir, err := os.MkdirTemp("", fmt.Sprintf("strata-%d-*", os.Getpid()))
 	if err != nil {
 		return fmt.Errorf("run: creating work dir: %w", err)
 	}
 	defer os.RemoveAll(workDir) //nolint:errcheck
 
-	// 7. Mount overlay with user-local paths and auto-detected strategy.
+	// 8. Mount overlay with user-local paths and auto-detected strategy.
 	cfg := overlay.Config{
 		LayersDir: filepath.Join(workDir, "layers"),
 		RWDir:     filepath.Join(workDir, "rw"),
@@ -125,10 +144,10 @@ func runRun(ctx context.Context, lockfilePath string, args []string, noVerify bo
 	defer stop()
 	defer ov.Cleanup() //nolint:errcheck
 
-	// 8. Build environment for the child process.
+	// 9. Build environment for the child process.
 	env := buildRunEnv(&lf, ov.MergedPath, envOverrides)
 
-	// 9. Execute the command.
+	// 10. Execute the command.
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 	cmd.Env = env
 	cmd.Stdin = os.Stdin
@@ -142,6 +161,170 @@ func runRun(ctx context.Context, lockfilePath string, args []string, noVerify bo
 		return fmt.Errorf("run: %w", err)
 	}
 	return nil
+}
+
+// runLayerCheck is one layer that passed every check not needing cosign, held
+// with its parsed bundle so the signature step does not re-read or re-parse it.
+type runLayerCheck struct {
+	layerID string
+	sqfs    string
+	bundle  *trust.Bundle
+}
+
+// verifyRunLayers refuses to let runRun proceed unless every layer about to be
+// mounted verifies. It reports all failures rather than the first, because a
+// user fixing a lockfile wants the whole list.
+//
+// noVerify skips the whole step and says so on stderr. That announcement is
+// load-bearing: the defect this replaces (#55) was a --no-verify flag that
+// disabled nothing, and a silent skip is indistinguishable from a check that
+// ran and passed.
+func verifyRunLayers(ctx context.Context, lf *spec.LockFile, paths []overlay.LayerPath, noVerify bool, keyRef string) error {
+	if noVerify {
+		fmt.Fprintln(os.Stderr, //nolint:errcheck
+			"run: warning: --no-verify given: layer signatures were NOT verified; mounting unverified content")
+		return nil
+	}
+
+	failures, checks := collectRunBundleFailures(lf, paths)
+
+	// The signature step runs only when every structural check passed, matching
+	// strata verify's shape (verify.go: presence failures gate the Rekor step).
+	// Ordering matters for more than tidiness: the structural checks need no
+	// cosign, so they stay reachable — and testable — on a machine that has
+	// none, while a missing cosign would otherwise mask every bundle defect
+	// behind one prerequisite error.
+	if len(failures) == 0 {
+		v, err := newRunVerifier(keyRef)
+		if err != nil {
+			failures = append(failures, err.Error())
+		} else {
+			failures = append(failures, verifyRunSignatures(ctx, checks, v)...)
+		}
+	}
+
+	if len(failures) == 0 {
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "run: %d verification failure(s):\n", len(failures)) //nolint:errcheck
+	for _, f := range failures {
+		fmt.Fprintf(os.Stderr, "  - %s\n", f) //nolint:errcheck
+	}
+	return errors.New("run: refusing to mount unverified layers (pass --no-verify to mount them anyway)")
+}
+
+// collectRunBundleFailures performs every per-layer check that does not need
+// cosign, and returns the layers that still need a signature check.
+//
+// This discharges trust.VerifyLayer's steps in a different order rather than
+// calling it, so each of that function's guarantees is accounted for here
+// explicitly:
+//
+//   - step 1, file digest vs manifest: already done, unconditionally, by
+//     fetchLayersToCache — which will not return a path it has not hashed
+//     against a well-formed digest (#57). Re-hashing here would hash the same
+//     squashfs a third time for no new information.
+//   - step 2, bundle non-empty / not a bare URI / readable / parses: done here
+//     via loadLocalBundle, the same helper strata verify --rekor uses.
+//   - step 2, HasRekorEntry: done here.
+//   - step 3, cosign signature: done by verifyRunSignatures.
+//
+// One check here is *not* in trust.VerifyLayer: the bundle must attest the
+// digest this lockfile pins. VerifyLayer can omit it because cosign verify-blob
+// ties bundle to artifact itself; this path cannot, because a missing cosign
+// must not be the difference between "wrong layer's bundle" and "accepted".
+// Without it, a valid bundle for a different artifact passes every local check.
+func collectRunBundleFailures(lf *spec.LockFile, paths []overlay.LayerPath) ([]string, []runLayerCheck) {
+	pathByID := make(map[string]string, len(paths))
+	for _, p := range paths {
+		pathByID[p.ID] = p.Path
+	}
+
+	var (
+		failures []string
+		checks   []runLayerCheck
+	)
+	for _, layer := range lf.Layers {
+		sqfs, ok := pathByID[layer.ID]
+		if !ok {
+			failures = append(failures, fmt.Sprintf(
+				"layer %s: no fetched file to verify", layer.ID))
+			continue
+		}
+
+		bundle, err := loadLocalBundle(layer.Bundle)
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("layer %s: %v", layer.ID, err))
+			continue
+		}
+		if !bundle.HasRekorEntry() {
+			failures = append(failures, fmt.Sprintf(
+				"layer %s: bundle has no Rekor entry: unsigned layers will not mount", layer.ID))
+			continue
+		}
+		if alg := bundle.MessageSignature.MessageDigest.Algorithm; alg != "" && !isBundleSHA256(alg) {
+			failures = append(failures, fmt.Sprintf(
+				"layer %s: bundle digest algorithm is %q, not SHA-256", layer.ID, alg))
+			continue
+		}
+		attested := hex.EncodeToString(bundle.MessageSignature.MessageDigest.Digest)
+		if !strings.EqualFold(attested, layer.SHA256) {
+			failures = append(failures, fmt.Sprintf(
+				"layer %s: bundle attests sha256:%s but the lockfile pins sha256:%s",
+				layer.ID, attested, layer.SHA256))
+			continue
+		}
+
+		checks = append(checks, runLayerCheck{layerID: layer.ID, sqfs: sqfs, bundle: bundle})
+	}
+	return failures, checks
+}
+
+// isBundleSHA256 reports whether a Sigstore digest algorithm name means SHA-256.
+// Bundles write "SHA2_256"; be lenient about the spellings seen in the wild
+// rather than rejecting a correct bundle over punctuation.
+func isBundleSHA256(alg string) bool {
+	switch strings.ToUpper(strings.NewReplacer("-", "", "_", "").Replace(alg)) {
+	case "SHA2256", "SHA256":
+		return true
+	}
+	return false
+}
+
+// verifyRunSignatures checks each layer's signature with v.
+//
+// v is a parameter so a test can drive the pass and fail directions without
+// cosign on PATH; runRun supplies a real CosignVerifier. There is deliberately
+// no nil-means-skip case — that shape is the defect filed as #56.
+func verifyRunSignatures(ctx context.Context, checks []runLayerCheck, v trust.Verifier) []string {
+	var failures []string
+	for _, c := range checks {
+		if err := v.Verify(ctx, c.sqfs, c.bundle); err != nil {
+			failures = append(failures, fmt.Sprintf(
+				"layer %s: signature verification failed: %v", c.layerID, err))
+		}
+	}
+	return failures
+}
+
+// newRunVerifier builds the cosign verifier for strata run.
+//
+// Both prerequisites are errors rather than a nil verifier: strata run is used
+// where cosign is often absent, which is exactly the case that must not
+// silently downgrade to mounting unverified content. The message names the flag
+// that makes the trade-off explicit instead of making it by default.
+func newRunVerifier(keyRef string) (trust.Verifier, error) {
+	if keyRef == "" {
+		return nil, errors.New("no --key given: layer signatures cannot be verified without a cosign public key (pass --key, or --no-verify to mount unverified layers)")
+	}
+	if _, err := os.Stat(keyRef); err != nil {
+		return nil, fmt.Errorf("--key %q is not readable: layer signatures cannot be verified (fix the path, or pass --no-verify to mount unverified layers): %w", keyRef, err)
+	}
+	if _, err := exec.LookPath("cosign"); err != nil {
+		return nil, fmt.Errorf("cosign not found on PATH: layer signatures cannot be verified (install cosign, or pass --no-verify to mount unverified layers): %w", err)
+	}
+	return &trust.CosignVerifier{KeyRef: keyRef}, nil
 }
 
 // buildRunEnv builds the environment for the child process from os.Environ()

--- a/cmd/strata/run_verify_test.go
+++ b/cmd/strata/run_verify_test.go
@@ -1,0 +1,539 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/scttfrdmn/strata/internal/overlay"
+	"github.com/scttfrdmn/strata/internal/trust"
+	"github.com/scttfrdmn/strata/spec"
+)
+
+// Tests for strata run's pre-mount layer verification (#55).
+//
+// The defect: --no-verify disabled nothing, because nothing was enabled. So the
+// obligation on these tests is not "the happy path still works" — it is that
+// material a correct implementation must reject is actually rejected, and
+// rejected for the reason under test rather than incidentally. Every negative
+// case below therefore asserts exactly one failure and the text of it; a row
+// that failed for an earlier check would report the wrong reason and fail here.
+
+// writeBundleFile writes a bundle to a temp file and returns a file:// URI for
+// it, which is what a fetched lockfile carries.
+func writeBundleFile(t *testing.T, b *trust.Bundle) string {
+	t.Helper()
+	data, err := b.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal bundle: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "bundle.json")
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+	return "file://" + path
+}
+
+// bundleAttesting builds a well-formed bundle that attests digest and carries
+// sig as its signature. digest and sig are supplied by the caller so no test
+// derives its expectation from the code under test.
+func bundleAttesting(digest, sig []byte) *trust.Bundle {
+	return &trust.Bundle{
+		MediaType: trust.BundleMediaType,
+		VerificationMaterial: trust.VerificationMaterial{
+			PublicKey:   &trust.RawMaterial{Hint: "test-key"},
+			TlogEntries: []trust.TlogEntry{{LogIndex: "1234", IntegratedTime: "1700000000"}},
+		},
+		MessageSignature: trust.MessageSignature{
+			MessageDigest: trust.MessageDigest{Algorithm: "SHA2_256", Digest: digest},
+			Signature:     sig,
+		},
+	}
+}
+
+// squashfsStub writes a stand-in for a layer file and returns its path and the
+// hex SHA256 of its contents, hashed here rather than by anything under test.
+func squashfsStub(t *testing.T, contents string) (path, hexDigest string) {
+	t.Helper()
+	path = filepath.Join(t.TempDir(), "layer.sqfs")
+	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+		t.Fatalf("write layer stub: %v", err)
+	}
+	sum := sha256.Sum256([]byte(contents))
+	return path, hex.EncodeToString(sum[:])
+}
+
+func layerWith(id, sha256hex, bundleURI string) spec.ResolvedLayer {
+	return spec.ResolvedLayer{
+		LayerManifest: spec.LayerManifest{
+			ID:         id,
+			Name:       id,
+			Version:    "1.0.0",
+			SHA256:     sha256hex,
+			Bundle:     bundleURI,
+			RekorEntry: "1234",
+		},
+		MountOrder: 1,
+	}
+}
+
+// TestCollectRunBundleFailures_MustReject drives the checks that need no cosign.
+//
+// Each row is otherwise valid apart from the one defect named, so the asserted
+// reason is evidence that this check fired and not a neighbouring one. The final
+// row is the accept case: without it, a function that rejected everything would
+// pass every other row here.
+func TestCollectRunBundleFailures_MustReject(t *testing.T) {
+	sqfs, goodDigestHex := squashfsStub(t, "layer contents under test")
+	goodDigest, err := hex.DecodeString(goodDigestHex)
+	if err != nil {
+		t.Fatalf("decode digest: %v", err)
+	}
+
+	// A digest of different bytes: a bundle that is internally valid but
+	// attests some other artifact. Computed here, from a different input, so
+	// the mismatch is a property of the fixture and not of the comparison.
+	otherSum := sha256.Sum256([]byte("some entirely different artifact"))
+	otherDigest := otherSum[:]
+
+	goodBundleURI := writeBundleFile(t, bundleAttesting(goodDigest, []byte("sig")))
+
+	noRekor := bundleAttesting(goodDigest, []byte("sig"))
+	noRekor.VerificationMaterial.TlogEntries = nil
+	noRekorURI := writeBundleFile(t, noRekor)
+
+	wrongAlg := bundleAttesting(goodDigest, []byte("sig"))
+	wrongAlg.MessageSignature.MessageDigest.Algorithm = "SHA2_512"
+	wrongAlgURI := writeBundleFile(t, wrongAlg)
+
+	otherArtifactURI := writeBundleFile(t, bundleAttesting(otherDigest, []byte("sig")))
+
+	notJSON := filepath.Join(t.TempDir(), "bundle.json")
+	if err := os.WriteFile(notJSON, []byte("this is not a sigstore bundle"), 0600); err != nil {
+		t.Fatalf("write malformed bundle: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		// mutate adjusts the otherwise-valid layer to introduce one defect.
+		mutate func(l *spec.ResolvedLayer)
+		// omitPath drops the layer from the fetched-paths list.
+		omitPath   bool
+		wantReason string
+		wantChecks int
+	}{
+		{
+			name:       "bundle field empty",
+			mutate:     func(l *spec.ResolvedLayer) { l.Bundle = "" },
+			wantReason: "empty Bundle field",
+		},
+		{
+			name:       "bundle still an s3 URI",
+			mutate:     func(l *spec.ResolvedLayer) { l.Bundle = "s3://strata-registry/bundles/x.json" },
+			wantReason: "must be fetched to disk",
+		},
+		{
+			name:       "bundle file missing",
+			mutate:     func(l *spec.ResolvedLayer) { l.Bundle = "file:///nonexistent/strata/bundle.json" },
+			wantReason: "reading bundle",
+		},
+		{
+			name:       "bundle does not parse",
+			mutate:     func(l *spec.ResolvedLayer) { l.Bundle = "file://" + notJSON },
+			wantReason: "parsing bundle",
+		},
+		{
+			name:       "bundle has no Rekor entry",
+			mutate:     func(l *spec.ResolvedLayer) { l.Bundle = noRekorURI },
+			wantReason: "no Rekor entry",
+		},
+		{
+			name:       "bundle digest is not SHA-256",
+			mutate:     func(l *spec.ResolvedLayer) { l.Bundle = wrongAlgURI },
+			wantReason: "not SHA-256",
+		},
+		{
+			// The check trust.VerifyLayer does not perform: a valid bundle for
+			// a different artifact. Without this, substituting any signed
+			// layer's bundle passes every local check.
+			name:       "bundle attests a different artifact",
+			mutate:     func(l *spec.ResolvedLayer) { l.Bundle = otherArtifactURI },
+			wantReason: "bundle attests sha256:",
+		},
+		{
+			name:       "no fetched file for the layer",
+			omitPath:   true,
+			wantReason: "no fetched file to verify",
+		},
+		{
+			name:       "valid layer is accepted",
+			wantChecks: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			layer := layerWith("python-3.11", goodDigestHex, goodBundleURI)
+			if tt.mutate != nil {
+				tt.mutate(&layer)
+			}
+			lf := &spec.LockFile{Layers: []spec.ResolvedLayer{layer}}
+
+			var paths []overlay.LayerPath
+			if !tt.omitPath {
+				paths = []overlay.LayerPath{{
+					ID: layer.ID, SHA256: layer.SHA256, Path: sqfs, MountOrder: 1,
+				}}
+			}
+
+			failures, checks := collectRunBundleFailures(lf, paths)
+
+			if tt.wantReason == "" {
+				if len(failures) != 0 {
+					t.Fatalf("want no failures, got %v", failures)
+				}
+				if len(checks) != tt.wantChecks {
+					t.Fatalf("want %d layer(s) passed to the signature step, got %d",
+						tt.wantChecks, len(checks))
+				}
+				return
+			}
+
+			if len(failures) != 1 {
+				t.Fatalf("want exactly 1 failure (so the reason is unambiguous), got %d: %v",
+					len(failures), failures)
+			}
+			if !strings.Contains(failures[0], tt.wantReason) {
+				t.Errorf("failure fired for the wrong reason:\n got: %s\nwant substring: %s",
+					failures[0], tt.wantReason)
+			}
+			if len(checks) != 0 {
+				t.Errorf("a rejected layer reached the signature step: %+v", checks)
+			}
+		})
+	}
+}
+
+// TestVerifyRunSignatures uses trust.FakeVerifier, whose accept/reject decision
+// is a real property of the input (signature must equal the hex SHA256 of the
+// artifact) rather than a flag on a stub. A stub told to fail would prove only
+// that the error is propagated.
+func TestVerifyRunSignatures(t *testing.T) {
+	sqfs, digestHex := squashfsStub(t, "signed layer contents")
+	digest, err := hex.DecodeString(digestHex)
+	if err != nil {
+		t.Fatalf("decode digest: %v", err)
+	}
+
+	good := bundleAttesting(digest, []byte(digestHex))
+	bad := bundleAttesting(digest, []byte("0000000000000000000000000000000000000000000000000000000000000000"))
+
+	t.Run("valid signature passes", func(t *testing.T) {
+		checks := []runLayerCheck{{layerID: "python-3.11", sqfs: sqfs, bundle: good}}
+		if failures := verifyRunSignatures(context.Background(), checks, &trust.FakeVerifier{}); len(failures) != 0 {
+			t.Fatalf("want no failures, got %v", failures)
+		}
+	})
+
+	t.Run("wrong signature is rejected", func(t *testing.T) {
+		checks := []runLayerCheck{{layerID: "python-3.11", sqfs: sqfs, bundle: bad}}
+		failures := verifyRunSignatures(context.Background(), checks, &trust.FakeVerifier{})
+		if len(failures) != 1 {
+			t.Fatalf("want 1 failure, got %d: %v", len(failures), failures)
+		}
+		if !strings.Contains(failures[0], "signature verification failed") {
+			t.Errorf("wrong reason: %s", failures[0])
+		}
+		if !strings.Contains(failures[0], "python-3.11") {
+			t.Errorf("failure does not name the layer: %s", failures[0])
+		}
+	})
+}
+
+// TestNewRunVerifier_NeverReturnsANilVerifier pins the property that makes this
+// path different from the agent's (#56): every prerequisite failure is an error,
+// never a nil Verifier. trust.VerifyLayer and verifyRunSignatures both call
+// v.Verify unconditionally, so a nil verifier is not a skip — it is a panic, and
+// the shape that produces one is the fail-open being repaired.
+func TestNewRunVerifier_NeverReturnsANilVerifier(t *testing.T) {
+	keyPath := filepath.Join(t.TempDir(), "cosign.pub")
+	if err := os.WriteFile(keyPath, []byte("-----BEGIN PUBLIC KEY-----\ntest\n-----END PUBLIC KEY-----\n"), 0600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		keyRef     string
+		wantReason string
+	}{
+		{name: "no key given", keyRef: "", wantReason: "no --key given"},
+		{name: "key not readable", keyRef: filepath.Join(t.TempDir(), "absent.pub"), wantReason: "is not readable"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := newRunVerifier(tt.keyRef)
+			if err == nil {
+				t.Fatalf("want an error, got verifier %+v", v)
+			}
+			if v != nil {
+				t.Errorf("returned a verifier alongside an error: %+v", v)
+			}
+			if !strings.Contains(err.Error(), tt.wantReason) {
+				t.Errorf("wrong reason:\n got: %v\nwant substring: %s", err, tt.wantReason)
+			}
+			if !strings.Contains(err.Error(), "--no-verify") {
+				t.Errorf("error does not name the flag that makes the trade-off explicit: %v", err)
+			}
+		})
+	}
+
+	// With a readable key the result depends on whether cosign is installed,
+	// which differs between a developer machine and CI. Both outcomes are
+	// asserted, because the property under test is the invariant that holds
+	// either way: exactly one of (verifier, error) is non-nil, and it is never
+	// (nil, nil).
+	t.Run("readable key: never nil verifier with nil error", func(t *testing.T) {
+		v, err := newRunVerifier(keyPath)
+		switch {
+		case err != nil && v != nil:
+			t.Errorf("both verifier and error returned: %+v / %v", v, err)
+		case err != nil:
+			if !strings.Contains(err.Error(), "cosign not found on PATH") {
+				t.Errorf("unexpected error for a readable key: %v", err)
+			}
+		case v == nil:
+			t.Error("returned (nil, nil): a nil Verifier is a panic in verifyRunSignatures, not a skip")
+		}
+	})
+}
+
+// captureStderr swaps os.Stderr for a pipe for the duration of fn.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	saved := os.Stderr
+	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		var sb strings.Builder
+		buf := make([]byte, 4096)
+		for {
+			n, err := r.Read(buf)
+			sb.Write(buf[:n])
+			if err != nil {
+				break
+			}
+		}
+		done <- sb.String()
+	}()
+	fn()
+	os.Stderr = saved
+	w.Close() //nolint:errcheck
+	out := <-done
+	r.Close() //nolint:errcheck
+	return out
+}
+
+// TestVerifyRunLayers_NoVerifyAnnouncesTheSkip is the assertion that keeps
+// --no-verify honest in the other direction. Returning nil is not enough: a
+// silent skip is indistinguishable from a check that ran and passed, which is
+// the condition this issue was filed about.
+func TestVerifyRunLayers_NoVerifyAnnouncesTheSkip(t *testing.T) {
+	// Deliberately unverifiable material: an empty bundle field. With
+	// noVerify the function must not look at it at all.
+	lf := &spec.LockFile{Layers: []spec.ResolvedLayer{layerWith("python-3.11", strings.Repeat("a", 64), "")}}
+
+	var err error
+	stderr := captureStderr(t, func() {
+		err = verifyRunLayers(context.Background(), lf, nil, true, "")
+	})
+	if err != nil {
+		t.Fatalf("--no-verify must not fail: %v", err)
+	}
+	if !strings.Contains(stderr, "NOT verified") {
+		t.Errorf("--no-verify skipped verification silently; stderr was: %q", stderr)
+	}
+}
+
+// TestVerifyRunLayers_ReportsEveryFailure: a user fixing a lockfile wants the
+// whole list, and reporting only the first would make a two-layer problem take
+// two runs to see.
+func TestVerifyRunLayers_ReportsEveryFailure(t *testing.T) {
+	lf := &spec.LockFile{Layers: []spec.ResolvedLayer{
+		layerWith("python-3.11", strings.Repeat("a", 64), ""),
+		layerWith("openmpi-5.0", strings.Repeat("b", 64), "s3://strata-registry/b.json"),
+	}}
+	paths := []overlay.LayerPath{
+		{ID: "python-3.11", Path: "/nonexistent/a.sqfs", MountOrder: 1},
+		{ID: "openmpi-5.0", Path: "/nonexistent/b.sqfs", MountOrder: 2},
+	}
+
+	var err error
+	stderr := captureStderr(t, func() {
+		err = verifyRunLayers(context.Background(), lf, paths, false, "")
+	})
+	if err == nil {
+		t.Fatal("want a refusal, got nil")
+	}
+	if !strings.Contains(err.Error(), "refusing to mount unverified layers") {
+		t.Errorf("wrong error: %v", err)
+	}
+	for _, want := range []string{"2 verification failure(s)", "python-3.11", "openmpi-5.0"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr missing %q; got: %q", want, stderr)
+		}
+	}
+}
+
+// writeRunFixture writes a layer file, a bundle attesting bundleDigestHex, and a
+// lockfile pointing at both. Returns the lockfile path and the cache dir.
+//
+// The layer digest the lockfile pins always matches the file, so
+// fetchLayersToCache succeeds and execution reaches the verification step: a
+// test that failed at the fetch would prove nothing about this change.
+func writeRunFixture(t *testing.T, bundleDigestHex string) (lockPath, cacheDir string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	contents := "squashfs stand-in for run fixture"
+	layerPath := filepath.Join(dir, "python.sqfs")
+	if err := os.WriteFile(layerPath, []byte(contents), 0600); err != nil {
+		t.Fatalf("write layer: %v", err)
+	}
+	sum := sha256.Sum256([]byte(contents))
+	layerHex := hex.EncodeToString(sum[:])
+
+	bundleDigest, err := hex.DecodeString(bundleDigestHex)
+	if err != nil {
+		t.Fatalf("decode bundle digest: %v", err)
+	}
+	bundleData, err := bundleAttesting(bundleDigest, []byte("sig")).Marshal()
+	if err != nil {
+		t.Fatalf("marshal bundle: %v", err)
+	}
+	bundlePath := filepath.Join(dir, "python.bundle.json")
+	if err := os.WriteFile(bundlePath, bundleData, 0600); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+
+	lf := spec.LockFile{
+		ProfileName: "run-verify-fixture",
+		RekorEntry:  "999",
+		Layers: []spec.ResolvedLayer{{
+			LayerManifest: spec.LayerManifest{
+				ID:         "python-3.11",
+				Name:       "python",
+				Version:    "3.11.9",
+				Source:     "file://" + layerPath,
+				SHA256:     layerHex,
+				Bundle:     "file://" + bundlePath,
+				RekorEntry: "1234",
+			},
+			MountOrder: 1,
+		}},
+	}
+	data, err := yaml.Marshal(lf)
+	if err != nil {
+		t.Fatalf("marshal lockfile: %v", err)
+	}
+	lockPath = filepath.Join(dir, "lock.yaml")
+	if err := os.WriteFile(lockPath, data, 0600); err != nil {
+		t.Fatalf("write lockfile: %v", err)
+	}
+	return lockPath, filepath.Join(dir, "cache")
+}
+
+// TestRunRun_RefusesLayerWhoseBundleAttestsAnotherArtifact drives runRun itself,
+// not the helper.
+//
+// This distinction is the point of the test. Extracting verifyRunLayers and
+// testing that in isolation would leave runRun at zero coverage — the command
+// could stop calling it and every other test here would still pass.
+//
+// The discriminating assertion is that the error is the verification refusal and
+// NOT the mount error that follows it. Against the unfixed code this test fails:
+// verification did not happen, so runRun proceeded to mounting and returned
+// "mounting overlay". Asserting only err != nil would have passed there too.
+func TestRunRun_RefusesLayerWhoseBundleAttestsAnotherArtifact(t *testing.T) {
+	otherSum := sha256.Sum256([]byte("a different artifact entirely"))
+	lockPath, cacheDir := writeRunFixture(t, hex.EncodeToString(otherSum[:]))
+
+	var err error
+	stderr := captureStderr(t, func() {
+		err = runRun(context.Background(), lockPath,
+			[]string{"/nonexistent/strata-run-verify-probe"}, false, cacheDir, "", nil)
+	})
+
+	if err == nil {
+		t.Fatal("runRun mounted a layer whose bundle attests a different artifact")
+	}
+	if !strings.Contains(err.Error(), "refusing to mount unverified layers") {
+		t.Fatalf("runRun failed for the wrong reason — verification did not gate the mount:\n%v", err)
+	}
+	if strings.Contains(err.Error(), "mounting overlay") {
+		t.Errorf("execution reached the mount despite a failed verification: %v", err)
+	}
+	if !strings.Contains(stderr, "bundle attests sha256:") {
+		t.Errorf("stderr does not name the check that fired; got: %q", stderr)
+	}
+}
+
+// TestRunRun_NoVerifyReachesTheMount is the other half: it proves --no-verify
+// now controls something. The pair is what closes #55 — before the fix both
+// directions behaved identically, because verification never ran either way.
+//
+// Mounting a stand-in squashfs cannot succeed in a test environment, so the
+// assertion is not on success but on which failure: anything other than the
+// verification refusal means execution got past the gate.
+func TestRunRun_NoVerifyReachesTheMount(t *testing.T) {
+	otherSum := sha256.Sum256([]byte("a different artifact entirely"))
+	lockPath, cacheDir := writeRunFixture(t, hex.EncodeToString(otherSum[:]))
+
+	var err error
+	stderr := captureStderr(t, func() {
+		err = runRun(context.Background(), lockPath,
+			[]string{"/nonexistent/strata-run-verify-probe"}, true, cacheDir, "", nil)
+	})
+
+	if err != nil && strings.Contains(err.Error(), "refusing to mount unverified layers") {
+		t.Fatalf("--no-verify did not skip verification: %v", err)
+	}
+	if !strings.Contains(stderr, "NOT verified") {
+		t.Errorf("--no-verify did not announce the skip; stderr was: %q", stderr)
+	}
+}
+
+// TestRunRun_MissingKeyIsARefusalNotASkip: on a machine with no cosign key
+// configured, the absence of the means to verify must stop the mount. This is
+// the failure mode the codebase already has a precedent against — verification
+// that cannot be performed is not verification that passed (verify.go).
+func TestRunRun_MissingKeyIsARefusalNotASkip(t *testing.T) {
+	// Bundle attests the real layer digest, so every structural check passes
+	// and the only thing left is the signature — which cannot be checked
+	// without a key.
+	contents := "squashfs stand-in for run fixture"
+	sum := sha256.Sum256([]byte(contents))
+	lockPath, cacheDir := writeRunFixture(t, hex.EncodeToString(sum[:]))
+
+	var err error
+	stderr := captureStderr(t, func() {
+		err = runRun(context.Background(), lockPath,
+			[]string{"/nonexistent/strata-run-verify-probe"}, false, cacheDir, "", nil)
+	})
+
+	if err == nil || !strings.Contains(err.Error(), "refusing to mount unverified layers") {
+		t.Fatalf("a structurally valid but unverifiable layer was mounted: %v", err)
+	}
+	if !strings.Contains(stderr, "no --key given") {
+		t.Errorf("stderr does not say why verification could not be performed; got: %q", stderr)
+	}
+}

--- a/cmd/strata/verify.go
+++ b/cmd/strata/verify.go
@@ -159,18 +159,25 @@ func verifyRekorEntries(ctx context.Context, lf *spec.LockFile, client trust.Rek
 // job everywhere else in this codebase (see trust.VerifyLayer, which refuses URIs
 // outright). Rather than pass a nil bundle and let the Rekor check degrade into a
 // presence check, an unfetchable bundle is an error that names what is missing.
-// Fetching remote bundles so that --rekor works against an s3-backed lockfile is
+// Fetching remote bundles so that s3-backed lockfiles can be verified in place is
 // tracked separately (#60).
+//
+// Callers: strata verify --rekor, and strata run's pre-mount check (#55). The
+// messages are worded for both — they used to name --rekor, which would have been
+// a lie in run's output. Nothing else about this function changed when run started
+// calling it: it neither fetches nor mutates, and every failure it can report is
+// returned rather than logged, so the second caller inherits no behaviour that the
+// first one's tests were not already asserting.
 func loadLocalBundle(uri string) (*trust.Bundle, error) {
 	if uri == "" {
-		return nil, errors.New("empty Bundle field: nothing to verify the log entry against")
+		return nil, errors.New("empty Bundle field: nothing to verify the signature against")
 	}
 	path := uri
 	switch {
 	case strings.HasPrefix(uri, "file://"):
 		path = strings.TrimPrefix(uri, "file://")
 	case strings.Contains(uri, "://"):
-		return nil, fmt.Errorf("bundle %q must be fetched to disk before --rekor can verify against it", uri)
+		return nil, fmt.Errorf("bundle %q must be fetched to disk before it can be verified", uri)
 	}
 
 	data, err := os.ReadFile(path)


### PR DESCRIPTION
Closes #55.

## The defect

`strata run` took a `--no-verify` flag that disabled nothing. Its only effect was to suppress a warning about an empty `rekor_entry` **field in the lockfile** — and a field is not evidence about a file. No signature was checked in either state, so both paths mounted identical content.

Before this change, `runRun` had **0.0%** test coverage (`go tool cover -func`), so nothing observed the difference.

## The fix

Verification now runs after the layers are on disk and before anything is mounted: the bytes about to be mounted are what has to be verified.

Per layer, in this order:

1. **Structural checks, no cosign and no network** — the bundle must be readable (an unfetched `s3://` URI is a failure, not a skip), must parse, must carry a Rekor entry, and must **attest the digest the lockfile pins**.
2. **Signature** — verified with cosign against a new `--key`.

All failures are collected and reported together, each naming its layer and its reason; the mount is then refused.

### Three design points, argued rather than assumed

**The digest-match check is not one `trust.VerifyLayer` performs.** cosign ties bundle to artifact itself, so `VerifyLayer` can omit it. This path cannot: on a machine without cosign, that omission makes "a valid bundle for somebody else's layer" indistinguishable from "verified". Without the check, substituting any signed layer's bundle passes every local check.

**Structural checks run before the cosign prerequisite.** Not for tidiness: a missing cosign would otherwise mask every bundle defect behind one prerequisite error, and the reject direction would become untestable in CI, which has no cosign. This mirrors `strata verify`'s existing shape, where presence failures gate the Rekor step, rather than inventing a new one.

**Prerequisite failures are errors, never a nil verifier.** `verifyRunSignatures` and `trust.VerifyLayer` both call `v.Verify` unconditionally, so a nil verifier is not a skip — it is a panic. The shape that produces one is the fail-open filed separately as #56, and `TestNewRunVerifier_NeverReturnsANilVerifier` pins the invariant.

`--no-verify` still mounts unverified content and now announces it on stderr. A silent skip is indistinguishable from a check that ran and passed, which is the condition this issue was filed about.

## Which of `trust.VerifyLayer`'s guarantees is discharged where

Stated because relocating a rule to a new site is where preconditions get dropped. `collectRunBundleFailures` does not call `VerifyLayer`; each of that function's steps is accounted for:

| `VerifyLayer` step | Where it happens here |
|---|---|
| file digest vs manifest | `fetchLayersToCache`, unconditionally, on both cache hit and post-download (#57). Re-hashing here would hash the same squashfs a third time for no new information. |
| bundle non-empty / not a bare URI / readable / parses | `collectRunBundleFailures`, via `loadLocalBundle` |
| `HasRekorEntry()` | `collectRunBundleFailures` |
| cosign signature | `verifyRunSignatures` |
| — (not in `VerifyLayer`) | bundle attests the digest **this** lockfile pins |

## Evidence

**The tests drive `runRun` itself, not only the extracted helper.** Coverage of `runRun` goes **0.0% → 39.1%**:

```
go test -race -covermode=atomic -coverprofile=cov.out ./cmd/strata/
go tool cover -func=cov.out | grep -E 'runRun|verifyRunLayers|collectRunBundleFailures|verifyRunSignatures|newRunVerifier'
```

```
run.go:72:   runRun                     39.1%
run.go:182:  verifyRunLayers            86.7%
run.go:238:  collectRunBundleFailures  100.0%
run.go:287:  isBundleSHA256            100.0%
run.go:300:  verifyRunSignatures       100.0%
run.go:317:  newRunVerifier             85.7%
```

That distinction matters: testing only the helper would leave the command free to stop calling it while every test still passed.

**Must-reject material, each row firing for the reason under test.** `TestCollectRunBundleFailures_MustReject` has eight reject rows and one accept row. Every row is otherwise valid apart from the one defect named, and each asserts **exactly one** failure plus its text — a row that failed at an earlier check would report the wrong reason and fail the test. The accept row is there because a function that rejected everything would otherwise pass all eight.

Rejected: empty `Bundle` field · bundle still an `s3://` URI · bundle file missing · bundle does not parse · no Rekor entry · digest algorithm not SHA-256 · **bundle attests a different artifact** · no fetched file for the layer.

The digest-mismatch fixture is built from an independently hashed second input, so the mismatch is a property of the fixture and not of the comparison being tested.

**Signature rejection uses `trust.FakeVerifier`**, whose accept/reject decision is a real property of the input (signature must equal the hex SHA256 of the artifact), not a flag on a stub. A stub told to fail would prove only that an error propagates.

**Negative control against the unfixed tree.** The discriminating assertion is that the error is the verification refusal and **not** the mount error that used to follow it. Asserting `err != nil` would have passed against the defect — proven, not assumed, by running the same fixture against `9a735ca` in a detached worktree:

```
git worktree add --detach /tmp/probe-unfixed 9a735ca
# same fixture, old 6-arg runRun signature
UNFIXED runRun returned: run: mounting overlay: overlay: OverlayFS assembly requires Linux
```

Non-nil, and not a refusal: nothing gated the mount on the bundle. The fixed tree returns `run: refusing to mount unverified layers`.

**Both directions of `--no-verify` are asserted**, which is what actually closes the issue: with the flag, execution gets past the gate and the skip is announced; without it, the mount is refused. Before the fix both directions behaved identically.

## Behaviour change

`strata run` **without `--key` and without `--no-verify` now fails where it previously mounted.** This breaks every existing invocation, and it is the point of the fix — the previous behaviour was an unverified mount reported as a normal one. `CHANGELOG.md` states it per consumer, including that `strata capture` / `strata stratify`'s existing advice to pass `--no-verify` for unsigned layers stops being decorative and becomes required.

## Notes for review

- **No new dependencies.**
- **No inherited test file is modified.** The only test file in the diff is the new `cmd/strata/run_verify_test.go`. Settled from the diff, not from intent:
  ```
  git diff --name-only origin/main...HEAD -- '*_test.go'
  ```
- `cmd/strata/verify.go` is touched only to reword two `loadLocalBundle` messages that named `--rekor`, which would have been false in `strata run`'s output. The helper still neither fetches nor mutates and still returns every failure rather than logging one; `strata verify --rekor` is unchanged, and its existing assertion on the substring `fetched to disk` still holds.
- `go vet`, `go test -race ./...`, and `golangci-lint run ./...` are clean locally. Local linter is **v2.13.0**; CI pins **v2.11.3** (`.github/workflows/ci.yml:90`). Neither is evidence for the other — the drift is #75, and CI's Lint job is the binding result.
