### PR TITLE
fix(ci): the fuzz non-vacuity floor scales with duration (#125)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -79,9 +79,28 @@ jobs:
       # badge level from a night of real searching. So non-vacuity is asserted
       # before the search result is read, and asserted first because a vacuous
       # green is worse than a crasher: a crasher gets fixed.
+      # The floor below is derived from the requested duration rather than being a
+      # constant, because a constant floor detects only one of the two failure
+      # modes its own error message names. Measured: run 32546861518, dispatched
+      # from main at -fuzztime=120s, did 3,249,288 execs at 27,305/sec. The same
+      # target does 236,367/sec locally, so the runner is 8.7x slower. Against
+      # that rate the old constant floor of 100,000 was 3.7 seconds of search —
+      # 0.61% of a 600s nightly. It could catch a search that never started, and
+      # could not catch a search that ran its full window at 1/30th throughput,
+      # which is what a regressed generator looks like. See #125.
+      #
+      # MIN_EXECS_PER_SEC is set an order of magnitude below the measured rate on
+      # purpose: the floor exists to catch collapse, not to track performance. At
+      # 2000/sec the nightly floor is 1,200,000 — 12x tighter than the constant it
+      # replaces and still 13.7x below measured throughput, so a slower runner or
+      # a heavier generator does not produce a false failure. If this ever trips,
+      # it is evidence about the run or about the generator; it is not a reason to
+      # lower the floor to whatever was observed.
       - name: Assert the search actually ran
         env:
-          MIN_EXECS: "100000"
+          FUZZTIME: ${{ inputs.fuzztime || '600s' }}
+          MIN_EXECS_PER_SEC: "2000"
+          MIN_EXECS_ABSOLUTE: "100000"
         run: |
           set -euo pipefail
 
@@ -92,6 +111,49 @@ jobs:
             exit 1
           fi
 
+          # Derive the floor from what was asked for. Only single-unit integer
+          # durations and -fuzztime's Nx exec-count form are accepted; anything
+          # else exits non-zero rather than falling back to a default. A
+          # non-vacuity check that silently guesses its own threshold is the
+          # defect this step exists to prevent, one level up.
+          is_digits() { case "$1" in ''|*[!0-9]*) return 1 ;; *) return 0 ;; esac; }
+          floor=""
+          case "$FUZZTIME" in
+            *x)
+              # -fuzztime=Nx is a count of executions, not a duration, so it is
+              # the floor. Note the untreated edge: for a very small N, go may
+              # finish before printing any "execs:" line at all, and the
+              # no-exec-count branch below fires. Nobody dispatches a
+              # hundred-execution search as a property check.
+              n="${FUZZTIME%x}"
+              is_digits "$n" || { echo "::error::FUZZTIME='$FUZZTIME' is not an integer exec count."; exit 1; }
+              floor="$n"
+              basis="an explicit exec count of $n"
+              ;;
+            *h) n="${FUZZTIME%h}"; is_digits "$n" || { echo "::error::FUZZTIME='$FUZZTIME' is not an integer number of hours."; exit 1; }; secs=$((n * 3600)) ;;
+            *m) n="${FUZZTIME%m}"; is_digits "$n" || { echo "::error::FUZZTIME='$FUZZTIME' is not an integer number of minutes."; exit 1; }; secs=$((n * 60)) ;;
+            # Note that 'Nms' lands here, not in the *m arm, since it ends in 's'.
+            # Sub-second windows are rejected rather than supported: a floor
+            # derived from them would be smaller than one scheduler tick.
+            *s) n="${FUZZTIME%s}"; is_digits "$n" || { echo "::error::FUZZTIME='$FUZZTIME' is not an integer number of seconds (note: 'ms' is not supported)."; exit 1; }; secs="$n" ;;
+            *)
+              echo "::error::FUZZTIME='$FUZZTIME' has no recognised unit. Use a single-unit"
+              echo "integer duration (600s, 30m, 1h) or an exec count (5000x). Compound"
+              echo "durations like 10m30s and fractional ones like 1.5h are rejected"
+              echo "deliberately: this step will not guess the floor it is enforcing."
+              exit 1
+              ;;
+          esac
+
+          if [ -z "$floor" ]; then
+            floor=$((secs * MIN_EXECS_PER_SEC))
+            basis="${secs}s at a floor of ${MIN_EXECS_PER_SEC} execs/sec"
+            if [ "$floor" -lt "$MIN_EXECS_ABSOLUTE" ]; then
+              floor="$MIN_EXECS_ABSOLUTE"
+              basis="$basis, raised to the absolute floor of $MIN_EXECS_ABSOLUTE"
+            fi
+          fi
+
           # The last reported cumulative exec count. Absent entirely if the
           # target failed to build or the corpus baseline never completed.
           execs="$(sed -n 's/.*execs: \([0-9]*\).*/\1/p' fuzz.log | tail -1)"
