### PR TITLE
fix(agent): refuse to mount a layer with no attestation bundle (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **A layer that names no attestation bundle no longer mounts** (#92). With a
+  verifier and a bundle fetcher both configured — the shape `cmd/strata-agent`
+  always wires — `internal/agent.verifyBundles` dropped any layer whose `Bundle`
+  field was empty from the verify set, and then returned success on an empty
+  verify set. The trigger was a property of the lockfile rather than of the
+  wiring, so it fired against a fully configured verifier: a publisher who
+  omitted `Bundle`, or an attacker who stripped it, booted clean past a verifier
+  that would have refused every layer it was actually shown. Omitting a field is
+  cheaper than forging a signature, which is why absent and invalid now get the
+  same answer.
+
+  Two sites had to change, not one. Inverting the layer filter alone leaves the
+  hole open through a second door: `FetchBundleJSON` is documented to return
+  `(nil, nil)` for an empty bundle, the shipped `s3LayerFetcher` does exactly
+  that, and `verifyBundles` treated a fetch that produced no bytes as nothing to
+  verify. A layer that names a bundle and receives no bytes for it is now a
+  refusal too. Both refusals name the offending layers — the whole unverifiable
+  set, not the first one found — so one boot failure reports everything an
+  operator has to fix.
+
+  **What changes per consumer**, enumerated from
+  `grep -rn 'agent.Config{' --include='*.go' .`,
+  `grep -rn 'internal/agent' --include='*.go' . | grep -v '^./internal/agent'`,
+  and `grep -rn 'FetchBundleJSON' --include='*.go' .`:
+  - **`strata-agent` now fails to boot on any lockfile with a layer that has no
+    `bundle`**, where it previously booted and mounted that layer. This is the
+    intended breaking change and it is reachable in production today: any
+    registry or lockfile carrying a layer published without a bundle stops
+    booting. There is no new opt-out — `STRATA_AGENT_ALLOW_UNVERIFIED=1` (#56)
+    already covers the deliberate case, and it takes effect earlier, by leaving
+    the verifier nil.
+  - `internal/agent`'s `Verifier == nil || BundleFetcher == nil` fail-open at
+    `agent.go:285` is **deliberately untouched**, and is still a fail-open.
+    Inverting it fails three inherited tests that construct a boot with
+    verification disabled and call it a happy path; that is a decision about this
+    package's default contract, filed as #93, not a fix to fold in here.
+  - `cmd/strata-agent`'s `s3LayerFetcher.FetchBundleJSON` still returns
+    `(nil, nil)` for an empty `Bundle` — **no behaviour change**, but that return
+    is no longer a skip anywhere, and its doc comment now says so.
+  - `strata run` is **unchanged**: `collectRunBundleFailures` already refused an
+    empty `Bundle` via `loadLocalBundle` (`cmd/strata/verify.go:172-174`), with a
+    must-reject row and an accept control asserting it
+    (`cmd/strata/run_verify_test.go:131-135`, `:174-177`). The two paths agree
+    now; before this change they disagreed, and only the agent path was wrong.
+  - `pkg/strata` and every other command are **unchanged**: nothing outside
+    `cmd/strata-agent` imports `internal/agent`.
 - **`strata-agent` refuses to boot when it cannot verify layer authenticity**
   (#56). `newCosignVerifier` returned a nil `trust.Verifier` when cosign was not
   on `PATH` or the public key could not be fetched from S3, and
@@ -40,25 +86,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     Operators who relied on the old degradation must set
     `STRATA_AGENT_ALLOW_UNVERIFIED=1`. The AMI build is the place to check: if
     cosign is not baked in, every instance was taking the old path.
-  - `internal/agent` is **unchanged** — deliberately. `verifyBundles`'s
-    `Verifier == nil` guard is still fail-open, and inverting it fails three
-    inherited tests in `internal/agent/agent_test.go` that construct a boot with
-    verification disabled and call it a happy path. That is a reviewed decision,
-    not a fix to slip in, and it is filed as such (#92, #93). What *is* closed is
-    one deployed path in: `internal/agent` is an internal package with exactly one
-    non-test `agent.Config` construction (`cmd/strata-agent/main.go`), where
-    `BundleFetcher` is never nil, so after this change no shipped caller reaches
-    the **nil-verifier** fail-open at `agent.go:270`.
+  - `internal/agent` was **unchanged by this entry** — deliberately.
+    `verifyBundles`'s `Verifier == nil` guard is still fail-open, and inverting it
+    fails three inherited tests in `internal/agent/agent_test.go` that construct a
+    boot with verification disabled and call it a happy path. That is a reviewed
+    decision, not a fix to slip in, and it is filed as such (#93). What *is*
+    closed by this entry is one deployed path in: `internal/agent` is an internal
+    package with exactly one non-test `agent.Config` construction
+    (`cmd/strata-agent/main.go`), where `BundleFetcher` is never nil, so after
+    this change no shipped caller reaches the **nil-verifier** fail-open at
+    `agent.go:285`.
 
     That is narrower than it first read, and the difference matters to anyone
-    deploying this. `verifyBundles` fails open a **second** way, which the
-    enumeration above does not touch and cannot: a layer whose `Bundle` field is
-    empty is dropped from the verify set (`agent.go:285-293`), and an empty verify
-    set returns nil. Its trigger is a property of the lockfile rather than of the
-    wiring, so it fires with a fully configured verifier and bundle fetcher and
-    **is reachable in production, with and without this change**. A publisher who
-    omits `Bundle`, or an attacker who strips it, still gets a clean boot. Tracked
-    as #92 (decision) and #93 (fix); not closed here.
+    deploying this. `verifyBundles` failed open a **second** way, which the
+    enumeration above does not touch and cannot: a layer whose `Bundle` field was
+    empty was dropped from the verify set, and an empty verify set returned nil.
+    Its trigger is a property of the lockfile rather than of the wiring, so it
+    fired with a fully configured verifier and bundle fetcher and **was reachable
+    in production, with and without this change**. A publisher who omitted
+    `Bundle`, or an attacker who stripped it, got a clean boot.
+
+    **Amended 2026-08-21:** that second fail-open is now closed — see the #92
+    entry above, which ships in the same release. This bullet is left standing
+    with its tense corrected rather than deleted, because the two changes are
+    separately reviewable and a reader tracing why the agent refuses a
+    bundle-less layer needs both halves. #93 remains open and is the only
+    fail-open left in `verifyBundles`.
   - `STRATA.md`'s layer-verification section claimed verification "is
     unconditional — there is no flag to skip verification". That was false in the
     worse direction: verification was skippable without a flag. It now documents

--- a/PROPERTIES.md
+++ b/PROPERTIES.md
@@ -14,10 +14,10 @@ Provenance for every measurement in this document unless stated otherwise:
 
 | | |
 |---|---|
-| commit | `339329fb08f2876c5d08405d25f40540f1609268` |
-| tree | `457cd8e5350336aa2fe197eed388162f267b10a2` |
-| working tree | clean at that commit; this branch adds this file, `internal/propdoc/` and `cmd/propgen/`, and changes nothing else |
-| re-derive | `git rev-parse HEAD; git rev-parse HEAD^{tree}; git status --porcelain` |
+| measured at | `339329fb08f2876c5d08405d25f40540f1609268`, tree `457cd8e5350336aa2fe197eed388162f267b10a2` |
+| refreshed for | #104, which moves `internal/agent/agent.go` — see §7 items 33–36 |
+| citations into files #104 changes | updated where they support a **live** property, pinned in the past tense to `339329fb` where they are the evidence for a **discharged** refutation |
+| re-derive | `git rev-parse HEAD; git rev-parse HEAD^{tree}; git status --porcelain`, and `go run ./cmd/propgen` for the Status column |
 
 Note on self-reference: this document is inside the tree it measures, so a
 repository-wide `grep` run after it lands will match its own prose. Every grep
@@ -143,22 +143,24 @@ is present and malformed. Propositions must be evaluated against composed
 adversaries, not one capability at a time.
 
 That nomination is no longer a prediction. `internal/agent/agent.go:285-293`
-drops any layer whose `Bundle` field is empty from the set to be verified, and an
-empty set returns success — so A1 (write the manifest) plus A5 (omit the bundle
-field) produces a clean boot with a fully configured verifier that is never
-consulted. The probe is on #92.
+**at `339329fb`** dropped any layer whose `Bundle` field was empty from the set to
+be verified, and an empty set returned success — so A1 (write the manifest) plus
+A5 (omit the bundle field) produced a clean boot with a fully configured verifier
+that was never consulted. The probe is on #92.
 
-Line numbers here and in T1/T5 are as of the commit in the provenance header.
-#104 inverts both sites and deletes `:285-293`, so this citation names the tree
-this document measures rather than the tree that will exist after that PR merges;
-§7 enumerates what to refresh, and in which order.
+**Closed by #104.** That block no longer exists; `internal/agent/agent.go:310-323`
+now collects every bundle-less layer and refuses, naming all of them. The citation
+above is retained in the past tense and pinned to the commit where the measurement
+was made, because a refutation's evidence is the tree it was taken on — renumbering
+it to a line that now refuses would make the counterexample unreproducible. §7
+records the refresh.
 
 ### 1.4 What the model cannot express — and the class that fills the gap
 
 **Five of the six fail-open paths found in this codebase need no adversary at
-all.** `internal/agent/agent.go:270` skips verification when the caller supplied
-no verifier; the historical `strata run --no-verify` disabled a check that was
-never performed (#55). No capability in §1.1 describes "the deployment's default
+all.** `internal/agent/agent.go:285` skips verification when the caller supplied
+no verifier — still open, tracked by #93; the historical `strata run --no-verify`
+disabled a check that was never performed (#55). No capability in §1.1 describes "the deployment's default
 is weaker than the operator believes", because that is not something an attacker
 *does*.
 
@@ -227,9 +229,11 @@ tier being mistaken for available.
 6. **A test that does not execute the property's site is not E1 for that
    property.** Rule 4 asks whether the *test* runs. Rule 6 asks whether the
    *line* runs. Both have been violated here. Inverting
-   `internal/agent/agent.go:285-293` leaves all seven tests in the package green
-   with zero coverage hits on the inverted statements (measurement on #93): the
-   suite is green and the change is unexecuted. Reachability is shown with a
+   `internal/agent/agent.go:285-293` **at `339329fb`** left all seven tests in the
+   package green with zero coverage hits on the inverted statements (measurement on
+   #93): the suite was green and the change unexecuted. #104 both deletes that
+   block and supplies the missing tests, so the measurement is no longer
+   reproducible on `main` — which is the point of pinning it. Reachability is shown with a
    coverage delta on the lines the property is about, not with a passing suite.
    (Added 2026-08-21; see §7.)
 7. **A documented claim that is false is not E0 — it is a refutation, and the
@@ -320,8 +324,8 @@ in §4 is many-to-many.
 
 | # | Proposition | Verdict | Basis | Status | Evidence |
 |---|-------------|---------|-------|--------|----------|
-| **I1** | *Mount integrity.* Every byte made visible in an assembled environment belongs to a layer whose content hashes to the digest recorded for it in the lockfile. | **TOO STRONG** | withdrawn — I1′, I6 | WITHDRAWN (superseded by I1′, I6) | Satisfying I1 as a universal claim over every visible byte requires abandoning two things Strata deliberately does: `packages:` installs (`internal/agent/agent.go:172`) put bytes from PyPI, conda and CRAN into the merged overlay, and Path B mounts a writable EBS upper (`MutableLayerSpec`). Neither set of bytes belongs to any layer. I1 is therefore restricted to layer-derived bytes, and I6 below covers the remainder. |
-| **I1′** | *(restriction of I1)* Every byte made visible **from a layer** hashes to that layer's recorded digest. | SOUND | E1 — `cmd/strata/layer_cache_integrity_test.go:74,123,185,249`, `internal/agent/agent_test.go:181` | ENFORCED E1 | `strata run` route: `cmd/strata/run.go:426` builds the cache path only through `spec.LayerCachePath`, and both return paths hash the file against the declared digest first (`:436`, `:481`). Witnessed by `cmd/strata/layer_cache_integrity_test.go:74 TestLayerCacheAcceptsHonestLayers` (the control, showing the harness can pass) with `:185 TestLayerCacheRejectsPlantedCacheHit`, `:123 TestLayerCacheRejectsTraversalDigest`, `:249 TestLayerCacheRejectsEmptyDigest`. Agent route: `internal/agent/agent.go:231-241` hashes every path `Fetch` returns and compares unconditionally, with no `!= ""` guard; witnessed by `internal/agent/agent_test.go:181 TestRun_SHA256Mismatch`. Domain: these two routes. |
+| **I1** | *Mount integrity.* Every byte made visible in an assembled environment belongs to a layer whose content hashes to the digest recorded for it in the lockfile. | **TOO STRONG** | withdrawn — I1′, I6 | WITHDRAWN (superseded by I1′, I6) | Satisfying I1 as a universal claim over every visible byte requires abandoning two things Strata deliberately does: `packages:` installs (`internal/agent/agent.go:178`) put bytes from PyPI, conda and CRAN into the merged overlay, and Path B mounts a writable EBS upper (`MutableLayerSpec`). Neither set of bytes belongs to any layer. I1 is therefore restricted to layer-derived bytes, and I6 below covers the remainder. |
+| **I1′** | *(restriction of I1)* Every byte made visible **from a layer** hashes to that layer's recorded digest. | SOUND | E1 — `cmd/strata/layer_cache_integrity_test.go:74,123,185,249`, `internal/agent/agent_test.go:181` | ENFORCED E1 | `strata run` route: `cmd/strata/run.go:426` builds the cache path only through `spec.LayerCachePath`, and both return paths hash the file against the declared digest first (`:436`, `:481`). Witnessed by `cmd/strata/layer_cache_integrity_test.go:74 TestLayerCacheAcceptsHonestLayers` (the control, showing the harness can pass) with `:185 TestLayerCacheRejectsPlantedCacheHit`, `:123 TestLayerCacheRejectsTraversalDigest`, `:249 TestLayerCacheRejectsEmptyDigest`. Agent route: `internal/agent/agent.go:237-247` hashes every path `Fetch` returns and compares unconditionally, with no `!= ""` guard; witnessed by `internal/agent/agent_test.go:181 TestRun_SHA256Mismatch`. Domain: these two routes. |
 | **I2** | *Cache soundness.* Content obtained from a local cache is used only after its bytes have been hashed and compared against the declared digest, on every use. Under **A2** this must hold for cache hits, not only for fresh downloads. | SOUND | E1 — `cmd/strata/layer_cache_integrity_test.go:74,185` | ENFORCED E1 | Three cache-hit sites, all routed through validation: `cmd/strata/run.go:426` + `spec.VerifyFileDigest`, `internal/registry/s3client.go:366-371`, `internal/registry/localclient.go:268-273`. Witnessed by `TestLayerCacheRejectsPlantedCacheHit` (plants different content under a correct digest and requires refusal) against `TestLayerCacheAcceptsHonestLayers` as the control. `#83` records the standing cost objection — re-hashing every hit is O(environment size) per invocation — and is a design question, not a refutation. |
 | **I3** | *Digest well-formedness.* Any value used as a digest — in a comparison, a filesystem path, or a cache key — is syntactically a SHA-256 digest before it is so used. Absent and malformed are both rejected (**A5**). | SOUND | E1 — `spec/digest_test.go:16`, `spec/digest_test.go:53` | REFUTED (2 of 3 live) | The rule exists and is enforced where it is called: `spec/digest.go:30-47 ValidateLayerDigest` requires exactly 64 lowercase hex and rejects empty explicitly, witnessed at `spec/digest_test.go:16 TestValidateLayerDigest` and `:53 TestLayerCachePathRejectsEscape`. Two sites do not call it. (a) `cmd/strata-agent/s3_fetcher.go:73` builds `filepath.Join(f.cacheDir, layer.SHA256+".sqfs")` from an unvalidated digest and `os.Rename`s into it — #81. (b) `LockFile.IsFrozen()` and `EnvironmentID()` treat any non-empty string as a digest: the repository's own `spec/spec_test.go:544` passes `SHA256: "bbbbbb"` and `internal/resolver/resolver_test.go:597` passes `AMISHA256: "sha256-ami-test123456789"`, and both tests pass. So "frozen" is satisfied by a lockfile with no digests in it. (b) (b) untracked → filed as #96. |
 | **I4** | *Path confinement.* No field of a lockfile or manifest can cause a filesystem operation outside the directory designated for it, for any field value. | SOUND | E1 — `spec/digest_test.go:53` | REFUTED (3 of 4 live) | The mechanism is understood and stated correctly in one place — `spec/digest.go:52-55`: *"`filepath.Join` calls `Clean`, which resolves `..` rather than rejecting it, so joining an unvalidated digest can name a file outside `cacheDir`. Every site that builds a layer cache path must go through here."* Executed confirmation: `filepath.Join("/var/cache/strata/layers", "../../../../etc/cron.d/evil.sqfs")` → `/etc/cron.d/evil.sqfs`. Four sites build a path from an unvalidated lockfile field: `internal/trust/verify.go:92` (`layer.ID`, and its own comment at `:90-91` asserts the opposite — #58); `internal/overlay/mount_linux.go:141` (`layer.ID` into `os.MkdirAll` then `MountSquashfs` — a **write** primitive, untracked); `internal/export/oci.go:60` (`"layer-"+lp.ID`, untracked); `cmd/strata-agent/s3_fetcher.go:73` (`layer.SHA256`, #81). Untracked pair → filed as #97. |
@@ -334,13 +338,13 @@ This group is the core of Strata's differentiating claim.
 
 | # | Proposition | Verdict | Basis | Status | Evidence |
 |---|-------------|---------|-------|--------|----------|
-| **T1** | *No unverified mount.* There exists no execution path from *layer declared in a lockfile* to *layer mounted in an assembled environment* that does not pass a successful signature verification under the trust policy in force. | **TOO WEAK** | E1 — `cmd/strata/run_verify_test.go:370,519` | REFUTED (2 of 4 live) | *The most important finding in this review.* Broken-but-satisfying implementation: ship an agent whose default policy is `allow-unverified`, and route every layer through a verifier that returns success when a layer names no bundle. Every mount then "passes a successful verification under the trust policy in force" and T1 holds — which is precisely the shape of the five fail-opens this document was written about. T1 defers its content to "the policy in force" and never says what the policy is when the operator selects nothing. It is only worth having when read together with T5's second sentence, and it should be restated to quantify over the *default* configuration (see H1, §1.4). Status under that reading: refuted at `internal/agent/agent.go:270` (nil verifier ⇒ skip) and `:285-293` (layer with `Bundle: ""` dropped from the set; empty set ⇒ success) — #92, #93. Probe 3 on #92 boots READY with a verifier that refuses every artifact, `VerifierCalled=false`. Closed on the `strata run` route by #55: `cmd/strata/run_verify_test.go:519 TestRunRun_MissingKeyIsARefusalNotASkip`, `:370 TestVerifyRunLayers_ReportsEveryFailure`. |
+| **T1** | *No unverified mount.* There exists no execution path from *layer declared in a lockfile* to *layer mounted in an assembled environment* that does not pass a successful signature verification under the trust policy in force. | **TOO WEAK** | E1 — `cmd/strata/run_verify_test.go:370,519` | REFUTED (1 of 4 live) | *The most important finding in this review.* Broken-but-satisfying implementation: ship an agent whose default policy is `allow-unverified`, and route every layer through a verifier that returns success when a layer names no bundle. Every mount then "passes a successful verification under the trust policy in force" and T1 holds — which is precisely the shape of the five fail-opens this document was written about. T1 defers its content to "the policy in force" and never says what the policy is when the operator selects nothing. It is only worth having when read together with T5's second sentence, and it should be restated to quantify over the *default* configuration (see H1, §1.4). Status under that reading: refuted at `internal/agent/agent.go:285` (nil verifier ⇒ skip — still open, #93) and, at `339329fb`, `:285-293` (layer with `Bundle: ""` dropped from the set; empty set ⇒ success — #92, **closed by #104**, which replaces the filter with a refusal naming every bundle-less layer at `:310-323`; witnessed at `internal/agent/verify_bundles_test.go:187,252,291` and `cmd/strata-agent/s3_bundle_contract_test.go:22`). Probe 3 on #92 boots READY with a verifier that refuses every artifact, `VerifierCalled=false`. Closed on the `strata run` route by #55: `cmd/strata/run_verify_test.go:519 TestRunRun_MissingKeyIsARefusalNotASkip`, `:370 TestVerifyRunLayers_ReportsEveryFailure`. |
 | **T2** | *Verification soundness.* Verification succeeds for a layer only if a signature exists, by an identity admitted by the trust policy, over the digest of the exact bytes that will be mounted. | SOUND | E1 — `cmd/strata/run_verify_test.go:466` | REFUTED | The "exact bytes" clause is the load-bearing part and it is satisfied deliberately: `cmd/strata/run.go` adds a check absent from `trust.VerifyLayer` — that the bundle attests *this lockfile's* digest — with the reason stated in its doc comment (*"a missing cosign must not be the difference between 'wrong layer's bundle' and 'accepted'"*). Witnessed by `cmd/strata/run_verify_test.go:466 TestRunRun_RefusesLayerWhoseBundleAttestsAnotherArtifact`. For the *lockfile*, no signature verification exists at all (#60), so T2 does not hold of the artifact that names the layer set. Weakness worth recording: "an identity admitted by the trust policy" is satisfied here by possession of one `--key`; there is no identity policy to admit or refuse anything. |
 | **T3** | *Transparency binding.* A transparency-log entry accepted as evidence for artifact *A* has a body that corresponds to *A*'s attestation. Under **A4**, the existence of the referenced entry is not itself evidence about *A*. | SOUND | E1 — `cmd/strata/verify_rekor_test.go:80,147,217` | REFUTED (2 of 3 live) | Discharged for the verify command by #59, which replaced a log-index existence check that discarded the bundle: `cmd/strata/verify_rekor_test.go:80 TestVerifyRekorEntries_PassesTheBundle`, with `:217 TestVerifyRekorEntries_BadIndexIsNotVerified` and `:147 TestVerifyRekorEntries_UnfetchableBundleIsAFailure` as the failing controls. Refuted on the resolver path: stage 7 holds a bundle *URI*, not bundle bytes, so it cannot compare anything (#85). Two open objections to the *evidence*, not to the proposition: #88 — the `hashedrekord` body shape is inferred from our own `Log`, so writer and verifier can be wrong together, which is rule 3's tautology at the level of a design; #86 — `TestStage7_RekorVerification` asserts a negative case its body never exercises, which is rule 6. |
 | **T4** | *Trust-anchor independence.* The root of trust used to verify artifacts is not obtained from the authority that serves those artifacts. Under **A1**, an attacker who can replace an artifact cannot also replace the material that decides who may sign it. | SOUND | none | REFUTED (2 of 2 live) | #62 — the agent fetches its cosign public key from the same S3 bucket that serves the layers, so A1 alone replaces both. #63 — `ec2runner` downloads the cosign binary itself with no checksum or signature check, which is the §1.2 clause "obtaining the verification binary is in scope under A3" paying out. |
-| **T5** | *Fail-closed.* Any inability to complete verification — absent tool, absent key, absent bundle, absent log entry, network failure, unparseable material — results in refusal. Degradation to a weaker check occurs only when a weaker policy has been explicitly selected by the operator. | SOUND | E1 — `cmd/strata/run_verify_test.go:264`, `cmd/strata-agent/cosign_verifier_test.go:127,187,249` | REFUTED (2 of 4 live) | The strongest proposition in this document: it names absence alongside invalidity, so A5 cannot slip past it, and it fixes the default in its second sentence, which is what T1 fails to do. Refuted at `internal/agent/agent.go:270` and `:285-293` (#92, #93) — an absent bundle is a skip, not a refusal. Enforced at E1 on the routes already fixed: `cmd/strata/run_verify_test.go:264 TestNewRunVerifier_NeverReturnsANilVerifier` (#55) and `cmd/strata-agent/cosign_verifier_test.go:127 TestResolveVerifier_NilVerifierOnlyWithAnExplicitOptOut`, `:187 TestAllowUnverified_DefaultsToClosed`, `:249 TestProductionPrereqs_ClosedByDefault` (#56). |
+| **T5** | *Fail-closed.* Any inability to complete verification — absent tool, absent key, absent bundle, absent log entry, network failure, unparseable material — results in refusal. Degradation to a weaker check occurs only when a weaker policy has been explicitly selected by the operator. | SOUND | E1 — `cmd/strata/run_verify_test.go:264`, `cmd/strata-agent/cosign_verifier_test.go:127,187,249` | REFUTED (1 of 4 live) | The strongest proposition in this document: it names absence alongside invalidity, so A5 cannot slip past it, and it fixes the default in its second sentence, which is what T1 fails to do. Refuted at `internal/agent/agent.go:285` (#93, still open) and, at `339329fb`, `:285-293` (#92) — an absent bundle was a skip, not a refusal. **#104 closes the #92 half**: absence is now refused at `:310-323`, witnessed at `internal/agent/verify_bundles_test.go:187,252,291` and `cmd/strata-agent/s3_bundle_contract_test.go:22`. Enforced at E1 on the routes already fixed: `cmd/strata/run_verify_test.go:264 TestNewRunVerifier_NeverReturnsANilVerifier` (#55) and `cmd/strata-agent/cosign_verifier_test.go:127 TestResolveVerifier_NilVerifierOnlyWithAnExplicitOptOut`, `:187 TestAllowUnverified_DefaultsToClosed`, `:249 TestProductionPrereqs_ClosedByDefault` (#56). |
 | **T6** | *Policy explicitness.* The trust policy under which a result was produced is recorded alongside that result, so that a verification outcome is interpretable without knowledge of the invoking environment. | **ILL-FORMED** | none | REFUTED | "Recorded alongside that result" names neither an artifact nor a lifetime. A line on stderr satisfies it on one reading and no durable record satisfies it on another, so as written it cannot be failed. Falsifiable form: *the lockfile, or an attestation deposited with it, carries a field naming the trust policy in force, and a consumer reading only the artifact can determine what was checked.* Under that form: refuted by absence. `grep -rn 'TrustPolicy\|VerifiedAt' --include='*.go' . \| grep -v _test.go` returns 0 lines, and no lockfile field records what was checked. Filed as #100. |
-| **T7** | *Command-name honesty.* A command's name and documented behaviour do not claim a stronger check than it performs. A flag that purports to disable a check disables a check that was otherwise performed. | **TOO WEAK** | E1 — `cmd/strata/run_verify_test.go:350,497` | REFUTED (1 of 4 live) | Broken-but-satisfying implementation: keep the fail-open and fix the *documentation*. T7 constrains names and docs, so the cheapest way to satisfy it is to document the weakness while leaving the command called `verify` and the behaviour unchanged — the operator's attention is displaced exactly as before. Repair: pair T7 with a requirement that a weaker check announces itself **at use time**, not only in prose. `strata run --no-verify` already meets the repaired form (`cmd/strata/run.go:184` prints the warning; `cmd/strata/run_verify_test.go:350 TestVerifyRunLayers_NoVerifyAnnouncesTheSkip` with `:497 TestRunRun_NoVerifyReachesTheMount` as its pair), and so does `STRATA_AGENT_ALLOW_UNVERIFIED` (#56). `strata verify` does not: without `--rekor` it performs presence checks only (`cmd/strata/verify.go:82-98 collectPresenceFailures`) under a name that claims verification — #60. And `verifyBundles`'s doc comment stated the skip as intended design (`internal/agent/agent.go:266-268`) — T7's broken-but-satisfying implementation occurring in the wild rather than as a hypothetical: the weakness was documented accurately and the behaviour left alone, so T7 as written was *satisfied* by the artifact that recorded the fail-open. #104 rewrites the comment and inverts the behaviour together, which is the only combination that discharges anything. |
+| **T7** | *Command-name honesty.* A command's name and documented behaviour do not claim a stronger check than it performs. A flag that purports to disable a check disables a check that was otherwise performed. | **TOO WEAK** | E1 — `cmd/strata/run_verify_test.go:350,497` | REFUTED (1 of 4 live) | Broken-but-satisfying implementation: keep the fail-open and fix the *documentation*. T7 constrains names and docs, so the cheapest way to satisfy it is to document the weakness while leaving the command called `verify` and the behaviour unchanged — the operator's attention is displaced exactly as before. Repair: pair T7 with a requirement that a weaker check announces itself **at use time**, not only in prose. `strata run --no-verify` already meets the repaired form (`cmd/strata/run.go:184` prints the warning; `cmd/strata/run_verify_test.go:350 TestVerifyRunLayers_NoVerifyAnnouncesTheSkip` with `:497 TestRunRun_NoVerifyReachesTheMount` as its pair), and so does `STRATA_AGENT_ALLOW_UNVERIFIED` (#56). `strata verify` does not: without `--rekor` it performs presence checks only (`cmd/strata/verify.go:82-98 collectPresenceFailures`) under a name that claims verification — #60. And `verifyBundles`'s doc comment stated the skip as intended design (`internal/agent/agent.go:272-283`) — T7's broken-but-satisfying implementation occurring in the wild rather than as a hypothetical: the weakness was documented accurately and the behaviour left alone, so T7 as written was *satisfied* by the artifact that recorded the fail-open. #104 rewrites the comment and inverts the behaviour together, which is the only combination that discharges anything. |
 | **T8** | *(new)* *Freshness.* A verifier can determine that the artifact set it has been given is the current one, and refuses a set that is older than a stated bound. | SOUND | none | REFUTED | Added 2026-08-21 (§7). §5 asked for group T to be checked against TUF's taxonomy; **A6 was in the model and no proposition used it.** Doing the check: nothing records a freshness threshold, an expiry, or a timestamp/snapshot role, so rollback and freeze both succeed against a genuinely signed old artifact, and `strata update` moves forward only when a human runs it. Filed as #101. |
 | **T9** | *(new)* *Set integrity.* The layer set is verified as a set, not layer by layer: a verifier refuses a combination of individually valid layers that was never attested together. | SOUND | none | REFUTED (2 of 2 live) | Added 2026-08-21 (§7). This is TUF's mix-and-match attack. The lockfile is the artifact that names the set, and no lockfile-level signature verification exists (#60), so under A1 an attacker composes any set of genuinely signed layers. |
 
@@ -464,8 +468,8 @@ moves the status of every proposition it names; nothing else does.
 | X3 | The inline software-ref form `- python@3.13` was documented and did not parse | H1 | #53 | Yes — E1, `spec/softwareref_yaml_test.go:22-24`, `spec/docsnippets_test.go` |
 | X3 | All three shipped examples name formation versions the catalog does not contain, and `go test ./examples/` passes | H1 | #70 | No |
 | R4, R5 | Stage 4 validates against one provider, stage 6 wires the edge to another; stage 4 is itself first-match | H1 | #67 | No |
-| T1, T5 | `verifyBundles` skips when the verifier is nil **and** when a layer names no bundle | A1 + A5; H1 for the nil half | #92 (decision), #93 (fix) | No |
-| T1, T5 | `BundleFetcher`'s godoc **specified** the fail-open: implementations were told to return `(nil, nil)` for a layer naming no bundle, and `verifyBundles` treated no bytes as nothing to verify. The shipped `s3LayerFetcher` conforms. A defect in an interface's *specification* is inherited by every conforming implementation, so no amount of testing the implementations finds it | H1 | #92 | No — inverted at both sites on `fix/agent-absent-bundle` (#104) with E1 evidence at `internal/agent/verify_bundles_test.go:291` and `cmd/strata-agent/s3_bundle_contract_test.go:22`, which is not this document's merge target; see §7 |
+| T1, T5 | `verifyBundles` skips when the verifier is nil **and** when a layer names no bundle | A1 + A5; H1 for the nil half | #92 (decision), #93 (fix) | Partially — the absent-bundle half is closed by #104 at `internal/agent/agent.go:310-323`, E1 at `internal/agent/verify_bundles_test.go:187,252`; the nil-verifier half at `:285` is open under #93. `Partially` counts as live, so T1 and T5 stay refuted |
+| T1, T5 | `BundleFetcher`'s godoc **specified** the fail-open: implementations were told to return `(nil, nil)` for a layer naming no bundle, and `verifyBundles` treated no bytes as nothing to verify. The shipped `s3LayerFetcher` conforms. A defect in an interface's *specification* is inherited by every conforming implementation, so no amount of testing the implementations finds it | H1 | #92 | Yes — E1, `internal/agent/verify_bundles_test.go:291` (empty bytes refused) and `cmd/strata-agent/s3_bundle_contract_test.go:22` (the shipped `s3LayerFetcher` held to the corrected contract). #104 rewrote the godoc and inverted the behaviour together |
 | T2, T7, T9 | `strata verify` and `IsSigned()` are presence checks; no lockfile verification exists | A1 | #60 | No |
 | T4 | Agent fetches its cosign public key from the bucket that serves the layers | A1 | #62 | No |
 | T4 | `ec2runner` downloads the cosign binary with no checksum or signature | A3 | #63 | No |
@@ -882,6 +886,72 @@ structurally wrong. Both are recorded here.
     `cmd/strata-agent/s3_bundle_contract_test.go:22`. The `#92 (decision), #93
     (fix)` row stays `No`: #93's nil-verifier fail-open is untouched. If #104
     merges first, the same list applies to this document before it lands.
+
+### 2026-08-21 — #103 merged; the refresh executed, and the enumeration scored
+
+#103 merged first (`3206ca4`), then this refresh, then #104. The prediction in
+item 32 above is left as written so it can be scored; it was **incomplete in one
+class and wrong in one detail**.
+
+33. **The enumeration missed every citation that shifts merely because the file
+    grew.** Item 32 listed the citations *about* the fail-open and none of the
+    four that simply live in the same file below the insertion point: I1's
+    `agent.go:172` → `:178`, I1′'s `agent.go:231-241` → `:237-247`, and two
+    historical entries in this log. Nothing in item 32's reasoning would have
+    found them, because it reasoned from *what the PR changes* rather than from
+    *what cites the file it changes*. The correct query is mechanical:
+
+    ```
+    for f in $(git diff --name-only <base>...HEAD); do
+      grep -c "$(basename $f):" PROPERTIES.md; done
+    ```
+
+    which reports 10 citations into `agent.go`, not the 4 item 32 anticipated. It
+    also surfaced 3 citations into `cmd/strata-agent/s3_fetcher.go`, a file #104
+    also edits — those turned out to need no change, because the edit is at `:130`
+    and the citations are at `:73`, but *that* was established by checking rather
+    than by assuming. This is the relocated-rule failure in its documentation
+    form: I enumerated the sites I had been thinking about, not the sites that
+    refer to what moved.
+
+34. **`:314-325` was wrong; the refusal is at `:310-323`.** Predicted by arithmetic
+    on a diff, corrected by reading the merged file. `:325` lands inside the
+    comment for the *next* branch — the no-fetched-layers case, which is
+    explicitly not the absent-bundle case — so the prediction cited a boundary
+    that would have argued against the point it was cited for.
+
+35. **Three citations were pinned in the past tense rather than renumbered**, in
+    §1.3, §2 rule 6, and T1/T5: `agent.go:285-293` at `339329fb`. A refutation's
+    evidence is the tree it was taken on, and renumbering it to the line that now
+    *refuses* would make the counterexample unreproducible — the reader would go
+    looking for a fail-open at a refusal and conclude the register was wrong. Rule
+    for future refreshes: **a citation supporting a discharged refutation is
+    pinned, not updated; a citation supporting a live property is updated.**
+
+36. **T1 and T5 each dropped one live row**, so their statuses moved from
+    `REFUTED (2 of 4 live)` to `REFUTED (1 of 4 live)` — regenerated with
+    `go run ./cmd/propgen -write`, not typed. This is the movement that was
+    invisible in the first population and is the reason the column was made
+    generated at all: the propositions correctly stay `REFUTED` (#93's
+    nil-verifier fail-open is untouched, and its row stays `No`), and the progress
+    is nonetheless legible in the column.
+
+    #104 is therefore the first change in this repository whose claimed
+    proposition movements were **checked by CI rather than reviewed by eye** — with
+    the scope of that check stated precisely, because it is narrower than it
+    sounds. Two independent mechanisms, not one:
+
+    - **The bookkeeping** is bound. Reverting the `Yes` in the `BundleFetcher` row
+      to `No`, changing nothing else, makes `propgen` report drift on T1 and T5 and
+      `TestPropertiesStatusColumnIsDerived` fail. Probed, not assumed.
+    - **The behaviour** is bound separately, by `internal/agent`'s tests.
+
+    What CI still does **not** check is that a citation names a test which actually
+    *exercises* the property — a plausible-looking `_test.go:NNN` in an evidence
+    cell is accepted as long as the suite is green. That is rule 6's question, and
+    it is answered by a coverage delta on the line, by hand, per refutation. The
+    generator removed the drift between two columns; it did not remove the need to
+    show reachability.
 
 **Placement.** This file sits at the repository root beside `STRATA.md` rather
 than under `docs/`. `CLAUDE.md` hygiene rule 1 sends documentation to `docs/`;

--- a/STRATA.md
+++ b/STRATA.md
@@ -299,10 +299,14 @@ are explicit:
   without authenticity verification, logging that it has done so (#56).
 
 What the earlier "there is no flag to skip verification" sentence obscured is that
-verification was skippable *without* a flag: the agent returned a nil verifier whenever
-cosign was missing, and the library treated a nil verifier as nothing to do. A documented
-opt-out that defaults to closed is a weaker claim than the one this paragraph used to make
-and a stronger property than the code used to have.
+verification was skippable *without* a flag, by two separate routes. The agent returned a
+nil verifier whenever cosign was missing, and the library treated a nil verifier as nothing
+to do (#56). Independently of that, a layer whose `bundle` field was empty was dropped from
+the verify set, and an empty verify set was reported as success — so omitting one field
+bought a clean boot past a fully configured verifier (#92). Both routes are now closed: the
+second refuses the layer and names it, as does a bundle fetch that yields no bytes for a
+layer that names one. A documented opt-out that defaults to closed is a weaker claim than
+the one this paragraph used to make and a stronger property than the code used to have.
 
 In every case SHA256 integrity against the lockfile is still enforced. What an opt-out
 gives up is *authenticity* — evidence about who produced the layers — which is precisely

--- a/cmd/strata-agent/s3_bundle_contract_test.go
+++ b/cmd/strata-agent/s3_bundle_contract_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/scttfrdmn/strata/spec"
+)
+
+// TestFetchBundleJSON_EmptyBundleReturnsNoBytes pins the shipped fetcher's
+// answer for a layer that names no bundle: no bytes and no error.
+//
+// This is the second door in #92. Inverting only the agent's layer filter would
+// still admit a bundle-less layer if the agent treated an empty fetch result as
+// "nothing to verify", because this is the implementation the agent is wired to
+// in production (main.go). The agent's refusal on len(data) == 0 is what makes
+// this return safe, and this test is the record of why that refusal exists —
+// so a later simplification of either side has to contend with the other.
+//
+// A nil S3 client is deliberate: reaching the client at all would falsify the
+// claim that this path short-circuits before any network use.
+func TestFetchBundleJSON_EmptyBundleReturnsNoBytes(t *testing.T) {
+	f := newS3LayerFetcherWithAPI(nil, t.TempDir())
+
+	data, err := f.FetchBundleJSON(context.Background(), spec.ResolvedLayer{
+		LayerManifest: spec.LayerManifest{ID: "python-3.11"},
+	})
+	if err != nil {
+		t.Fatalf("FetchBundleJSON with empty Bundle: unexpected error %v", err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("FetchBundleJSON with empty Bundle returned %d bytes, want 0", len(data))
+	}
+}
+
+// TestFetchBundleJSON_NamedBundleIsNotSilentlyEmpty is the control for the test
+// above: with a bundle named, the method does not return the same (nil, nil)
+// answer. Without this, the assertion "empty Bundle yields no bytes" would also
+// be satisfied by a method that always yields no bytes — which would defeat the
+// agent's refusal by making every layer look like a fetch failure.
+func TestFetchBundleJSON_NamedBundleIsNotSilentlyEmpty(t *testing.T) {
+	f := newS3LayerFetcherWithAPI(nil, t.TempDir())
+
+	data, err := f.FetchBundleJSON(context.Background(), spec.ResolvedLayer{
+		LayerManifest: spec.LayerManifest{
+			ID:     "python-3.11",
+			Bundle: "s3://strata-registry/bundles/python-3.11.json",
+		},
+	})
+	if err == nil {
+		t.Fatal("FetchBundleJSON with a named bundle and no S3 client: expected an error, got nil")
+	}
+	if len(data) != 0 {
+		t.Errorf("FetchBundleJSON returned %d bytes alongside an error, want 0", len(data))
+	}
+}

--- a/cmd/strata-agent/s3_fetcher.go
+++ b/cmd/strata-agent/s3_fetcher.go
@@ -130,8 +130,12 @@ func (f *s3LayerFetcher) Fetch(ctx context.Context, layer spec.ResolvedLayer) (s
 }
 
 // FetchBundleJSON downloads the Sigstore bundle JSON for a layer from the
-// registry and returns the raw bytes. Returns (nil, nil) when layer.Bundle is
-// empty. The caller parses the JSON with trust.ParseBundle.
+// registry and returns the raw bytes. The caller parses the JSON with
+// trust.ParseBundle.
+//
+// Returns (nil, nil) when layer.Bundle is empty. That is not a skip: the agent
+// refuses a bundle-less layer before reaching this method, and treats an empty
+// return as a verification failure if it does reach it (internal/agent, #92).
 func (f *s3LayerFetcher) FetchBundleJSON(ctx context.Context, layer spec.ResolvedLayer) ([]byte, error) {
 	if layer.Bundle == "" {
 		return nil, nil

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -39,8 +40,13 @@ type LayerFetcher interface {
 
 // BundleFetcher downloads the Sigstore bundle JSON for a layer from the
 // registry. Used alongside Verifier to perform cryptographic signature
-// verification after layers are fetched. Implementations should return
-// (nil, nil) when layer.Bundle is empty.
+// verification after layers are fetched.
+//
+// An implementation may return (nil, nil) when layer.Bundle is empty, but must
+// not rely on that being tolerated: with a Verifier configured, the agent
+// refuses a layer that names no bundle before calling this, and treats an empty
+// return for a layer that does name one as a verification failure. Returning no
+// bytes is never a way to skip verification.
 type BundleFetcher interface {
 	FetchBundleJSON(ctx context.Context, layer spec.ResolvedLayer) ([]byte, error)
 }
@@ -263,9 +269,18 @@ func (a *Agent) fetchAndVerifyLayers(ctx context.Context, lf *spec.LockFile) ([]
 	return paths, nil
 }
 
-// verifyBundles verifies the Sigstore cosign bundle for each layer in
-// parallel. Skipped when Verifier or BundleFetcher is nil, or when a layer
-// has no Bundle field. The first verification failure cancels the rest.
+// verifyBundles verifies the Sigstore cosign bundle for each fetched layer in
+// parallel. The first verification failure cancels the rest.
+//
+// Skipped entirely when Verifier or BundleFetcher is nil. That remaining
+// fail-open is tracked by #93 and is not closed here: no shipped caller reaches
+// it (cmd/strata-agent always wires both), but three inherited tests assert it
+// and inverting it is a decision about this package's default contract.
+//
+// With both configured, verification is not optional per layer. A layer that
+// names no bundle, or whose bundle fetch yields no bytes, is refused — absent
+// material is treated the same as invalid material, because a lockfile is
+// attacker-influenced input and omitting a field is cheaper than forging one.
 func (a *Agent) verifyBundles(ctx context.Context, lf *spec.LockFile, paths []overlay.LayerPath) error {
 	if a.cfg.Verifier == nil || a.cfg.BundleFetcher == nil {
 		return nil
@@ -281,13 +296,33 @@ func (a *Agent) verifyBundles(ctx context.Context, lf *spec.LockFile, paths []ov
 		err error
 	}
 
-	// Count layers that have both a local path and a bundle URI.
+	// Every fetched layer must be verifiable. A layer that names no bundle
+	// cannot be verified, and with a verifier configured that is a refusal
+	// rather than a skip: the trigger is a property of the lockfile, not of
+	// the wiring, so an attacker who can write the registry can also omit the
+	// field and reach a clean boot past a verifier that refuses everything
+	// (#92). Absent and invalid are the same answer here.
+	//
+	// Every unverifiable layer is named, not just the first, so one boot
+	// failure reports the whole set.
 	var toVerify []spec.ResolvedLayer
+	var unverifiable []string
 	for _, layer := range lf.Layers {
-		if _, ok := pathByID[layer.ID]; ok && layer.Bundle != "" {
-			toVerify = append(toVerify, layer)
+		if _, ok := pathByID[layer.ID]; !ok {
+			continue
 		}
+		if layer.Bundle == "" {
+			unverifiable = append(unverifiable, layer.ID)
+			continue
+		}
+		toVerify = append(toVerify, layer)
 	}
+	if len(unverifiable) > 0 {
+		return fmt.Errorf("agent: refusing to mount layers with no attestation bundle: %s",
+			strings.Join(unverifiable, ", "))
+	}
+	// No fetched layers at all — nothing was mounted, so there is nothing to
+	// verify. This is not the absent-bundle case, which is refused above.
 	if len(toVerify) == 0 {
 		return nil
 	}
@@ -310,8 +345,15 @@ func (a *Agent) verifyBundles(ctx context.Context, lf *spec.LockFile, paths []ov
 				cancel()
 				return
 			}
-			if data == nil {
-				results <- result{} // no bundle data — skip
+			// A fetcher that returns no bytes for a layer that names a bundle
+			// leaves the layer unverified. Skipping here would reopen the
+			// refusal above through a second door: the shipped S3 fetcher
+			// returns (nil, nil) for an empty Bundle, so a filter-only fix
+			// would still admit a bundle-less layer (#92).
+			if len(data) == 0 {
+				results <- result{fmt.Errorf("no bundle bytes for %q: layer names %q",
+					layer.ID, layer.Bundle)}
+				cancel()
 				return
 			}
 

--- a/internal/agent/verify_bundles_test.go
+++ b/internal/agent/verify_bundles_test.go
@@ -1,0 +1,343 @@
+package agent_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/scttfrdmn/strata/internal/agent"
+	"github.com/scttfrdmn/strata/internal/overlay"
+	"github.com/scttfrdmn/strata/internal/trust"
+	"github.com/scttfrdmn/strata/spec"
+)
+
+// These tests cover the fully-configured shape: both Verifier and BundleFetcher
+// non-nil, which is what cmd/strata-agent wires. The inherited tests in
+// agent_test.go all leave both nil, so none of them reach verifyBundles past its
+// first line and none of them can distinguish a refusal from a skip (#92).
+//
+// Every negative case here has a control that differs from it in exactly one
+// respect — the bundle — so a green negative cannot be explained by the fixture
+// failing an earlier check (SHA-256, fetch, mount) instead of verification.
+
+// recordingMounter reports whether the mount step was reached. FakeMounter does
+// not record its calls, and "Run returned an error" does not distinguish
+// refusing before the mount from mounting and failing afterwards.
+type recordingMounter struct {
+	mu     sync.Mutex
+	called bool
+}
+
+func (m *recordingMounter) Mount(_ []overlay.LayerPath) (*overlay.Overlay, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.called = true
+	return &overlay.Overlay{MergedPath: "/strata/env"}, nil
+}
+
+func (m *recordingMounter) wasCalled() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.called
+}
+
+// mapBundleFetcher serves bundle bytes by layer ID and records which layers it
+// was asked about. A layer ID present in Bytes with a nil value models the
+// shipped s3LayerFetcher, which returns (nil, nil) rather than an error.
+type mapBundleFetcher struct {
+	Bytes map[string][]byte
+
+	mu     sync.Mutex
+	asked  []string
+	allNil bool // when true, return (nil, nil) for every layer
+}
+
+func (f *mapBundleFetcher) FetchBundleJSON(_ context.Context, layer spec.ResolvedLayer) ([]byte, error) {
+	f.mu.Lock()
+	f.asked = append(f.asked, layer.ID)
+	f.mu.Unlock()
+	if f.allNil {
+		return nil, nil
+	}
+	return f.Bytes[layer.ID], nil
+}
+
+func (f *mapBundleFetcher) askedCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.asked)
+}
+
+// countingVerifier delegates to trust.FakeVerifier and counts calls, so a
+// passing control can assert that verification actually ran rather than that
+// nothing objected.
+type countingVerifier struct {
+	inner trust.FakeVerifier
+
+	mu    sync.Mutex
+	calls int
+}
+
+func (v *countingVerifier) Verify(ctx context.Context, artifactPath string, bundle *trust.Bundle) error {
+	v.mu.Lock()
+	v.calls++
+	v.mu.Unlock()
+	return v.inner.Verify(ctx, artifactPath, bundle)
+}
+
+func (v *countingVerifier) callCount() int {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.calls
+}
+
+// signedBundleJSON returns marshalled bundle bytes that trust.FakeVerifier
+// accepts for the file at path.
+func signedBundleJSON(t *testing.T, path string) []byte {
+	t.Helper()
+	signer := &trust.FakeSigner{NextLogIndex: 1}
+	bundle, err := signer.Sign(context.Background(), path, nil)
+	if err != nil {
+		t.Fatalf("FakeSigner.Sign(%q): %v", path, err)
+	}
+	data, err := bundle.Marshal()
+	if err != nil {
+		t.Fatalf("Bundle.Marshal: %v", err)
+	}
+	return data
+}
+
+// TestVerifyBundles_ValidBundleMounts is the control for every refusal test
+// below. The fixture is identical apart from the bundle: same layer content,
+// same matching SHA-256, same wiring. It establishes that these inputs reach
+// the mount step when — and only when — verification succeeds, so a refusal
+// elsewhere in this file cannot be attributed to the fixture.
+func TestVerifyBundles_ValidBundleMounts(t *testing.T) {
+	ctx := context.Background()
+
+	layer, path := makeLayer(t, "python-3.11", []byte("squashfs content alpha"), 1)
+	layer.Bundle = "s3://strata-registry/bundles/python-3.11.json"
+
+	lf := &spec.LockFile{ProfileName: "ml-env", Layers: []spec.ResolvedLayer{layer}}
+
+	signaler := &agent.FakeReadySignaler{}
+	mounter := &recordingMounter{}
+	verifier := &countingVerifier{}
+	fetcher := &mapBundleFetcher{Bytes: map[string][]byte{
+		layer.ID: signedBundleJSON(t, path),
+	}}
+
+	a := newAgent(t, agent.Config{
+		Source:        &agent.FakeLockfileSource{Lockfile: lf},
+		Fetcher:       &agent.FakeLayerFetcher{Paths: map[string]string{layer.ID: path}},
+		BundleFetcher: fetcher,
+		Verifier:      verifier,
+		Signaler:      signaler,
+		Mounter:       mounter,
+	})
+
+	if _, err := a.Run(ctx); err != nil {
+		t.Fatalf("Run with a valid bundle: %v", err)
+	}
+	if verifier.callCount() != 1 {
+		t.Errorf("Verify call count = %d, want 1 — the control must actually verify", verifier.callCount())
+	}
+	if !mounter.wasCalled() {
+		t.Error("Mount was not reached on the passing control")
+	}
+	if !signaler.ReadyCalled {
+		t.Error("SignalReady was not called on the passing control")
+	}
+	if signaler.FailedCalled {
+		t.Errorf("SignalFailed was called on the passing control: %v", signaler.FailedReason)
+	}
+}
+
+// TestVerifyBundles_AbsentBundleRefused is the #92 counterexample, inverted.
+// A layer that names no bundle is refused before the mount, with a verifier
+// configured, even though its content hashes correctly.
+func TestVerifyBundles_AbsentBundleRefused(t *testing.T) {
+	ctx := context.Background()
+
+	// Same content and matching digest as the control; Bundle left empty.
+	layer, path := makeLayer(t, "python-3.11", []byte("squashfs content alpha"), 1)
+	if layer.Bundle != "" {
+		t.Fatalf("fixture: Bundle should be empty, got %q", layer.Bundle)
+	}
+
+	lf := &spec.LockFile{ProfileName: "ml-env", Layers: []spec.ResolvedLayer{layer}}
+
+	signaler := &agent.FakeReadySignaler{}
+	mounter := &recordingMounter{}
+	verifier := &countingVerifier{}
+	fetcher := &mapBundleFetcher{}
+
+	a := newAgent(t, agent.Config{
+		Source:        &agent.FakeLockfileSource{Lockfile: lf},
+		Fetcher:       &agent.FakeLayerFetcher{Paths: map[string]string{layer.ID: path}},
+		BundleFetcher: fetcher,
+		Verifier:      verifier,
+		Signaler:      signaler,
+		Mounter:       mounter,
+	})
+
+	_, err := a.Run(ctx)
+	if err == nil {
+		t.Fatal("Run: expected refusal for a layer with no attestation bundle, got nil")
+	}
+	// Assert which check fired, not merely that one did: the same fixture with a
+	// bundle passes (see the control), so a SHA-256 or fetch error here would be
+	// a different defect wearing a green test.
+	if !strings.Contains(err.Error(), "no attestation bundle") {
+		t.Errorf("Run error should name the missing attestation bundle, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), layer.ID) {
+		t.Errorf("Run error should name the offending layer %q, got: %v", layer.ID, err)
+	}
+	if mounter.wasCalled() {
+		t.Error("Mount was reached for a layer with no attestation bundle")
+	}
+	if signaler.ReadyCalled {
+		t.Error("SignalReady was called despite an unverifiable layer")
+	}
+	if !signaler.FailedCalled {
+		t.Error("SignalFailed was not called on refusal")
+	}
+	if verifier.callCount() != 0 {
+		t.Errorf("Verify call count = %d, want 0 — the refusal precedes verification", verifier.callCount())
+	}
+	if fetcher.askedCount() != 0 {
+		t.Errorf("BundleFetcher was asked %d times, want 0 — nothing to fetch for an absent bundle",
+			fetcher.askedCount())
+	}
+}
+
+// TestVerifyBundles_AbsentBundleNamesEveryLayer asserts the whole unverifiable
+// set is reported, not just the first one encountered. One boot failure should
+// tell the operator every layer they have to fix.
+func TestVerifyBundles_AbsentBundleNamesEveryLayer(t *testing.T) {
+	ctx := context.Background()
+
+	signed, signedPath := makeLayer(t, "base-os", []byte("base bytes"), 1)
+	signed.Bundle = "s3://strata-registry/bundles/base-os.json"
+	bare1, bare1Path := makeLayer(t, "python-3.11", []byte("python bytes"), 2)
+	bare2, bare2Path := makeLayer(t, "cuda-12.3", []byte("cuda bytes"), 3)
+
+	lf := &spec.LockFile{
+		ProfileName: "ml-env",
+		Layers:      []spec.ResolvedLayer{signed, bare1, bare2},
+	}
+
+	signaler := &agent.FakeReadySignaler{}
+	mounter := &recordingMounter{}
+
+	a := newAgent(t, agent.Config{
+		Source: &agent.FakeLockfileSource{Lockfile: lf},
+		Fetcher: &agent.FakeLayerFetcher{Paths: map[string]string{
+			signed.ID: signedPath,
+			bare1.ID:  bare1Path,
+			bare2.ID:  bare2Path,
+		}},
+		BundleFetcher: &mapBundleFetcher{Bytes: map[string][]byte{
+			signed.ID: signedBundleJSON(t, signedPath),
+		}},
+		Verifier: &countingVerifier{},
+		Signaler: signaler,
+		Mounter:  mounter,
+	})
+
+	_, err := a.Run(ctx)
+	if err == nil {
+		t.Fatal("Run: expected refusal, got nil")
+	}
+	for _, id := range []string{bare1.ID, bare2.ID} {
+		if !strings.Contains(err.Error(), id) {
+			t.Errorf("Run error should name unverifiable layer %q, got: %v", id, err)
+		}
+	}
+	if mounter.wasCalled() {
+		t.Error("Mount was reached with unverifiable layers in the set")
+	}
+}
+
+// TestVerifyBundles_EmptyBundleBytesRefused closes the second door. Inverting
+// the filter alone is not enough: the shipped s3LayerFetcher returns
+// (nil, nil) for an empty Bundle, so a fetcher answering with no bytes for a
+// layer that does name a bundle must also be a refusal, not a skip.
+func TestVerifyBundles_EmptyBundleBytesRefused(t *testing.T) {
+	ctx := context.Background()
+
+	layer, path := makeLayer(t, "python-3.11", []byte("squashfs content alpha"), 1)
+	layer.Bundle = "s3://strata-registry/bundles/python-3.11.json"
+
+	lf := &spec.LockFile{ProfileName: "ml-env", Layers: []spec.ResolvedLayer{layer}}
+
+	signaler := &agent.FakeReadySignaler{}
+	mounter := &recordingMounter{}
+	verifier := &countingVerifier{}
+
+	a := newAgent(t, agent.Config{
+		Source:        &agent.FakeLockfileSource{Lockfile: lf},
+		Fetcher:       &agent.FakeLayerFetcher{Paths: map[string]string{layer.ID: path}},
+		BundleFetcher: &mapBundleFetcher{allNil: true},
+		Verifier:      verifier,
+		Signaler:      signaler,
+		Mounter:       mounter,
+	})
+
+	_, err := a.Run(ctx)
+	if err == nil {
+		t.Fatal("Run: expected refusal when the bundle fetch yields no bytes, got nil")
+	}
+	if !strings.Contains(err.Error(), "no bundle bytes") {
+		t.Errorf("Run error should name the empty bundle fetch, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), layer.ID) {
+		t.Errorf("Run error should name the offending layer %q, got: %v", layer.ID, err)
+	}
+	if mounter.wasCalled() {
+		t.Error("Mount was reached for a layer whose bundle fetch returned no bytes")
+	}
+	if signaler.ReadyCalled {
+		t.Error("SignalReady was called despite an unverified layer")
+	}
+	if !signaler.FailedCalled {
+		t.Error("SignalFailed was not called on refusal")
+	}
+	if verifier.callCount() != 0 {
+		t.Errorf("Verify call count = %d, want 0 — no material to verify", verifier.callCount())
+	}
+}
+
+// TestVerifyBundles_NoLayersIsNotAbsentBundle distinguishes the two zero cases.
+// An empty lockfile has nothing to verify and boots; a lockfile with layers and
+// no bundles does not. Without this, the refusal could be satisfied by an
+// implementation that refuses whenever the verify set is empty.
+func TestVerifyBundles_NoLayersIsNotAbsentBundle(t *testing.T) {
+	ctx := context.Background()
+
+	lf := &spec.LockFile{ProfileName: "empty-env", Layers: nil}
+
+	signaler := &agent.FakeReadySignaler{}
+	verifier := &countingVerifier{}
+
+	a := newAgent(t, agent.Config{
+		Source:        &agent.FakeLockfileSource{Lockfile: lf},
+		Fetcher:       &agent.FakeLayerFetcher{Paths: map[string]string{}},
+		BundleFetcher: &mapBundleFetcher{},
+		Verifier:      verifier,
+		Signaler:      signaler,
+		Mounter:       &recordingMounter{},
+	})
+
+	if _, err := a.Run(ctx); err != nil {
+		t.Fatalf("Run with no layers and a verifier configured: %v", err)
+	}
+	if !signaler.ReadyCalled {
+		t.Error("SignalReady was not called for an empty lockfile")
+	}
+	if verifier.callCount() != 0 {
+		t.Errorf("Verify call count = %d, want 0 for an empty lockfile", verifier.callCount())
+	}
+}


### PR DESCRIPTION
## What this is

`internal/agent.verifyBundles` dropped any layer whose `Bundle` field was empty
from the verify set, then returned success on an empty verify set. The trigger is
a property of the lockfile, not of the wiring, so it fired in the fully
configured shape `cmd/strata-agent` always wires: a publisher who omitted
`bundle`, or an attacker with registry write who stripped it, booted clean past a
verifier that would have refused every layer it was actually shown.

Closes the second of the two fail-opens enumerated on #92. Does **not** touch
#93.

## Propositions this PR moves

Against `PROPERTIES.md` as committed on `docs/properties` (5a8695d, PR #103 —
not yet merged; see *Merge-order hazard* below).

| Proposition | From | To | What changed |
|---|---|---|---|
| **T5** *Fail-closed* | SOUND / REFUTED — two counterexamples: `agent.go:270` (nil verifier ⇒ skip) and `:285-293` (absent bundle ⇒ dropped ⇒ empty set ⇒ success), both #92/#93 | SOUND / **still REFUTED** — one counterexample discharged at E1, one live | The absent-bundle counterexample is discharged with evidence. The nil-verifier one (#93) is untouched, and by proof-standard rule 5 one live counterexample keeps the status at REFUTED. T5 additionally *gains* an E1 enforcement on the agent route it did not have. |
| **T1** *No unverified mount* | **TOO WEAK** / REFUTED, same two counterexamples | **TOO WEAK** (unchanged) / **still REFUTED** | Same discharge, same remaining counterexample. The *verdict* does not move at all: T1's weakness is that it quantifies over "the policy in force" rather than the default, and closing a concrete instance does not repair a proposition that defers its content to a definition the implementation controls. |
| **T7** *Command-name honesty* | **TOO WEAK** / ENFORCED E1 (flags) / REFUTED (`strata verify`) | unchanged, minus one cited instance | The row's last sentence — "`verifyBundles`'s doc comment still states the skip as intended design (`agent.go:266-268`)" — is discharged: the comment now states the refusal and names #93 as the remainder. T7's REFUTED half is `strata verify` (#60) and is untouched. |
| **I1′**, **I6**, **P3**, everything in R / B / X | — | unchanged | Integrity (SHA-256 vs manifest) was already unconditional on this path and is not what this PR touches. |

**Register movement:** the #92 row moves to *discharged*, with the E1 evidence
below. The #93 row does not.

### Finding about the document (phase 2's actual point)

The register keys refutations on (proposition, counterexample); the Status column
is a single independently-edited field. T1 and T5 each carry two counterexamples,
so discharging one moves **nothing** in the status column and the whole movement
lives in prose. Stating this PR's effect cleanly required reading the evidence
cell, not the status cell.

That is a defect in the document's shape, not in this PR: **Status should be
derived from the register, not maintained beside it.** Proposed amendment for
`PROPERTIES.md` — a proposition's status is `REFUTED` iff it has an undischarged
register row, and the Status cell carries the count (`REFUTED (1 of 2 live)`).
Filed rather than fixed here, because it changes every row of a document that is
under review in PR #103.

## The two sites, and why one was not enough

Inverting the layer filter alone leaves the hole open through a second door:

- `BundleFetcher`'s contract *documented* `(nil, nil)` for an empty bundle;
- the shipped `s3LayerFetcher.FetchBundleJSON` does exactly that;
- the verify goroutine treated a fetch that produced no bytes as nothing to
  verify.

So a filter-only fix would still admit a bundle-less layer in the shipped
configuration. Both sites are inverted. Both refusals name the **whole**
unverifiable set rather than the first member found, so one boot failure reports
everything an operator has to fix.

`agent.go:285` — `Verifier == nil || BundleFetcher == nil` — is deliberately
untouched. That is #93: inverting it fails three inherited tests that construct a
verification-disabled boot and call it a happy path, which is a decision about
this package's default contract.

## Reachability

CI runs, with no `-run` filter:

```
$ grep -n "go test" .github/workflows/ci.yml
25:        run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
```

`./...` includes `internal/agent` and `cmd/strata-agent`, so the new tests are
executed, not merely compiled. Evidence tier E1, not E0.

## Coverage delta on the changed lines

Baseline is `origin/main` (339329fb) in a clean worktree; after is this head.
Both `go test -race -coverprofile=... -covermode=atomic ./internal/agent/... ./cmd/strata-agent/...`.

```
internal/agent      58.2%  ->  81.3%
cmd/strata-agent    44.9%  ->  47.5%
```

Per-block counts inside `verifyBundles` — the number after each block is its hit
count.

**Baseline — every block past the nil-verifier guard is zero:**

```
269.104,270.57  1  3     <- function entry
270.57,272.3    1  3     <- return nil (the #93 fail-open); the inherited suite stops here
280.2,286.34    3  0
286.34,287.60   1  0     <- the absent-bundle filter: never executed
287.60,289.4    1  0
291.2,291.24    1  0
313.4,313.19    1  0     <- if data == nil: never executed
313.19,316.5    2  0     <- the skip: never executed
325.4,325.72    1  0     <- Verify was never called by any test
```

**After — the inverted branches are taken:**

```
314.3,314.25    1  6     <- if layer.Bundle == ""     (evaluated 6x)
314.25,316.12   2  3     <- collected as unverifiable (taken 3x)
320.2,320.27    1  5     <- if len(unverifiable) > 0
320.27,323.3    1  2     <- the refusal                (taken 2x)
326.2,326.24    1  3     <- if len(toVerify) == 0
326.24,328.3    1  1     <- empty-lockfile return      (taken 1x)
353.4,353.22    1  2     <- if len(data) == 0          (evaluated 2x)
353.22,358.5    3  1     <- the empty-bytes refusal    (taken 1x)
367.4,367.72    1  1     <- Verifier.Verify is now actually called
373.4,373.23    1  1     <- and succeeds on the control
```

Still zero after this PR, and not claimed otherwise: the bundle-fetch error path
(`343.18,347.5`), the parse-error path (`361.18,365.5`), the verify-failure path
(`367.72,371.5`), and the fetched-map-miss `continue` (`311.39,312.12`). Those are
pre-existing paths this PR does not add tests for.

## Revert-the-line check

Each inverted site reverted individually, on top of this commit, tests re-run,
then `git checkout --` (dirty count back to 0 both times):

| Reverted | Goes red |
|---|---|
| `if layer.Bundle == ""` collects → reverted to `continue` | `TestVerifyBundles_AbsentBundleRefused` (verify_bundles_test.go:187) and `TestVerifyBundles_AbsentBundleNamesEveryLayer` (:252), both on `err == nil` — a dropped layer is never fetched, so site 2 does not catch it |
| `if len(data) == 0` refusal → reverted to `if data == nil { skip }` | `TestVerifyBundles_EmptyBundleBytesRefused` (:291) only |

The sites are independently load-bearing and each is pinned by a distinct
assertion. Under both mutations the **inherited** suite stayed green — which is
the same measurement #92 records, now reproduced from the other direction.

## Controls

Every negative case has a control differing in exactly one respect — the bundle:

- `TestVerifyBundles_ValidBundleMounts` — same layer content, same matching
  SHA-256, same wiring, valid bundle: `Run` returns nil, `Verify` call count is
  asserted `== 1` (not merely "nothing objected"), the mount is reached, and
  `SignalReady` fires. Without it, a refusal here could be the fixture failing
  SHA-256, fetch, or mount instead of verification.
- `TestVerifyBundles_NoLayersIsNotAbsentBundle` — distinguishes the two zero
  cases. Without it, the refusal would also be satisfied by an implementation
  that refuses whenever the verify set is empty.
- `TestFetchBundleJSON_NamedBundleIsNotSilentlyEmpty` — control for the shipped
  fetcher's `(nil, nil)` contract. Without it, "empty `Bundle` yields no bytes"
  would also be satisfied by a method that always yields no bytes.

Assertions match the authenticity-specific message (`no attestation bundle`,
`no bundle bytes`) and the offending layer ID, not `err != nil`. A recording
mounter is used because `FakeMounter` does not record its calls, and "`Run`
returned an error" does not distinguish refusing before the mount from mounting
and failing after.

## Sibling path: no change needed

`strata run` already refused this: `collectRunBundleFailures` →
`loadLocalBundle` returns `empty Bundle field: nothing to verify the signature
against` (`cmd/strata/verify.go:172-174`), asserted by the must-reject row
`cmd/strata/run_verify_test.go:131-135` with the accept control at `:174-177`.
The two paths disagreed before this PR and only the agent path was wrong.

## Correction completeness (0b)

Sites asserting the corrected claim, enumerated from
`grep -rn "285-293\|empty Bundle\|no Bundle\|bundle-less\|absent bundle" --include='*.md' --include='*.go' .`
and `grep -rn "#92\|#93" --include='*.md' --include='*.go' .`:

- `internal/agent/agent.go` — `verifyBundles` and `BundleFetcher` doc comments
  rewritten; both previously described the skip as intended design.
- `cmd/strata-agent/s3_fetcher.go` — `FetchBundleJSON` doc comment now says its
  `(nil, nil)` is not a skip.
- `CHANGELOG.md` — the #56 entry asserted this path was still live and ships in
  the **same** release as this fix. Tense corrected and a **dated amendment
  (2026-08-21)** added rather than a silent edit; the bullet is kept because a
  reader tracing why the agent refuses a bundle-less layer needs both halves.
- `STRATA.md` — the "skippable *without* a flag" paragraph named only the
  nil-verifier route. It now names both and states which is closed.
- `CHANGELOG.md:530` (a released section) describes `FetchBundleJSON` returning
  `(nil, nil)`. Still true; not touched.
- `internal/trust/trust_test.go:287`, `cmd/strata/verify.go:26,:91,:173` — about
  the `run`/`verify` paths, already correct.

## Merge-order hazard (0e)

**PROPERTIES.md in PR #103 cites `agent.go:270` and `agent.go:285-293`.** This PR
deletes the code at `:285-293` and moves the nil-verifier guard to `:285`. The two
PRs touch no common line, so **nothing will report a conflict** and merge order
alone decides whether #103's citations are true.

Verified against the tree this PR merges into (`origin/main` 339329fb, re-fetched
2026-08-21T21:46:09Z): #103 is not merged, so this PR's prose is correct as
written. Required follow-up, whichever order is chosen: after both land, T1's,
T5's and T7's evidence cells in `PROPERTIES.md` need re-derived line numbers and
the #92 register row needs marking discharged. Not done here — it would put a
`PROPERTIES.md` edit in a PR that is not the `PROPERTIES.md` PR.

## Checks

- `gofmt -l .` → no output; `go vet ./...` → clean; `go test -race ./...` → all
  packages ok; `golangci-lint run` → `0 issues.`
- Local `golangci-lint` is **2.13.0** (go1.26.6); CI pins **v2.11.3**
  (`.github/workflows/ci.yml:88-90`). Neither run is evidence for the other.
- No inherited test file modified — both test files are new
  (`git cat-file -e origin/main:<path>` fails for both). No test deleted or
  skipped.
- Provenance for every measurement above: tree
  `/Users/scttfrdmn/src/strata-recon/strata`, head `f24a551`, dirty count 0,
  go1.26.7 darwin/arm64.

## Closing references: deliberately empty

```
$ gh pr view 104 --json closingIssuesReferences
{"closingIssuesReferences":[]}
```

That is intended, and no closing keyword is used. #92 is a decision request
covering **both** fail-opens — (a) nil verifier and (b) absent bundle — and this
PR closes only (b). #93 is the fix issue for (a) and requires rewriting the three
inherited fixtures, which the standing constraint for this work forbids. Both
issues stay open; the reconciliation comment on #92 records which half is
discharged.

What #92 *has* settled by being implemented: its own framing said closing these
"requires rewriting three inherited tests". For (b) that turned out to be false —
(b) closes with the three fixtures untouched, because they configure no
`Verifier` and return at `agent.go:285` before reaching either inverted site. That
measurement is what option 2 rested on, and the green suite here is it holding
rather than a claim that it would.
