### PR TITLE
test(agent): enumerate the boot verification decision surface (112 cells)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -365,6 +365,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same exit status.
 
 ### Added
+- **The agent's boot verification decision surface is enumerated, not sampled**
+  (#128). All 112 combinations of `Config.Verifier` (nil, accepts-anything,
+  refuses-anything, content-bound) × the bundle bytes a fetch yields (no fetcher,
+  valid for this layer, valid for *other* content, `(nil, nil)`, non-JSON,
+  well-formed JSON with the wrong media type, fetch error) × `layer.Bundle`
+  (empty, named) × the layer's content against its declared `SHA256` (match,
+  mismatch) now run as cells, each asserting which check fired, whether `Mount`
+  was reached, and how many times the verifier was called.
+
+  This closes a gap that a green suite and 81.3% coverage both concealed: four of
+  the twenty-nine statement blocks in `verifyBundles` were unreached by the whole
+  module's tests, one of them `Verifier.Verify` returning an error. The verifier
+  exists in order to be able to refuse, and no test had ever made it do so
+  through the agent. Three of the four are now executed (the fourth, a `pathByID`
+  miss at `internal/agent/agent.go:311`, is unreachable through `Run`:
+  `fetchAndVerifyLayers` returns a path for every layer or an error). Package
+  coverage 81.3% → 86.7%.
+
+  **20 of the 112 cells reach the mount with nothing verified**, because a nil
+  `Verifier` or a nil `BundleFetcher` still skips verification entirely (#93(a),
+  open). Those cells assert today's behaviour — including that `Mount` was
+  reached and `Verify` was never called — and fail with instructions when the
+  hole closes, so the enumeration cannot quietly certify the fail-open it was
+  built to measure.
+
+  No production behaviour changes: this is test-only, and the count of fail-open
+  cells is the measurement, not a new tolerance.
 - **Documented profile snippets are checked mechanically** (#53). Every fenced
   YAML block in the repository's markdown with a top-level `software:` or
   `defaults:` key must unmarshal as a profile. Blocks are matched by shape rather

--- a/internal/agent/boot_matrix_test.go
+++ b/internal/agent/boot_matrix_test.go
@@ -1,0 +1,604 @@
+package agent_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/scttfrdmn/strata/internal/agent"
+	"github.com/scttfrdmn/strata/internal/trust"
+	"github.com/scttfrdmn/strata/spec"
+)
+
+// This file enumerates the boot sequence's verification decision surface instead
+// of sampling it. The space is finite and small, so enumeration is available —
+// and it is strictly stronger than sampling, because a sample cannot report which
+// cells it missed. Issue #128 has the derivation; the short version:
+//
+//	Config.Verifier   nil | accepts-anything | refuses-anything | content-bound   (4)
+//	bundle bytes      no fetcher | valid-for-this | valid-for-other | (nil,nil)
+//	                  | non-JSON | wrong media type | fetch error                 (7)
+//	layer.Bundle      "" | "s3://..."                                             (2)
+//	content vs SHA256 match | mismatch                                            (2)
+//
+// Two corrections came out of deriving that list rather than estimating it.
+//
+// `cached` is deliberately absent. LayerFetcher.Fetch returns a path; a cache hit
+// and a fresh download are indistinguishable to Run, and verifyBundles iterates
+// lf.Layers rather than fetch provenance, so a cache hit cannot skip verification
+// by construction. That question belongs to cmd/strata-agent.s3LayerFetcher as one
+// assertion, not as a doubling of this table.
+//
+// The bundle *bytes* are their own dimension, separate from the verifier's
+// disposition. Splitting them makes the substitution case — a valid bundle for
+// different content — an ordinary cell of the product rather than a special case
+// somebody has to think of.
+//
+// The expected outcome per cell comes from the precedence ladder in wantFor(),
+// authored from the contract (#92, #93, and the interface documentation) rather
+// than from reading verifyBundles. The evidence that it is not a paraphrase of the
+// implementation is that it *disagrees* with it: the ladder says a boot with no
+// verifier is a refusal, and today it boots. Those cells carry knownOpen and
+// assert today's behaviour, so they fail loudly when the hole closes instead of
+// silently certifying it.
+
+// bootOutcome is the reason the boot sequence gave, or reasonBoots.
+//
+// Each value carries the substring the error must contain, so a cell asserts
+// *which* check fired rather than merely that one did. A test that only asserts
+// "Run returned an error" passes when the fixture fails an earlier step for an
+// unrelated reason, which is the defect #92's probe 3 was built to expose.
+type bootOutcome string
+
+const (
+	reasonBoots        bootOutcome = ""
+	reasonDigest       bootOutcome = "SHA256 mismatch"
+	reasonNoVerifier   bootOutcome = "no way to verify" // intended by #93(a); not implemented
+	reasonAbsentBundle bootOutcome = "no attestation bundle"
+	reasonFetchBundle  bootOutcome = "fetching bundle"
+	reasonEmptyBytes   bootOutcome = "no bundle bytes"
+	reasonParse        bootOutcome = "parsing bundle"
+	reasonVerify       bootOutcome = "verifying layer"
+)
+
+// ladderOutcomes is the manifest of arms wantFor() can return. The table asserts
+// that every one of these fires for at least one cell: an expectation arm no cell
+// reaches is an unsearched branch wearing a green table, the same defect class as
+// a fuzz floor nothing can trip (#125). Asserting the *set* rather than the count
+// is deliberate — a count matches while the members differ.
+var ladderOutcomes = []bootOutcome{
+	reasonBoots,
+	reasonDigest,
+	reasonNoVerifier,
+	reasonAbsentBundle,
+	reasonFetchBundle,
+	reasonEmptyBytes,
+	reasonParse,
+	reasonVerify,
+}
+
+// knownOpenCells is the number of cells that reach the mount with no authenticity
+// verification because Verifier or BundleFetcher is nil (#93(a)). It is asserted
+// as a literal so the size of the hole is a number in the suite: closing #93(a)
+// changes this line, and nothing can shrink it silently.
+const knownOpenCells = 20
+
+// --- dimension 1: the verifier's disposition -------------------------------
+
+type verifierKind int
+
+const (
+	verifierNil verifierKind = iota
+	verifierAcceptsAll
+	verifierRefusesAll
+	verifierContentBound // trust.FakeVerifier: accepts iff the bundle signs this artifact
+)
+
+func (k verifierKind) String() string {
+	switch k {
+	case verifierNil:
+		return "verifier=nil"
+	case verifierAcceptsAll:
+		return "verifier=accepts"
+	case verifierRefusesAll:
+		return "verifier=refuses"
+	case verifierContentBound:
+		return "verifier=content-bound"
+	}
+	return fmt.Sprintf("verifier=?%d", int(k))
+}
+
+// errRefuseAll is what verifierRefusesAll returns. A verifier that refuses
+// everything is the configuration #92's probe 3 used: it is the strongest
+// possible verifier, so any cell that boots past it boots past every verifier.
+var errRefuseAll = errors.New("matrixVerifier: refusing every artifact")
+
+// matrixVerifier counts calls and delegates to the disposition under test.
+// The call count is load-bearing: "Run returned nil" does not distinguish
+// verification succeeding from verification never happening, and the whole of
+// #92 is that second case.
+type matrixVerifier struct {
+	kind verifierKind
+
+	mu    sync.Mutex
+	calls int
+}
+
+func (v *matrixVerifier) Verify(ctx context.Context, artifactPath string, bundle *trust.Bundle) error {
+	v.mu.Lock()
+	v.calls++
+	v.mu.Unlock()
+
+	switch v.kind {
+	case verifierAcceptsAll:
+		return nil
+	case verifierRefusesAll:
+		return errRefuseAll
+	case verifierContentBound:
+		fv := &trust.FakeVerifier{}
+		return fv.Verify(ctx, artifactPath, bundle)
+	}
+	return fmt.Errorf("matrixVerifier: Verify called with kind %v", v.kind)
+}
+
+func (v *matrixVerifier) callCount() int {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.calls
+}
+
+// --- dimension 2: what the bundle fetch yields ----------------------------
+
+type bundleKind int
+
+const (
+	bundleNoFetcher bundleKind = iota // Config.BundleFetcher is nil
+	bundleValidForThis
+	bundleValidForOther // a valid bundle, signed over different content
+	bundleEmptyBytes    // (nil, nil) — what the shipped s3 fetcher does for an empty Bundle
+	bundleNonJSON
+	bundleWrongMediaType // well-formed JSON, wrong mediaType: ParseBundle's second gate
+	bundleFetchErr
+)
+
+func (k bundleKind) String() string {
+	switch k {
+	case bundleNoFetcher:
+		return "bytes=no-fetcher"
+	case bundleValidForThis:
+		return "bytes=valid"
+	case bundleValidForOther:
+		return "bytes=valid-for-other"
+	case bundleEmptyBytes:
+		return "bytes=empty"
+	case bundleNonJSON:
+		return "bytes=non-json"
+	case bundleWrongMediaType:
+		return "bytes=wrong-media-type"
+	case bundleFetchErr:
+		return "bytes=fetch-error"
+	}
+	return fmt.Sprintf("bytes=?%d", int(k))
+}
+
+var errBundleFetch = errors.New("matrixBundleFetcher: registry unreachable")
+
+// matrixBundleFetcher answers every layer the same way, per its kind, and counts
+// how many times it was asked. The ask count distinguishes "refused before the
+// fetch" from "fetched and then refused", which is the difference between the two
+// doors #92 documents.
+type matrixBundleFetcher struct {
+	kind  bundleKind
+	bytes []byte // for the two valid kinds
+
+	mu    sync.Mutex
+	asked int
+}
+
+func (f *matrixBundleFetcher) FetchBundleJSON(_ context.Context, _ spec.ResolvedLayer) ([]byte, error) {
+	f.mu.Lock()
+	f.asked++
+	f.mu.Unlock()
+
+	switch f.kind {
+	case bundleValidForThis, bundleValidForOther:
+		return f.bytes, nil
+	case bundleEmptyBytes:
+		return nil, nil
+	case bundleNonJSON:
+		return []byte("this is not a cosign bundle"), nil
+	case bundleWrongMediaType:
+		return []byte(`{"mediaType":"application/vnd.example.not-a-bundle+json"}`), nil
+	case bundleFetchErr:
+		return nil, errBundleFetch
+	}
+	return nil, fmt.Errorf("matrixBundleFetcher: asked with kind %v", f.kind)
+}
+
+func (f *matrixBundleFetcher) askedCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.asked
+}
+
+// --- the precedence ladder ------------------------------------------------
+
+// wantFor returns the outcome the contract requires for a cell, and whether the
+// implementation is known to disagree.
+//
+// Authored from the contract, not from verifyBundles. Rule 2 is the disagreement:
+// #93(a) says nil wiring must be a refusal (or an explicit opt-out), and today it
+// returns nil and boots.
+func wantFor(v verifierKind, b bundleKind, namesBundle, digestMatches bool) (want bootOutcome, knownOpen bool) {
+	// 1. Content integrity is checked before authenticity, so a digest mismatch
+	//    pre-empts every other cell value. Asserting this for all 56 mismatched
+	//    cells is what forbids a wiring combination that inverts the order.
+	if !digestMatches {
+		return reasonDigest, false
+	}
+	// 2. No verifier, or no way to fetch what it would verify.
+	if v == verifierNil || b == bundleNoFetcher {
+		return reasonNoVerifier, true
+	}
+	// 3. A layer naming no bundle cannot be verified, and with a verifier
+	//    configured that is a refusal rather than a skip (#92, closed).
+	if !namesBundle {
+		return reasonAbsentBundle, false
+	}
+	// 4-6. Absent or unusable material is treated as invalid material.
+	switch b {
+	case bundleFetchErr:
+		return reasonFetchBundle, false
+	case bundleEmptyBytes:
+		return reasonEmptyBytes, false
+	case bundleNonJSON, bundleWrongMediaType:
+		return reasonParse, false
+	}
+	// 7-8. Real material: the verifier decides.
+	switch v {
+	case verifierAcceptsAll:
+		return reasonBoots, false
+	case verifierRefusesAll:
+		return reasonVerify, false
+	case verifierContentBound:
+		if b == bundleValidForThis {
+			return reasonBoots, false
+		}
+		// A valid bundle over different content: the substitution case.
+		return reasonVerify, false
+	}
+	panic(fmt.Sprintf("wantFor: unhandled cell v=%v b=%v", v, b))
+}
+
+// --- the table -----------------------------------------------------------
+
+type matrixCell struct {
+	name          string
+	verifier      verifierKind
+	bundle        bundleKind
+	namesBundle   bool
+	digestMatches bool
+	want          bootOutcome
+	knownOpen     bool
+}
+
+func buildMatrix() []matrixCell {
+	verifiers := []verifierKind{verifierNil, verifierAcceptsAll, verifierRefusesAll, verifierContentBound}
+	bundles := []bundleKind{
+		bundleNoFetcher, bundleValidForThis, bundleValidForOther,
+		bundleEmptyBytes, bundleNonJSON, bundleWrongMediaType, bundleFetchErr,
+	}
+	naming := []bool{false, true}
+	digests := []bool{true, false}
+
+	cells := make([]matrixCell, 0, len(verifiers)*len(bundles)*len(naming)*len(digests))
+	for _, v := range verifiers {
+		for _, b := range bundles {
+			for _, names := range naming {
+				for _, digestOK := range digests {
+					want, open := wantFor(v, b, names, digestOK)
+					cells = append(cells, matrixCell{
+						name: fmt.Sprintf("%v/%v/bundle=%s/digest=%s",
+							v, b, namedLabel(names), digestLabel(digestOK)),
+						verifier:      v,
+						bundle:        b,
+						namesBundle:   names,
+						digestMatches: digestOK,
+						want:          want,
+						knownOpen:     open,
+					})
+				}
+			}
+		}
+	}
+	return cells
+}
+
+func namedLabel(named bool) string {
+	if named {
+		return "named"
+	}
+	return "empty"
+}
+
+func digestLabel(ok bool) string {
+	if ok {
+		return "ok"
+	}
+	return "bad"
+}
+
+// TestBootMatrix_Shape checks the table before the table checks anything. A
+// generated matrix can be short, unbalanced, or exercise only some arms of its
+// own expectation function, and all three are indistinguishable from a clean pass
+// once the cells run.
+func TestBootMatrix_Shape(t *testing.T) {
+	cells := buildMatrix()
+
+	// (1) Cardinality against a literal, deliberately. Deriving it from the same
+	// slices buildMatrix iterates would make a dropped dimension value shrink
+	// both sides of the comparison and pass — the derivation would be a
+	// consistency check against itself. So the count is stated, and changing a
+	// dimension means editing this line on purpose. Check (2) is the derived one:
+	// it compares each value's share against the cell total, which no single
+	// declaration controls.
+	wantCount := 4 * 7 * 2 * 2
+	if len(cells) != wantCount {
+		t.Fatalf("matrix has %d cells, want %d (4 verifiers x 7 bundle kinds x 2 bundle fields x 2 digests)",
+			len(cells), wantCount)
+	}
+
+	// (2) Balance: every value of every dimension appears in exactly
+	// len(cells)/n cells. This is what catches a dropped or duplicated value,
+	// which a bare cardinality check cannot.
+	byVerifier := map[verifierKind]int{}
+	byBundle := map[bundleKind]int{}
+	byNaming := map[bool]int{}
+	byDigest := map[bool]int{}
+	for _, c := range cells {
+		byVerifier[c.verifier]++
+		byBundle[c.bundle]++
+		byNaming[c.namesBundle]++
+		byDigest[c.digestMatches]++
+	}
+	for _, d := range []struct {
+		what  string
+		size  int
+		count map[string]int
+	}{
+		{"verifier", 4, stringifyKeys(byVerifier)},
+		{"bundle", 7, stringifyKeys(byBundle)},
+		{"names bundle", 2, stringifyKeys(byNaming)},
+		{"digest matches", 2, stringifyKeys(byDigest)},
+	} {
+		if len(d.count) != d.size {
+			t.Errorf("dimension %q has %d distinct values in the table, want %d",
+				d.what, len(d.count), d.size)
+			continue
+		}
+		want := len(cells) / d.size
+		for value, n := range d.count {
+			if n != want {
+				t.Errorf("dimension %q value %s appears in %d cells, want %d",
+					d.what, value, n, want)
+			}
+		}
+	}
+
+	// (3) Every arm of the ladder fires. Asserted as a set both ways: an arm no
+	// cell reaches is an unexercised branch, and a cell reaching an arm not on
+	// the manifest means the manifest is stale.
+	fired := map[bootOutcome]int{}
+	for _, c := range cells {
+		fired[c.want]++
+	}
+	manifest := map[bootOutcome]bool{}
+	for _, r := range ladderOutcomes {
+		manifest[r] = true
+		if fired[r] == 0 {
+			t.Errorf("ladder outcome %q fires for no cell — the arm is unexercised", r)
+		}
+	}
+	for r := range fired {
+		if !manifest[r] {
+			t.Errorf("cells expect outcome %q, which is not in ladderOutcomes", r)
+		}
+	}
+
+	// (4) Both classes of outcome occur, and cell names are unique — a duplicate
+	// name silently merges two cells under go test's subtest naming.
+	if fired[reasonBoots] == 0 {
+		t.Error("no cell boots — the table would pass by refusing everything")
+	}
+	refusals := len(cells) - fired[reasonBoots] - fired[reasonNoVerifier]
+	if refusals == 0 {
+		t.Error("no cell refuses — the table asserts nothing about refusal")
+	}
+	seen := map[string]bool{}
+	for _, c := range cells {
+		if seen[c.name] {
+			t.Errorf("duplicate cell name %q", c.name)
+		}
+		seen[c.name] = true
+	}
+
+	// (5) The size of the open hole, as a literal. Closing #93(a) changes this
+	// number, so it cannot shrink without a diff.
+	open := fired[reasonNoVerifier]
+	if open != knownOpenCells {
+		t.Errorf("%d cells are #93(a) fail-open, knownOpenCells says %d — "+
+			"if the hole moved, say so here", open, knownOpenCells)
+	}
+	t.Logf("%d cells; %d reach the mount unverified (#93(a)); outcome distribution: %s",
+		len(cells), open, describe(fired))
+}
+
+func stringifyKeys[K comparable](m map[K]int) map[string]int {
+	out := make(map[string]int, len(m))
+	for k, v := range m {
+		out[fmt.Sprint(k)] = v
+	}
+	return out
+}
+
+func describe(fired map[bootOutcome]int) string {
+	parts := make([]string, 0, len(ladderOutcomes))
+	for _, r := range ladderOutcomes {
+		label := string(r)
+		if r == reasonBoots {
+			label = "boots"
+		}
+		parts = append(parts, fmt.Sprintf("%s=%d", label, fired[r]))
+	}
+	return strings.Join(parts, " ")
+}
+
+// TestBootMatrix_DecisionSurface runs every cell.
+func TestBootMatrix_DecisionSurface(t *testing.T) {
+	for _, c := range buildMatrix() {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			runMatrixCell(t, c)
+		})
+	}
+}
+
+func runMatrixCell(t *testing.T, c matrixCell) {
+	t.Helper()
+	ctx := context.Background()
+
+	layer, path := makeLayer(t, "python-3.11", []byte("squashfs content alpha"), 1)
+	if c.namesBundle {
+		layer.Bundle = "s3://strata-registry/bundles/python-3.11.json"
+	}
+	if !c.digestMatches {
+		// Declare a digest the file does not have. The file is untouched, so the
+		// only difference from the matching cell is the manifest claim.
+		other := sha256.Sum256([]byte("some other content entirely"))
+		layer.SHA256 = hex.EncodeToString(other[:])
+	}
+
+	verifier := &matrixVerifier{kind: c.verifier}
+	fetcher := &matrixBundleFetcher{kind: c.bundle}
+	switch c.bundle {
+	case bundleValidForThis:
+		fetcher.bytes = signedBundleJSON(t, path)
+	case bundleValidForOther:
+		fetcher.bytes = signedBundleJSON(t, writeOtherArtifact(t))
+	}
+
+	cfg := agent.Config{
+		Source:   &agent.FakeLockfileSource{Lockfile: &spec.LockFile{ProfileName: "ml-env", Layers: []spec.ResolvedLayer{layer}}},
+		Fetcher:  &agent.FakeLayerFetcher{Paths: map[string]string{layer.ID: path}},
+		Signaler: &agent.FakeReadySignaler{},
+		Mounter:  &recordingMounter{},
+	}
+	signaler := cfg.Signaler.(*agent.FakeReadySignaler)
+	mounter := cfg.Mounter.(*recordingMounter)
+	if c.verifier != verifierNil {
+		cfg.Verifier = verifier
+	}
+	if c.bundle != bundleNoFetcher {
+		cfg.BundleFetcher = fetcher
+	}
+
+	_, err := newAgent(t, cfg).Run(ctx)
+
+	if c.knownOpen {
+		// #93(a): this cell should refuse and does not. Assert what actually
+		// happens, including that the mount was reached with nothing verified —
+		// stating the consequence, not just the tolerance.
+		if err != nil {
+			t.Fatalf("this cell is marked #93(a) fail-open but Run refused: %v\n"+
+				"If #93(a) is closed, change wantFor()'s rule 2 to return the refusal, "+
+				"drop the knownOpen flag, and lower knownOpenCells.", err)
+		}
+		if !mounter.wasCalled() {
+			t.Error("Run succeeded without reaching Mount — the fail-open cell's premise is wrong")
+		}
+		if !signaler.ReadyCalled {
+			t.Error("Run succeeded without signalling ready")
+		}
+		if got := verifier.callCount(); got != 0 {
+			t.Errorf("Verify call count = %d, want 0 — nothing was verified on this path", got)
+		}
+		return
+	}
+
+	if c.want == reasonBoots {
+		if err != nil {
+			t.Fatalf("Run: want boot, got error: %v", err)
+		}
+		if !mounter.wasCalled() {
+			t.Error("Mount was not reached on a booting cell")
+		}
+		if !signaler.ReadyCalled {
+			t.Error("SignalReady was not called on a booting cell")
+		}
+		if signaler.FailedCalled {
+			t.Errorf("SignalFailed was called on a booting cell: %v", signaler.FailedReason)
+		}
+		if got := verifier.callCount(); got != 1 {
+			t.Errorf("Verify call count = %d, want 1 — a boot that verified nothing is the #92 defect", got)
+		}
+		return
+	}
+
+	// Refusal cells.
+	if err == nil {
+		t.Fatalf("Run: want refusal %q, got nil", c.want)
+	}
+	if !strings.Contains(err.Error(), string(c.want)) {
+		t.Errorf("Run error should name %q, got: %v", c.want, err)
+	}
+	if mounter.wasCalled() {
+		t.Errorf("Mount was reached despite %q", c.want)
+	}
+	if signaler.ReadyCalled {
+		t.Errorf("SignalReady was called despite %q", c.want)
+	}
+	if !signaler.FailedCalled {
+		t.Errorf("SignalFailed was not called on refusal %q", c.want)
+	}
+
+	// Which checks ran before the refusal. This is the half that stops a refusal
+	// from passing for the wrong reason: reasonVerify must have called the
+	// verifier, and everything earlier must not have.
+	wantVerifyCalls := 0
+	if c.want == reasonVerify {
+		wantVerifyCalls = 1
+	}
+	if got := verifier.callCount(); got != wantVerifyCalls {
+		t.Errorf("Verify call count = %d, want %d for refusal %q", got, wantVerifyCalls, c.want)
+	}
+
+	// The bundle fetch happens only for a layer that names a bundle and only
+	// once the wiring is complete: an ask on an absent-bundle cell would mean the
+	// refusal came after the fetch, reopening #92's second door.
+	wantAsked := 0
+	switch c.want {
+	case reasonFetchBundle, reasonEmptyBytes, reasonParse, reasonVerify:
+		wantAsked = 1
+	}
+	if got := fetcher.askedCount(); got != wantAsked {
+		t.Errorf("BundleFetcher asked %d times, want %d for refusal %q", got, wantAsked, c.want)
+	}
+}
+
+// writeOtherArtifact returns the path of a file whose content differs from the
+// layer under test, so a bundle signed over it is valid and wrong.
+func writeOtherArtifact(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "other.sqfs")
+	if err := os.WriteFile(path, []byte("squashfs content from a different layer"), 0o600); err != nil {
+		t.Fatalf("writing substitute artifact: %v", err)
+	}
+	return path
+}