@@ -99,13 +161,14 @@ jobs:
             echo "::error::fuzz.log reports no exec count at all — the search did not start."
             exit 1
           fi
-          if [ "$execs" -lt "$MIN_EXECS" ]; then
-            echo "::error::Only $execs executions (floor $MIN_EXECS). The search started but"
-            echo "covered too little ground to count as one. Check for an early crash or a"
-            echo "generator that rejects most inputs."
+          if [ "$execs" -lt "$floor" ]; then
+            echo "::error::Only $execs executions against a floor of $floor ($basis)."
+            echo "The search ran but covered far less ground than its duration implies."
+            echo "Check for an early crash, a generator that rejects most inputs, or a"
+            echo "throughput regression. Do not lower the floor to match the observation."
             exit 1
           fi
-          echo "search executed $execs inputs"
+          echo "search executed $execs inputs (floor $floor — $basis)"
 
       - name: Upload crashers
         if: always() && steps.search.outputs.search_rc != '0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -475,7 +475,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     printing only `testing: warning: no fuzz tests to fuzz` and then `PASS`. A
     renamed target would leave the nightly job green forever while searching
     nothing. The job fails on that warning, on a missing exec count, and on an
-    exec count below a floor.
+    exec count below a floor that **scales with the requested duration** (#125).
+
+    The floor was a constant when the workflow shipped, and dispatching the
+    workflow — rather than reading its green — is what showed the constant was
+    the wrong shape. Run `32546861518` at `-fuzztime=120s` did **3,249,288
+    executions at 27,305/sec**, against 236,367/sec for the same target locally:
+    the runner is 8.7x slower, so the constant floor of 100,000 amounted to 3.7
+    seconds of search and 0.61% of a 600-second nightly. It could detect a search
+    that never started; it could not detect one that ran its full window at a
+    thirtieth of throughput, which is what its own error message claimed to
+    catch and what a regressed generator looks like. Replayed against a synthetic
+    log of 140,000 executions over ten minutes, the old step exits 0.
+
+    **What changes per consumer**, enumerated from the workflow's two entry
+    points (`on: schedule` and `on: workflow_dispatch`):
+    - **The nightly schedule** now requires 1,200,000 executions rather than
+      100,000 — 12x tighter, and still 13.7x below measured throughput, so a
+      slower runner does not manufacture a failure.
+    - **A manual dispatch** has its floor derived from the `fuzztime` input:
+      `seconds x 2000`, with 100,000 retained as an absolute floor for short
+      windows, and `Nx` treated as the execution count it is. A `fuzztime` that
+      does not parse to integer seconds — `10m30s`, `1.5h`, `600ms` — now fails
+      the job instead of falling back to a default, because a non-vacuity check
+      that guesses its own threshold is the defect one level up.
+
+    If this floor ever trips it is evidence about the run or the generator, not a
+    reason to lower it to what was observed.
 
   Crashers are reported as an artifact rather than auto-committed, and belong
   under `spec/testdata/fuzz/<Target>/` so the ordinary CI job replays them as


### PR DESCRIPTION
Closes #125.

## How this was found

The approval condition on #119 was: *dispatch `fuzz.yml` from `main` after merge, assert the run count is nonzero, and read a real exec count from the log — until that happens the workflow is a file, not a check.* Discharging it is what produced this fix. The workflow was green; the number underneath it was the finding.

Run [`32546861518`](https://github.com/scttfrdmn/strata/actions/runs/32546861518), `-fuzztime=120s`:

```
fuzz: elapsed: 2m0s, execs: 3249288 (27305/sec), new interesting: 67 (total: 74)
search executed 3249288 inputs
```

**27,305 execs/sec on the runner, against 236,367/sec locally — 8.7x slower.** That is the number the floor should have been set against, and was not.

## The defect

The floor was the constant `100000`, independent of `-fuzztime`:

| | expected execs | old floor as % | old floor as seconds of search |
|---|---|---|---|
| nightly `600s` | ~16,383,000 | 0.61% | 3.7s |
| dispatched `120s` | ~3,276,600 | 3.05% | 3.7s |

The step said:

> Only $execs executions (floor $MIN_EXECS). **The search started but covered too little ground to count as one.**

A constant floor detects a search that never started. It cannot detect the mode the message names — a search that starts, runs its whole window, and covers almost nothing. That is not a hypothetical: a generator regression that cut throughput 30x clears 100,000 in the first four seconds and reports green for the remaining 596.

Shown rather than argued. The step body at `2c11e19`, replayed against a synthetic log of 140,000 executions over ten minutes:

```
OLD step on the stall log: rc=0
search executed 140000 inputs
```

So this is the vacuity class the step was written to prevent, reappearing one level down — a check whose failure message asserts a property it does not test.

## The change

`floor = seconds(fuzztime) * 2000`, `100000` kept as an absolute floor for short windows, `-fuzztime=Nx` using `N` directly, and any duration that does not parse to integer seconds failing the job rather than defaulting.

The nightly floor becomes **1,200,000 — 12x tighter than the constant, still 13.7x below measured throughput**, so a slower runner or a heavier generator does not manufacture a failure. The rate is deliberately an order of magnitude under what was measured: the floor catches collapse, it does not track performance. Per the standing rule, if it trips that is evidence about the run or the generator and never a reason to lower it to what was observed.

Refusing unparseable durations is the load-bearing detail. A non-vacuity check that silently guesses its own threshold is exactly the defect above, so `10m30s`, `1.5h` and `600ms` exit 1 with a message naming the accepted forms.

## Verification

The step body was extracted from the YAML with a parser (so what was tested is what runs, not a paraphrase), GitHub expressions substituted, and its **exit code** asserted across eleven cases:

```
ok       rc=0 (want 0)  measured run, 120s as dispatched
ok       rc=0 (want 0)  same log as a 600s nightly
ok       rc=1 (want 1)  full window at 1/100 throughput      <- old step: rc=0
ok       rc=1 (want 1)  vacuous: no target matched
ok       rc=1 (want 1)  no exec count at all
ok       rc=0 (want 0)  explicit exec-count form
ok       rc=1 (want 1)  compound duration
ok       rc=1 (want 1)  fractional duration
ok       rc=1 (want 1)  milliseconds
ok       rc=1 (want 1)  garbage
ok       rc=1 (want 1)  empty

ALL EXIT CODES AS EXPECTED
```

Exit codes, not log text: a check that passes and one that fails have to be distinguishable by status, since that is all Actions reads.

## Not covered

`-fuzztime=Nx` with a very small `N` may finish before `go test` prints any `execs:` line, in which case the pre-existing "the search did not start" branch fires. Left unhandled and commented in place rather than papered over — a hundred-execution search is not a property check.

## Note

CI does not exercise this workflow — `fuzz.yml` has no `pull_request` trigger by design, and `grep fuzz .github/workflows/ci.yml` is empty. So a green CI run on this PR says the repo still builds and tests, not that the change works; the eleven-case harness above is the evidence for the change itself. The workflow will be dispatched from `main` after merge to confirm the new floor passes against a real search, same condition as #119.