### PR TITLE
fix(agent): refuse to boot when layer authenticity cannot be verified (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **`strata-agent` refuses to boot when it cannot verify layer authenticity**
+  (#56). `newCosignVerifier` returned a nil `trust.Verifier` when cosign was not
+  on `PATH` or the public key could not be fetched from S3, and
+  `internal/agent.verifyBundles` treats a nil verifier as nothing to do — so an
+  EC2 instance silently downgraded from authenticity checking to hash checking.
+  "cosign is not installed" and "the operator accepted the risk" were the same
+  value, and the second was never asked for.
+
+  `newCosignVerifier` now returns `(trust.Verifier, error)` and names the missing
+  prerequisite. The boot stops, signalling failure to EC2 first so the instance
+  is diagnosable rather than looking hung. The opt-out is explicit and defaults
+  to closed: `STRATA_AGENT_ALLOW_UNVERIFIED=1` boots without authenticity
+  verification and logs that it has done so. Unrecognised values — including
+  typos like `ture` — leave verification on.
+
+  A nil verifier is now returned **only** with the opt-out set. That pairing, not
+  "never nil", is the invariant, and it is what the new tests assert.
+
+  What is given up by opting out is *authenticity*, not integrity: SHA-256
+  against the lockfile is still enforced on every path. The distinction matters
+  because a lockfile is exactly the artifact an attacker would supply, so it
+  cannot vouch for who produced the layers it pins.
+
+  **What changes per consumer**, enumerated from
+  `grep -rn 'agent.Config{' --include='*.go' .` and
+  `grep -rn 'internal/agent' --include='*.go' . | grep -v '^./internal/agent'`:
+  - **`strata-agent` on an instance without cosign, or without registry access
+    to `build/keys/cosign.pub`, now fails to boot** where it previously booted
+    with authenticity checking off. This is the intended breaking change.
+    Operators who relied on the old degradation must set
+    `STRATA_AGENT_ALLOW_UNVERIFIED=1`. The AMI build is the place to check: if
+    cosign is not baked in, every instance was taking the old path.
+  - `internal/agent` is **unchanged** — deliberately. `verifyBundles`'s
+    `Verifier == nil` guard is still fail-open, and inverting it fails three
+    inherited tests in `internal/agent/agent_test.go` that construct a boot with
+    verification disabled and call it a happy path. That is a reviewed decision,
+    not a fix to slip in, and it is filed as such. What *is* closed is the
+    deployed hole: `internal/agent` is an internal package with exactly one
+    non-test `agent.Config` construction (`cmd/strata-agent/main.go`), where
+    `BundleFetcher` is never nil, so after this change no shipped caller can
+    reach the library fail-open.
+  - `STRATA.md`'s layer-verification section claimed verification "is
+    unconditional — there is no flag to skip verification". That was false in the
+    worse direction: verification was skippable without a flag. It now documents
+    both explicit opt-outs.
+  - `pkg/strata` and every other command are **unchanged**: nothing outside
+    `cmd/strata-agent` imports `internal/agent`.
 - **Rekor entry verification compares the entry to the bundle** (#59).
   `RekorHTTPClient.VerifyEntry` took a bundle, discarded it (`_ = bundle`), and
   returned success for any log index the server could find an entry at. That is a

--- a/STRATA.md
+++ b/STRATA.md
@@ -286,7 +286,27 @@ entry commits the layer's identity to a public, append-only log.
 
 The agent verifies the cosign bundle against the Rekor transparency log before mounting
 any layer. SHA256 of the pulled squashfs is verified against the manifest. Unsigned layers
-will not mount. This is unconditional — there is no flag to skip verification.
+will not mount.
+
+Verification is required, not unconditional, and the difference is worth stating because
+this paragraph previously claimed the stronger thing. Two escape hatches exist, and both
+are explicit:
+
+- `strata run` requires `--key` and refuses to mount without it; `--no-verify` mounts
+  unverified layers and says so on stderr (#55).
+- `strata-agent` refuses to boot when cosign or the public key is unavailable. Setting
+  `STRATA_AGENT_ALLOW_UNVERIFIED=1` in the instance's user-data or unit file lets it boot
+  without authenticity verification, logging that it has done so (#56).
+
+What the earlier "there is no flag to skip verification" sentence obscured is that
+verification was skippable *without* a flag: the agent returned a nil verifier whenever
+cosign was missing, and the library treated a nil verifier as nothing to do. A documented
+opt-out that defaults to closed is a weaker claim than the one this paragraph used to make
+and a stronger property than the code used to have.
+
+In every case SHA256 integrity against the lockfile is still enforced. What an opt-out
+gives up is *authenticity* — evidence about who produced the layers — which is precisely
+what a supplied lockfile cannot vouch for on its own.
 
 ### Lockfile signing
 

--- a/cmd/strata-agent/cosign_verifier_test.go
+++ b/cmd/strata-agent/cosign_verifier_test.go
@@ -1,0 +1,282 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/strata/internal/trust"
+)
+
+// Tests for the agent's verifier construction (#56).
+//
+// The defect was that "cosign is not installed" and "the operator accepted the
+// risk" were the same value — a nil trust.Verifier — so an EC2 instance
+// downgraded from authenticity checking to hash checking without anyone asking
+// it to. Before this change `newCosignVerifier` had 0.0% coverage: it was called
+// only from main(), so nothing in CI executed the most security-relevant branch
+// in the binary.
+//
+// The property under test is therefore not "a verifier is built". It is that a
+// nil verifier is returned if and only if the operator explicitly opted out.
+
+func cosignPresent(string) (string, error) { return "/usr/local/bin/cosign", nil }
+
+// cosignAbsent reproduces exec.LookPath's failure shape.
+func cosignAbsent(string) (string, error) {
+	return "", errors.New(`exec: "cosign": executable file not found in $PATH`)
+}
+
+func keyFetched(context.Context) string     { return "/tmp/strata-cosign-test.pub" }
+func keyUnavailable(context.Context) string { return "" }
+
+// TestNewCosignVerifier_NamesTheMissingPrerequisite covers the two refusal
+// directions and the one success direction.
+//
+// Both refusals must be reachable without cosign installed and without AWS
+// credentials, which is the state of CI — that reachability is most of what this
+// issue was about.
+func TestNewCosignVerifier_NamesTheMissingPrerequisite(t *testing.T) {
+	tests := []struct {
+		name       string
+		prereqs    verifierPrereqs
+		wantReason string
+	}{
+		{
+			name:       "cosign missing",
+			prereqs:    verifierPrereqs{lookPath: cosignAbsent, fetchKey: keyFetched},
+			wantReason: "cosign not found on PATH",
+		},
+		{
+			// Reported as the key, not as cosign: both prerequisites are
+			// consulted in order and this row proves the second one is
+			// reached rather than masked by the first.
+			name:       "cosign present, key unavailable",
+			prereqs:    verifierPrereqs{lookPath: cosignPresent, fetchKey: keyUnavailable},
+			wantReason: "could not fetch the cosign public key",
+		},
+		{
+			name:    "both prerequisites present",
+			prereqs: verifierPrereqs{lookPath: cosignPresent, fetchKey: keyFetched},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := newCosignVerifier(context.Background(), tt.prereqs)
+
+			if tt.wantReason == "" {
+				if err != nil {
+					t.Fatalf("want a verifier, got error: %v", err)
+				}
+				if v == nil {
+					t.Fatal("returned (nil, nil): a nil Verifier is a panic in trust.VerifyLayer, not a skip")
+				}
+				cv, ok := v.(*trust.CosignVerifier)
+				if !ok {
+					t.Fatalf("want *trust.CosignVerifier, got %T", v)
+				}
+				if cv.KeyRef != keyFetched(context.Background()) {
+					t.Errorf("verifier does not use the fetched key: KeyRef = %q", cv.KeyRef)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("want a refusal, got verifier %+v", v)
+			}
+			if v != nil {
+				t.Errorf("returned a verifier alongside an error: %+v", v)
+			}
+			if !strings.Contains(err.Error(), tt.wantReason) {
+				t.Errorf("refusal names the wrong prerequisite:\n got: %v\nwant substring: %s",
+					err, tt.wantReason)
+			}
+		})
+	}
+}
+
+// TestNewCosignVerifier_ReportsCosignBeforeTheKey: when both prerequisites are
+// missing, the operator must be sent to the binary and not to the key, because
+// without the binary the key is useless.
+//
+// This is the row that the two-refusal table above cannot express — it needs
+// both defects present at once, and it asserts which one wins.
+func TestNewCosignVerifier_ReportsCosignBeforeTheKey(t *testing.T) {
+	_, err := newCosignVerifier(context.Background(),
+		verifierPrereqs{lookPath: cosignAbsent, fetchKey: keyUnavailable})
+	if err == nil {
+		t.Fatal("want a refusal")
+	}
+	if !strings.Contains(err.Error(), "cosign not found on PATH") {
+		t.Errorf("want the cosign prerequisite reported first, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "public key") {
+		t.Errorf("key fetch was attempted or reported despite cosign being absent: %v", err)
+	}
+}
+
+// TestResolveVerifier_NilVerifierOnlyWithAnExplicitOptOut is the invariant.
+//
+// A nil verifier is not an error value here — it is the opt-out result — so the
+// assertion cannot be "never nil". It is that the pairing (nil verifier, nil
+// error) occurs only when allowUnverified is set, and that every other
+// prerequisite failure is an error the boot stops on.
+func TestResolveVerifier_NilVerifierOnlyWithAnExplicitOptOut(t *testing.T) {
+	failing := []struct {
+		name    string
+		prereqs verifierPrereqs
+	}{
+		{"cosign missing", verifierPrereqs{lookPath: cosignAbsent, fetchKey: keyFetched}},
+		{"key unavailable", verifierPrereqs{lookPath: cosignPresent, fetchKey: keyUnavailable}},
+	}
+
+	for _, f := range failing {
+		t.Run(f.name+", opt-out not set: refuses", func(t *testing.T) {
+			v, err := resolveVerifier(context.Background(), f.prereqs)
+			if err == nil {
+				t.Fatalf("boot was allowed to continue without verification (verifier %+v)", v)
+			}
+			if v != nil {
+				t.Errorf("returned a verifier alongside an error: %+v", v)
+			}
+			if !strings.Contains(err.Error(), allowUnverifiedEnv) {
+				t.Errorf("refusal does not name the opt-out an operator would need: %v", err)
+			}
+		})
+
+		t.Run(f.name+", opt-out set: proceeds without a verifier", func(t *testing.T) {
+			p := f.prereqs
+			p.allowUnverified = true
+			v, err := resolveVerifier(context.Background(), p)
+			if err != nil {
+				t.Fatalf("explicit opt-out must not fail the boot: %v", err)
+			}
+			if v != nil {
+				t.Errorf("opt-out returned a verifier: %+v", v)
+			}
+		})
+	}
+
+	t.Run("prerequisites present: a verifier, regardless of the opt-out", func(t *testing.T) {
+		// The opt-out is permission to boot unverified, not an instruction to
+		// stop verifying. An operator who sets it on a fleet where cosign is
+		// present should still get verification.
+		for _, allow := range []bool{false, true} {
+			v, err := resolveVerifier(context.Background(), verifierPrereqs{
+				lookPath: cosignPresent, fetchKey: keyFetched, allowUnverified: allow,
+			})
+			if err != nil {
+				t.Fatalf("allowUnverified=%v: unexpected error: %v", allow, err)
+			}
+			if v == nil {
+				t.Errorf("allowUnverified=%v: verification was skipped although both prerequisites were present", allow)
+			}
+		}
+	})
+}
+
+// TestAllowUnverified_DefaultsToClosed drives the opt-out parser through the
+// values an operator can actually produce, including the ones that look
+// affirmative and are not.
+//
+// The unset case is first because it is the one production depends on and the
+// one a table of hand-set booleans would never reach.
+func TestAllowUnverified_DefaultsToClosed(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{"", false}, // unset, and the production default
+		{"1", true},
+		{"true", true},
+		{"TRUE", true},
+		{"  yes  ", true}, // whitespace is trimmed
+
+		{"on", true},
+		{"0", false},
+		{"false", false},
+		{"no", false},
+		// Anything unrecognised leaves verification on. A typo in the value is
+		// not consent, and this is the direction of error a security default
+		// should have.
+		{"maybe", false},
+		{"ture", false},
+		{"2", false},
+		{"disabled", false},
+	}
+	for _, tt := range tests {
+		got := allowUnverified(func(string) string { return tt.value })
+		if got != tt.want {
+			t.Errorf("allowUnverified(%q) = %v, want %v", tt.value, got, tt.want)
+		}
+	}
+}
+
+// TestAllowUnverified_ReadsTheRightVariable: a parser that ignored its key would
+// pass every row above, because they all return the same value for any key.
+func TestAllowUnverified_ReadsTheRightVariable(t *testing.T) {
+	getenv := func(k string) string {
+		if k == allowUnverifiedEnv {
+			return "1"
+		}
+		return ""
+	}
+	if !allowUnverified(getenv) {
+		t.Errorf("allowUnverified does not read %s", allowUnverifiedEnv)
+	}
+
+	other := func(k string) string {
+		if k == "STRATA_AGENT_ALLOW_UNVERIFIED_LAYERS" {
+			return "1"
+		}
+		return ""
+	}
+	if allowUnverified(other) {
+		t.Error("a similarly-named variable enabled the opt-out")
+	}
+}
+
+// TestProductionPrereqs_ClosedByDefault reaches the default through the wiring
+// production uses, rather than by setting the field.
+//
+// This test exists because of a predicted failure recorded on #56 before the
+// code was written: that the closed default would be correct by construction and
+// asserted by nothing, since every other test here sets allowUnverified
+// explicitly. Reading the literal `false` back with one's eyes is not a check.
+func TestProductionPrereqs_ClosedByDefault(t *testing.T) {
+	// A getenv that reports every variable as unset — the state of a fresh
+	// instance whose user-data says nothing about verification.
+	unset := func(string) string { return "" }
+
+	p := productionPrereqs(unset)
+	if p.allowUnverified {
+		t.Error("the production default opts out of verification")
+	}
+	if p.lookPath == nil || p.fetchKey == nil {
+		t.Fatal("production prereqs are incompletely wired")
+	}
+
+	// And the consequence, through resolveVerifier rather than by inspecting
+	// the field: with cosign unavailable and nothing set, the boot stops.
+	p.lookPath = cosignAbsent
+	if _, err := resolveVerifier(context.Background(), p); err == nil {
+		t.Error("with nothing set and cosign absent, the boot was allowed to continue")
+	}
+}
+
+// TestProductionPrereqs_UsesTheRealEnvironment checks the wiring against
+// os.Getenv, which is what main passes. os.Setenv is safe here because the
+// variable is read once, synchronously, by the call under test.
+func TestProductionPrereqs_UsesTheRealEnvironment(t *testing.T) {
+	if productionPrereqs(os.Getenv).allowUnverified {
+		t.Fatalf("%s is set in this test environment; the default cannot be observed", allowUnverifiedEnv)
+	}
+
+	t.Setenv(allowUnverifiedEnv, "1")
+	if !productionPrereqs(os.Getenv).allowUnverified {
+		t.Errorf("productionPrereqs does not read %s from the environment", allowUnverifiedEnv)
+	}
+}

--- a/cmd/strata-agent/cosign_verifier_test.go
+++ b/cmd/strata-agent/cosign_verifier_test.go
@@ -267,6 +267,29 @@ func TestProductionPrereqs_ClosedByDefault(t *testing.T) {
 	}
 }
 
+// TestProductionPrereqs_RefusesWithTheRealLookPath closes the gap the injected
+// lookPath leaves: that the production wiring actually consults the real one.
+//
+// Every other test here substitutes cosignAbsent, which proves the decision
+// logic and nothing about what production calls. Stripping PATH makes the real
+// exec.LookPath fail — deterministically, whether or not cosign is installed on
+// the machine running this — and no S3 call happens, because the key fetch is
+// never reached.
+func TestProductionPrereqs_RefusesWithTheRealLookPath(t *testing.T) {
+	t.Setenv("PATH", "/nonexistent-strata-agent-test")
+
+	v, err := resolveVerifier(context.Background(), productionPrereqs(os.Getenv))
+	if err == nil {
+		t.Fatalf("cosign is unreachable and nothing was opted out, but the boot was allowed to continue (verifier %+v)", v)
+	}
+	if v != nil {
+		t.Errorf("returned a verifier alongside an error: %+v", v)
+	}
+	if !strings.Contains(err.Error(), "cosign not found on PATH") {
+		t.Errorf("refusal does not name the real prerequisite: %v", err)
+	}
+}
+
 // TestProductionPrereqs_UsesTheRealEnvironment checks the wiring against
 // os.Getenv, which is what main passes. os.Setenv is safe here because the
 // variable is read once, synchronously, by the call under test.

--- a/cmd/strata-agent/main.go
+++ b/cmd/strata-agent/main.go
@@ -12,11 +12,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -45,11 +47,26 @@ func main() {
 	fetcher := newS3LayerFetcher()
 	signaler := newEC2ReadySignaler()
 
+	// Resolve the verifier before anything else is built. A boot that cannot
+	// check authenticity is a boot that stops, and it stops here rather than
+	// six steps later with the layers already mounted.
+	verifier, err := resolveVerifier(ctx, productionPrereqs(os.Getenv))
+	if err != nil {
+		// Signal before dying. An instance that refuses to boot and says
+		// nothing is indistinguishable from an instance that hung, and the
+		// operator is paying for it either way. Signalling is best-effort;
+		// its failure is logged and must not make the refusal non-fatal.
+		if sigErr := signaler.SignalFailed(ctx, err); sigErr != nil {
+			log.Printf("strata-agent: could not signal boot failure: %v", sigErr)
+		}
+		log.Fatalf("strata-agent: %v", err)
+	}
+
 	a, err := agent.New(agent.Config{
 		Source:           newMetadataLockfileSource(),
 		Fetcher:          fetcher,
 		BundleFetcher:    fetcher,
-		Verifier:         newCosignVerifier(ctx),
+		Verifier:         verifier,
 		Signaler:         signaler,
 		PackageInstaller: agent.ExecPackageInstaller{},
 	})
@@ -71,24 +88,122 @@ func main() {
 	}
 }
 
-// newCosignVerifier checks that cosign is available on PATH and downloads the
-// public key from S3. Returns nil when either prerequisite is missing so the
-// agent degrades gracefully (SHA256 integrity is still enforced).
-func newCosignVerifier(ctx context.Context) trust.Verifier {
-	if _, err := exec.LookPath("cosign"); err != nil {
-		log.Printf("strata-agent: cosign not found on PATH; skipping bundle verification")
-		return nil
-	}
-	keyPath := fetchPublicKey(ctx)
-	if keyPath == "" {
-		log.Printf("strata-agent: could not fetch cosign public key; skipping bundle verification")
-		return nil
-	}
-	return &trust.CosignVerifier{KeyRef: keyPath}
+// allowUnverifiedEnv opts the agent out of authenticity verification. Unset —
+// or set to anything other than an affirmative value — means verification is
+// required and the agent refuses to boot without it.
+//
+// An environment variable rather than a flag because the agent is a systemd
+// unit with no meaningful argv, and because it matches the existing
+// STRATA_REGISTRY_BUCKET lever. Setting it is a recorded act in the instance's
+// user-data or unit file, which is the property that matters: the previous
+// behaviour was a downgrade nobody had to ask for.
+const allowUnverifiedEnv = "STRATA_AGENT_ALLOW_UNVERIFIED"
+
+// verifierPrereqs are the inputs the verifier decision consults.
+//
+// They are injected rather than called directly so that every refusal direction
+// is reachable in a test with no cosign installed and no AWS credentials — which
+// is the state of CI, and was the reason this branch had 0.0% coverage while
+// being the most security-relevant one in the agent (#56).
+type verifierPrereqs struct {
+	// lookPath resolves an executable, like exec.LookPath.
+	lookPath func(file string) (string, error)
+	// fetchKey returns a local path to the cosign public key, or "" on failure.
+	fetchKey func(ctx context.Context) string
+	// allowUnverified is the operator's explicit opt-out. False means refuse.
+	allowUnverified bool
 }
 
+// productionPrereqs wires the real prerequisites. getenv is a parameter so the
+// default this function produces — including the closed default for the opt-out
+// — is observable in a test rather than only by reading it.
+func productionPrereqs(getenv func(string) string) verifierPrereqs {
+	return verifierPrereqs{
+		lookPath:        exec.LookPath,
+		fetchKey:        fetchPublicKey,
+		allowUnverified: allowUnverified(getenv),
+	}
+}
+
+// allowUnverified reports whether the operator has explicitly opted out of
+// authenticity verification.
+//
+// Defaults to false for every input, including unset, empty, and unrecognised
+// values. A typo in the variable name or its value leaves verification on: the
+// direction of error for a security default is towards refusing.
+func allowUnverified(getenv func(string) string) bool {
+	switch strings.ToLower(strings.TrimSpace(getenv(allowUnverifiedEnv))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// resolveVerifier returns the verifier the agent should boot with.
+//
+// A non-nil error means the boot must stop. A nil verifier with a nil error
+// means the operator explicitly opted out — that pairing is the *only* way a
+// nil verifier is returned, and it is the invariant this function exists to
+// hold. Previously a nil verifier was returned on any prerequisite failure,
+// which made "cosign is not installed" and "the operator accepted the risk"
+// the same value.
+//
+// Why refusing is right here even though it costs boot availability: the agent
+// still checks SHA-256 against the lockfile either way, so what is lost when
+// verification is skipped is not integrity but *authenticity* — the lockfile
+// stops being evidence about who produced the layers, and a lockfile is exactly
+// the artifact an attacker would supply. Degrading that silently trades a
+// property nobody can observe was lost.
+func resolveVerifier(ctx context.Context, p verifierPrereqs) (trust.Verifier, error) {
+	v, err := newCosignVerifier(ctx, p)
+	if err == nil {
+		return v, nil
+	}
+	if !p.allowUnverified {
+		return nil, fmt.Errorf("%w (set %s=1 to boot without authenticity verification)", err, allowUnverifiedEnv)
+	}
+	log.Printf("strata-agent: WARNING: %s is set: booting WITHOUT authenticity verification (%v). "+
+		"SHA-256 integrity against the lockfile is still enforced; layer authorship is not checked.",
+		allowUnverifiedEnv, err)
+	return nil, nil
+}
+
+// newCosignVerifier builds a cosign verifier from the available prerequisites.
+//
+// It never returns a nil Verifier with a nil error: either both prerequisites
+// are present and a verifier is returned, or the missing one is named in an
+// error. Returning nil for "cannot verify" is the fail-open this replaces — and
+// it is not even a skip, since internal/trust/verify.go calls v.Verify
+// unconditionally.
+//
+// Prerequisites are reported in the order they are checked, and cosign comes
+// first deliberately: without the binary the key is useless, so naming the key
+// fetch when both are missing would send an operator to the wrong problem.
+func newCosignVerifier(ctx context.Context, p verifierPrereqs) (trust.Verifier, error) {
+	if _, err := p.lookPath("cosign"); err != nil {
+		return nil, fmt.Errorf("cosign not found on PATH: layer signatures cannot be verified: %w", err)
+	}
+	keyPath := p.fetchKey(ctx)
+	if keyPath == "" {
+		return nil, fmt.Errorf("could not fetch the cosign public key from s3://%s/%s: layer signatures cannot be verified",
+			registryBucket(), publicKeyObject)
+	}
+	return &trust.CosignVerifier{KeyRef: keyPath}, nil
+}
+
+// publicKeyObject is the registry key holding the Strata cosign public key.
+// Named here rather than inside fetchPublicKey so a refusal can tell the
+// operator which object could not be read.
+const publicKeyObject = "build/keys/cosign.pub"
+
 // fetchPublicKey downloads the Strata cosign public key from S3 to a temp
-// file and returns its path. Returns "" on any error (non-fatal).
+// file and returns its path. Returns "" on any error.
+//
+// The "" return is no longer a graceful degradation: its caller turns it into a
+// refusal to boot unless the operator has opted out. This function stays at 0.0%
+// coverage — it is an S3 GetObject against the registry and CI has no AWS
+// credentials by design — which is why the decision it feeds was moved out of it.
 func fetchPublicKey(ctx context.Context) string {
 	cfg, err := awsconfig.LoadDefaultConfig(ctx)
 	if err != nil {
@@ -100,10 +215,9 @@ func fetchPublicKey(ctx context.Context) string {
 	}
 	s3Client := s3.NewFromConfig(cfg)
 
-	const keyObject = "build/keys/cosign.pub"
 	out, err := s3Client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(registryBucket()),
-		Key:    aws.String(keyObject),
+		Key:    aws.String(publicKeyObject),
 	})
 	if err != nil {
 		log.Printf("strata-agent: fetchPublicKey: %v", err)


### PR DESCRIPTION
Closes #56.

Second of two PRs from this pair; #90 is the other. Neither depends on the other landing — the reasoning is on #56, and the one place they interact is called out under *Interaction with #90* below.

## The defect

`newCosignVerifier` returned a nil `trust.Verifier` when cosign was not on `PATH` or the public key could not be fetched, and `internal/agent.verifyBundles` treats a nil verifier as nothing to do. So **"cosign is not installed" and "the operator accepted the risk" were the same value**, and nobody was ever asked for the second.

The chain was proven by execution, not reading, against `9a735ca` in a detached worktree:

```
git worktree add --detach /tmp/probe-56 9a735ca
go test ./cmd/strata-agent/ -run TestProbe_Unfixed -v
# newCosignVerifier returned <nil> (interface nil: true)   [PATH stripped]
go test ./internal/agent/ -run TestProbe_NilVerifier -v
# Run err=<nil>  ReadyCalled=true  FailedCalled=false
```

Link 1: with cosign unreachable the constructor returns nil, and its signature has no error, so the caller cannot distinguish abandonment from success. Link 2: a nil verifier makes `verifyBundles` a no-op, so a lockfile naming a bundle at `s3://strata-registry/bundles/python-3.11.json` — never fetched, no Rekor entry required — **signals READY**.

That branch also had **0.0%** coverage, because it is reachable only from `main()`.

## The fix

`newCosignVerifier(ctx, p verifierPrereqs) (trust.Verifier, error)`. Both prerequisites are errors. The boot stops, and signals failure to EC2 first — an instance that refuses to boot and says nothing is indistinguishable from one that hung, and the operator pays either way. Signalling is best-effort; its failure is logged and does not make the refusal non-fatal.

Prerequisites are reported in check order, cosign first, deliberately: without the binary the key is useless, so naming the key fetch when both are missing sends an operator to the wrong problem. `TestNewCosignVerifier_ReportsCosignBeforeTheKey` asserts that ordering, which the two-refusal table cannot express because it needs both defects at once.

**The opt-out is explicit and defaults to closed:** `STRATA_AGENT_ALLOW_UNVERIFIED=1`. An environment variable rather than a flag because the agent is a systemd unit with no meaningful argv, matching the existing `STRATA_REGISTRY_BUCKET` lever. Unrecognised values — including `ture`, `2`, `disabled` — leave verification on: a typo is not consent.

### The invariant is not "never nil"

A nil verifier is the legitimate opt-out result, so "never nil" would be the wrong assertion. The property is that **`(nil verifier, nil error)` occurs only when the opt-out is set**, which is what `TestResolveVerifier_NilVerifierOnlyWithAnExplicitOptOut` asserts across both prerequisite failures in both opt-out states. `newCosignVerifier` itself never returns that pairing.

One row is there because it is a plausible wrong reading: the opt-out is permission to boot unverified, **not** an instruction to stop verifying. With both prerequisites present, a verifier is returned regardless of the flag.

## Making CI reach the code

`newCosignVerifier`: **0.0% → 100.0%.**

```
go test -covermode=atomic -coverprofile=cov.out ./cmd/strata-agent/
go tool cover -func=cov.out | grep -E 'newCosignVerifier|resolveVerifier|allowUnverified|productionPrereqs|fetchPublicKey'
```
```
main.go:120:  productionPrereqs  100.0%
main.go:134:  allowUnverified    100.0%
main.go:158:  resolveVerifier    100.0%
main.go:183:  newCosignVerifier  100.0%   (was 0.0%)
main.go:207:  fetchPublicKey       0.0%
```

Prerequisites are injected through `verifierPrereqs` so both refusal directions are reachable with **no cosign installed and no AWS credentials**, which is the state of CI and the reason this branch was untested.

**`fetchPublicKey` stays at 0.0%, stated rather than glossed.** It is an S3 `GetObject` against `strata-registry` and CI has no credentials by design. What changed is that its failure is now a refusal instead of a silent downgrade, and that transition is testable through the injected fetch. The I/O is not.

**Injection has its own gap, and it is closed separately.** An injected `lookPath` proves the decision logic and nothing about what production calls. `TestProductionPrereqs_RefusesWithTheRealLookPath` strips `PATH` and drives `resolveVerifier(ctx, productionPrereqs(os.Getenv))` through the real `exec.LookPath` — deterministic whether or not cosign is installed on the machine running it, and no S3 call happens because the key fetch is never reached.

Likewise `TestProductionPrereqs_ClosedByDefault` reaches the closed default through the production wiring with every variable unset, rather than by setting the field — and then asserts the consequence through `resolveVerifier` rather than by inspecting it. That test exists because of a failure I predicted on #56 *before writing the code*: that the default would be correct by construction and asserted by nothing.

## Scope: the binary's constructor. The library half is a decision request.

`internal/agent` is **deliberately untouched**. The issue asks for `TestRun_NilVerifier` — i.e. inverting `agent.go:269-272` — and doing that fails three inherited tests in `internal/agent/agent_test.go` which construct a boot with verification disabled (by omitting `Verifier` entirely) and call it a happy path.

I want to state the fixture side plainly rather than leave it implicit, because the hazard here is a fix that appears to need a check loosened: **those tests are what is wrong, not the fix.** A boot sequence whose happy path skips signature verification is the defect encoded as an expectation. *Would I have designed it this way if that test did not exist?* No.

I am not acting on that. Rewriting three inherited tests to invert a security default belongs in a reviewed decision, not in a fix's slipstream — filed as the decision request linked from #56.

**What this PR closes on its own**, enumerated rather than asserted — and it is fail-open (a) only; see the correction below:

```
grep -rn "agent.Config{" --include="*.go" .                                    # 1 non-test site
grep -rn "internal/agent" --include="*.go" . | grep -v '^./internal/agent'      # cmd/strata-agent only
```

`internal/agent` is internal, has exactly one non-test `agent.Config` construction, `pkg/strata` does not expose it, and `BundleFetcher` at that site is `fetcher` — never nil. So once `newCosignVerifier` cannot return a nil verifier, **no shipped caller can reach the *nil-verifier* fail-open at `agent.go:270`**; that branch survives only for tests. That is a real closure of the deployed path into it, and deliberately not the same as closing the library hole.

> **Corrected 2026-08-21, after review.** An earlier revision of this paragraph said "no shipped caller can reach the library fail-open", full stop. **That was false, and it was false in the direction that flatters this PR.** `verifyBundles` fails open a *second* way that the enumeration above does not touch and cannot: a layer whose `Bundle` field is empty is dropped from `toVerify` (`agent.go:285-293`), and an empty `toVerify` returns nil. Its trigger is a property of the lockfile, not of the wiring, so it fires with a fully configured verifier and bundle fetcher and **is reachable in production today, with or without this PR.** Proven by execution: a verifier that refuses every artifact, never consulted, `Run err=<nil> ReadyCalled=true VerifierCalled=false`.
>
> The sentence is corrected in place rather than rewritten away, because it was already published and whoever picks up #92 or #93 would otherwise inherit the overclaim. **Scope of this PR, stated precisely: it closes the deployed path into fail-open (a) and does nothing about (b).**

## Behaviour change

**`strata-agent` on an instance without cosign, or without registry access to `build/keys/cosign.pub`, now fails to boot** where it previously booted with authenticity checking off. Intended, and the AMI build is where to check: if cosign is not baked in, every instance was taking the old path. `CHANGELOG.md` states it per consumer.

`STRATA.md` claimed layer verification "is unconditional — there is no flag to skip verification." False in the worse direction: it was skippable *without* a flag. It now documents both explicit opt-outs and says what an opt-out gives up — authenticity, not integrity, since SHA-256 against the lockfile is enforced on every path.

## Interaction with #90

Checked separately from conflict, because a conflict reports collision and says nothing about interaction. There is **no code interaction**: disjoint files, disjoint packages, no import path between the two `main` packages, and neither PR touches `internal/trust`. The independence claim made on #56 holds on the code.

There is **one documentation interaction**, and I would rather name it than have a reviewer find it: the `STRATA.md` section I rewrote here describes `strata run`'s `--key` requirement, which is #90's change. If #56 lands and #90 does not, that bullet describes a flag that does not exist. It is a one-line edit, and it does not affect revert independence of either PR's code.

## Notes for review

- **No new dependencies.**
- **No inherited test file is modified.** The only test file in the diff is the new `cmd/strata-agent/cosign_verifier_test.go`:
  ```
  git diff --name-only origin/main...HEAD -- '*_test.go'
  ```
- `go vet`, `go test -race ./...`, `golangci-lint run ./...` clean locally. Local linter **v2.13.0**; CI pins **v2.11.3** (`.github/workflows/ci.yml:90`). Neither is evidence for the other — drift is #75, and CI's Lint job is binding.