### PR DESCRIPTION
Closes #128.

Test-only. No production code changes — `git diff --stat` is `CHANGELOG.md` and
one new file.

## What it does

Enumerates the boot sequence's verification decision surface instead of sampling
it. 4 verifier dispositions × 7 bundle-byte outcomes × 2 `layer.Bundle` values ×
2 digest states = **112 cells**, each asserting *which* check fired (not merely
that one did), whether `Mount` was reached, the verifier's call count, and
whether the bundle fetch happened at all.

## Why, measured before it was written

`verifyBundles` has 29 statement blocks. Four were unhit by the **whole
module's** suite:

```
go test -covermode=count -coverpkg=./internal/agent/ -coverprofile=agent-all.out ./...
# sections merged before asking "unhit" — a -coverpkg profile emits one section
# per test binary, so a block unhit by binary A and hit by binary B appears
# twice, once with hits=0.
```

| lines | what it is | after this PR |
|---|---|---|
| 343-347 | `FetchBundleJSON` errors | covered |
| 361-365 | `trust.ParseBundle` errors | covered |
| 367-371 | **`Verifier.Verify` returns an error** | covered |
| 311-312 | a lockfile layer with no fetched path | still unhit — see below |

The third one is the finding. The verifier exists in order to be able to refuse,
and no test in the module had ever made it do so through the agent. Every
"verification works" assertion in the suite was an assertion that a verifier
which *accepts* got called. Package coverage 81.3% → 86.7%.

The fourth is **unreachable through `Run`**, argued rather than asserted:
`fetchAndVerifyLayers` either returns one path per lockfile layer or returns an
error, so `pathByID` cannot be missing an ID that `lf.Layers` contains. It is
defensive code with no live caller. Left alone in this PR; noted for the record.

## The expectation is not a paraphrase of the implementation

Cell outcomes come from a precedence ladder in `wantFor()` authored from the
contract (#92, #93, the interface docs). The evidence that it is independent is
that it **disagrees** with the code: the ladder says a boot with no verifier is a
refusal, and today it boots.

**20 of the 112 cells reach the mount with nothing verified** (#93(a) — nil
`Verifier` or nil `BundleFetcher` skips verification entirely). Those cells are
marked `knownOpen` and assert what actually happens, including that `Mount` was
reached and `Verify` was called zero times. When #93(a) closes they fail with the
instruction to flip the expectation. That is the mechanism that stops the
enumeration from quietly certifying the fail-open it was built to measure.

## Non-vacuity of the table itself

A generated table can be short, unbalanced, or exercise only some arms of its own
expectation function, and all three look identical to a clean pass. `TestBootMatrix_Shape`:

1. cardinality against a **stated literal**, deliberately — deriving it from the
   same slices that build the table would let a dropped dimension value shrink
   both sides and pass;
2. the derived guard: every dimension value appears in exactly `112/n` cells;
3. every ladder arm fires for ≥1 cell, asserted as a set **in both directions**
   so a stale manifest is caught too;
4. both outcome classes occur; cell names unique;
5. the fail-open count pinned as a literal.

Distribution, logged by the shape test and predicted by hand before it was run:

```
112 cells; 20 reach the mount unverified (#93(a));
boots=3 SHA256 mismatch=56 no way to verify=20 no attestation bundle=18
fetching bundle=3 no bundle bytes=3 parsing bundle=6 verifying layer=3
```

## The table passed on the first run, so it was mutation-probed

All 112 green first time is exactly when a table deserves distrust. Six
mutations, each applied to `internal/agent/agent.go`, run, and reverted
(`git status --porcelain` empty after each). Failing-cell counts were predicted
from the distribution above before running:

| mutation | predicted | observed |
|---|---|---|
| absent-bundle refusal removed (re-opens #92) | 18 | **18** |
| empty bundle bytes tolerated | 3 | **3** |
| `ParseBundle` error tolerated | 6 | **6** |
| `Verify` error ignored | 3 | **3** |
| digest mismatch tolerated | 56 | **56** |
| **#93(a) closed** (nil wiring refuses) | 20 | **20**, with the instruction message |

A seventh probe was a patch that did not apply; the harness asserted its match
count was exactly 1 and refused, rather than no-op'ing and reporting "0 failing
cells" — which would have read as "the table cannot detect this."

Three guard probes on the test file itself, also reverted: dropping a dimension
value → cardinality fails (96 ≠ 112); claiming 19 fail-open cells → fails naming
20; removing an arm from the manifest → fails on the both-directions check.

## Incidental refinement of #93's forecast

#93 measured that inverting branch (a) breaks three inherited tests. Handling the
empty-lockfile case (`len(paths) == 0` still boots) breaks only **two** —
`TestRun_HappyPath` and `TestRun_MountFails`. `TestRun_NoLayers` survives,
because "no layers" is not "no verifier", which is the distinction
`TestVerifyBundles_NoLayersIsNotAbsentBundle` already asserts.

## Not in this PR, deliberately

- **`cached` is not a dimension.** `LayerFetcher.Fetch` returns a path; a cache
  hit and a download are indistinguishable to `Run`, and `verifyBundles`
  iterates `lf.Layers` rather than fetch provenance, so a cache hit cannot skip
  verification by construction. The question belongs to
  `cmd/strata-agent.s3LayerFetcher` as one assertion.
- **No `PROPERTIES.md` change.** T1 and T5 both cite
  `internal/agent/agent.go:285` as a live refutation with #93 named; this PR
  quantifies that refutation but does not discharge it, and an evidence-tier
  question falls out of it that should be settled on its own.
- **No inherited test file is touched**:
  `git diff --name-status origin/main...HEAD -- '*_test.go'` is one line, `A`.
