### PR TITLE
docs: Basis records a pair, not an ordinal (#130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -338,6 +338,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   timeout. Completes the two work items left unchecked in #36.
 
 ### Changed
+- **`PROPERTIES.md`'s evidence ladder is replaced by a pair: coverage × subject**
+  (#130). `E0 < E1 < E2 < E3` ranked propositions by *technique* — did you use a
+  generator, did you build a model — rather than by what was established, so an
+  exhaustive walk of a declared domain filed *below* a sampled walk of an
+  undeclared one. A basis is now Coverage ∈ {`asserted`, `chosen`, `sampled`,
+  `exhaustive`} × Subject ∈ {`implementation`, `model`}: seven cells, since
+  `asserted` takes no subject. The old ladder was one path through that grid which
+  switched subject at its top step, leaving three cells nameless — including
+  `exhaustive/implementation`, the strongest, which #129 produced and could only
+  be recorded as E1 or E2, beneath an exhaustive check of an abstraction. Per
+  consumer:
+  - *Readers of the document.* §2 is rewritten, and §2.1 rules 1, 2, 8 and 11 move
+    with it because removing the ordinal left them ill-formed. Rule 11 and §4's
+    preamble said "at E1 or better", and E3 was "better than E1" — so a
+    counterexample in shipping code could have been declared discharged on an
+    exhaustive check of a *model*. Both now read *coverage `chosen` or stronger,
+    subject `implementation`*, which is well formed because coverage alone is
+    totally ordered. No row was ever discharged that way.
+  - *Authors of Basis cells.* Both spellings are accepted — `E1` and
+    `chosen/implementation` derive the same Status — and `asserted/implementation`,
+    a bare `chosen`, and an unknown subject are each rejected with their own
+    message. **No Basis cell changed and no Status cell changed**: E0–E3 stay
+    canonical, so this is a change to what the column means, not to what it says.
+  - *`cmd/propgen` and `internal/propdoc` callers.* `propgen`'s output is
+    unchanged — no drift, same distribution, same 34 propositions. `propdoc` gains
+    exported `Coverage`, `Subject`, `BasisKind`, `Bases` and `Basis.Pair`; no
+    existing signature changed, and `Basis.Tier` now holds a canonical spelling
+    which `Pair` decodes. `DeriveStatus` resolves either spelling, so a `Basis`
+    built as a struct literal rather than parsed derives the same status.
+  - *Anyone relying on §2's availability claim.* It asserted "there are no fuzz
+    targets … no proposition may claim E2 until one exists" and had been false
+    since `spec/environment_id_r7_fuzz_test.go` merged. Replaced with the two
+    commands and their real output. `sampled/implementation` is reachable; no
+    proposition claims it, because that target's domain cannot satisfy R7's
+    premise — now stated as rule 2's second clause.
 - **A software ref's `name` carrying inline syntax is now re-parsed everywhere a
   `SoftwareRef` appears** (#53), not only in a profile's `software` list. A
   formation manifest or lockfile entry written as `- name: "cuda@12.3"` now means

--- a/PROPERTIES.md
+++ b/PROPERTIES.md
@@ -204,35 +204,160 @@ configuration, not over some configuration.
 
 ## 2. Proof standard
 
-Each proposition carries an **evidence tier**. Tiers are not interchangeable and
-a lower tier is not partial credit for a higher one.
+Each proposition carries a **basis**, and a basis is a **pair, not an ordinal**:
+how much of a stated domain the evidence reached, and what the evidence was
+*about*. The two vary independently, so no single number holds both.
 
-| Tier | Name | What it establishes |
-|------|------|---------------------|
-| **E0** | **Asserted** | The property is stated in documentation or established by the structure of the code, and no executed test checks it. This is an honest status, not a failure — but it must be labelled. |
-| **E1** | **Witnessed** | One or more example tests exercise the property on chosen inputs, and the site the property is about is executed by them. Establishes that the property holds *for those inputs*. |
-| **E2** | **Quantified** | A property-based or metamorphic test exercises the property over generated inputs, with the generator's domain stated. Establishes the property over that domain. |
-| **E3** | **Exhausted** | An abstract model is checked exhaustively over a bounded state space, *plus* an explicit faithfulness argument relating the model to the implementation. |
+**Coverage — how much of the declared domain the evidence reached.**
 
-**E2 is currently unreachable in this repository.** There are no fuzz targets
-and no property-testing library:
+| Coverage | What it establishes |
+|----------|---------------------|
+| **`asserted`** | Nothing was executed. The property is stated in documentation, or follows from the structure of the code. An honest basis, not a failure — but it must be labelled. |
+| **`chosen`** | Example tests exercise the property on inputs the author picked, and the site the property is about is executed by them. Establishes the property *for those inputs*. |
+| **`sampled`** | A generated, property-based or metamorphic run exercises the property over inputs drawn from a declared domain. Establishes it over what was drawn, which is not the domain. |
+| **`exhaustive`** | Every member of a declared, bounded domain was exercised. Establishes the property over that domain with nothing left to sample. |
+
+**Subject — what the evidence was about.**
+
+| Subject | What it establishes |
+|---------|---------------------|
+| **`implementation`** | The evidence executed the code that ships. |
+| **`model`** | The evidence executed an abstraction of it. What holds of the model holds of the code only so far as a *separately cited* faithfulness argument carries it — rule 1. |
+
+Coverage is totally ordered: `asserted` < `chosen` < `sampled` < `exhaustive`.
+Subject is not an ordering at all. The pair is what resists a total order, and
+"E1 or better" is therefore a well-formed phrase only about coverage.
+
+### The seven bases, and the four the old ladder named
+
+`asserted` takes no subject. Where nothing was executed there is no artifact the
+evidence was *about*, so `asserted/implementation` and `asserted/model` would
+distinguish nothing measurable. The grid is 1 + 3 × 2 = **seven** cells, not
+4 × 2 = eight — a reader who counts the dimensions will expect eight, so the
+collapse is stated rather than left to be noticed.
+
+| Spelling in a Basis cell | Coverage | Subject | Legacy name |
+|---|---|---|---|
+| `asserted` | `asserted` | — | **E0** |
+| `chosen/model` | `chosen` | `model` | *none* |
+| `chosen/implementation` | `chosen` | `implementation` | **E1** |
+| `sampled/model` | `sampled` | `model` | *none* |
+| `sampled/implementation` | `sampled` | `implementation` | **E2** |
+| `exhaustive/model` | `exhaustive` | `model` | **E3** |
+| `exhaustive/implementation` | `exhaustive` | `implementation` | *none* |
+
+Both spellings are accepted in a Basis cell. Where a legacy name exists it is the
+canonical one, so `chosen/implementation` in a cell derives the same Status as
+`E1` and the Status column stays uniform; `internal/propdoc` normalises at parse
+and `internal/propdoc/basis_pair_test.go` checks this table against the parser's
+registry in **both** directions, so a spelling the document defines and the tool
+rejects — or accepts and the document never defines — fails the build.
+
+**Why the ladder was one-dimensional and the evidence isn't.** E0 < E1 < E2 < E3
+ranked by *technique* — did you use a generator, did you build a model — where
+what matters is *what was established*. Traced onto the grid, the old ladder is
+one path that switches subject at its top step: `asserted` →
+`chosen/implementation` → `sampled/implementation` → `exhaustive/`**`model`**.
+Three consequences, all of which bit:
+
+- **Three of the seven bases had no rung**, so evidence of those kinds had to be
+  filed as something it wasn't.
+- **The strongest of the three had to file below a model check.** #129 enumerated
+  all 112 cells of the four-dimensional (`Verifier` × bundle bytes × names-a-bundle
+  × digest) domain of `internal/agent.verifyBundles` — an `exhaustive/implementation`
+  result — and found four blocks that no test in the module had ever executed, one
+  of them `Verifier.Verify` returning an error, at 81.3% package coverage with three
+  CI jobs green. The ladder's top rung had already spent itself on a change of
+  subject, so the only tiers left for that result were E1 and E2: *beneath* an
+  exhaustive walk of an abstraction.
+- **The perverse ordering, which is the tell:** an exhaustive walk of a declared
+  domain filed below a sampled walk of an undeclared one.
+
+### What is reachable here today
 
 ```
-grep -rn '^func Fuzz' --include='*_test.go' .                    # no output
-grep -rn 'testing/quick\|gopter\|pgregory\|rapid' --include='*.go' .  # no output
+$ grep -rn '^func Fuzz' --include='*_test.go' .
+spec/environment_id_r7_fuzz_test.go:445:func FuzzR7NoSpuriousDistinctions(f *testing.F) {
+$ grep -rn 'testing/quick\|gopter\|pgregory\|rapid' --include='*.go' .   # no output
 ```
 
-No proposition may claim E2 until one exists. Recording that here prevents the
-tier being mistaken for available.
+`sampled/implementation` is reachable: a fuzz target exists, without a
+property-testing library. The paragraph this replaces said the opposite — *"there
+are no fuzz targets … no proposition may claim E2 until one exists"* — and it
+was false from the day that target merged, which is the same relocated-rule
+failure it was written to prevent: the section asserting a technique's absence is
+a site that the technique's arrival has to update (§7).
+
+No proposition claims `sampled/implementation` yet. R7's basis is `none` despite
+that target's 46 million executions, for the reason rule 2's second clause now
+states as a rule.
+
+### Ranking, where a worklist needs one
+
+Order by coverage, breaking ties by subject `model` < `implementation`. Over the
+seven that is a total order. It is a **sorting convention, not an evidence
+comparison**, and these are the places where it ranks two bases the evidence does
+not:
+
+1. **`sampled/implementation` vs `exhaustive/model`** — legacy E2 vs E3. Sampling
+   the code that ships, against exhausting an abstraction of it. Neither
+   dominates. The order puts `exhaustive/model` higher; nothing establishes that.
+2. **`exhaustive/implementation` vs `exhaustive/model`** — strictly stronger on
+   faithfulness, and **incomparable on domain size**: a bounded model state space
+   can be orders of magnitude larger than any implementation domain that can be
+   enumerated. The order ranks it higher, which is right on the first count and
+   unwarranted on the second. This pair is why no single number could hold #129.
+3. **Any two bases with different declared bounds.** The pair says *how* a domain
+   was covered; only the bound says *which* domain. Comparing the Basis cells of
+   two propositions whose bounds are not stated and comparable compares nothing.
+4. **`chosen/model` and `sampled/model` against `asserted`.** The order puts them
+   higher because something ran. Without a faithfulness argument they establish
+   nothing about the code, and `asserted` at least does not imply otherwise.
+
+**A column that cannot be totally ordered is more useful than one that can be and
+lies about it.** Note what this ranking is not: nothing in this repository
+consumes it. No tool sorts propositions by basis, so the list above is a note,
+and notes do not fire. The first time something does sort by basis — a triage
+script, a dashboard, a release gate — the order and this list move into
+`internal/propdoc` together, and the list acquires the guard that makes it
+non-vacuous: **every pair named here must be one the order actually ranks**, or
+the caveat is a caveat about nothing.
 
 ### 2.1 Rules
 
-1. **E3 without a faithfulness argument is E0.** A model check proves a property
-   of the model. The claim that the model represents the code is a separate
-   claim and must be made separately, with its own evidence.
-2. **A generator's domain is part of the claim.** "Holds for all profiles" is not
-   established by a generator that only emits single-layer profiles. State the
-   domain; a property established over a stated domain is a real result.
+1. **A `model` subject does not transfer to the implementation, and a faithfulness
+   argument does not rewrite the subject.** A model check proves a property of the
+   model. The claim that the model represents the code is a separate claim, made
+   separately, with its own evidence and its own basis, cited on the row beside
+   the model result. This is what the rule reached for when it read *"E3 without a
+   faithfulness argument is E0"*, and the pair states it better in both
+   directions. **What it now permits:** recording an unargued model check honestly
+   as `exhaustive/model` — a real result about a real artifact — rather than
+   erasing it to `asserted`. **What it now forbids:** reading a model check *with*
+   a faithfulness argument as evidence about the implementation. The old wording
+   implied the argument promoted the tier; it does not, because there is no rung
+   to promote it to. Subject is not an ordering.
+2. **The declared bound is part of the claim, in both dimensions.** For coverage
+   the bound is the domain: "holds for all profiles" is not established by a
+   generator that only emits single-layer profiles, nor by an exhaustive walk of a
+   domain the walk itself declared. For subject the bound is what the model
+   abstracts away. State both; a property established over a stated bound is a
+   real result, and a bound that is not stated makes the coverage `asserted`
+   whatever ran.
+
+   **And a bound no member of which can satisfy the property's premise makes the
+   coverage `asserted` too, whatever ran.** R7 — *two lockfiles that assemble the
+   same environment have equal `EnvironmentID`* — was fuzzed for 46,546,540
+   executions, green, over a domain in which no two *distinct* lockfiles can
+   assemble the same environment at all: `internal/overlay` marshals the whole
+   lockfile into `/etc/strata/active.lock.yaml` inside the assembled root, so the
+   premise holds only for byte-identical pairs and the property is vacuously true.
+   An empty search space and a clean search are indistinguishable in every number
+   the run reports — exec count, corpus reach and transformation counters were all
+   green. So a `sampled` or `exhaustive` claim states not only its bound but that
+   the bound is **satisfiable** by something the generator can produce. For an
+   implication-shaped property that question is distinct from "did the
+   transformation fire" and from "was it non-identity". (Added 2026-08-21; see §7.)
 3. **An input that cannot fail establishes nothing.** A test whose expected input
    is derived from the artifact it is compared against is a tautology regardless
    of tier. Every negative test must include a control demonstrating that the
@@ -259,7 +384,7 @@ tier being mistaken for available.
    that `filepath.Join` prevents a `..` escape; it does not. A false invariant is
    worse than an absent one, because it gives a future auditor a reason to stop
    looking. (Added 2026-08-21; see §7.)
-8. **Every status is dated.** A tier is a claim about a commit. §7 carries the
+8. **Every status is dated.** A basis is a claim about a commit. §7 carries the
    dates; a row without one is `UNPOPULATED`.
 9. **A proposition may not defer its content to a definition the implementation
    under test controls.** Where a policy term is unavoidable, the proposition
@@ -315,9 +440,17 @@ tier being mistaken for available.
     see §7.)
 11. **Closure-discharged is not evidence-discharged.** An issue closing is a fact
     about the tracker. A property holding is a fact about the code. A register row
-    may be marked `Discharged: Yes` only on **re-derived evidence at E1 or better**,
-    and the row cites that evidence rather than the closure. "Closed completed" is
-    not a citation; the issue's title is not the row's counterexample.
+    may be marked `Discharged: Yes` only on **re-derived evidence whose subject is
+    `implementation` and whose coverage is `chosen` or stronger**, and the row cites
+    that evidence rather than the closure. "Closed completed" is not a citation; the
+    issue's title is not the row's counterexample.
+
+    That wording replaces *"at E1 or better"*, and it is narrower on purpose: read
+    against the old ladder, E3 was "better than E1", so a discharge could have been
+    claimed on an exhaustive check of a *model* — evidence that a counterexample in
+    the shipping code is gone, obtained without executing that code. No row was
+    discharged that way; the ordinal permitted it, which is enough. Subject is not
+    an ordering, so it cannot be traded for coverage (§2).
 
     This rule is retrospective, not hypothetical: three of the register's nine
     `Yes` rows at the time it was written had been discharged on closure alone, and
@@ -342,9 +475,12 @@ Three columns, two authored and one generated:
   `SOUND`, `TOO WEAK` (satisfiable by an implementation that still has the defect
   the proposition was written to exclude — the broken implementation is named),
   `TOO STRONG`, or `ILL-FORMED` (with the falsifiable replacement).
-- **Basis** — *authored.* The highest evidence tier claimed for the proposition
-  and the citation carrying it, `none` if nothing is cited, or `withdrawn`
-  naming what superseded it. A tier with no citation is not a tier.
+- **Basis** — *authored.* The strongest basis claimed for the proposition — a
+  (coverage, subject) pair from §2, written either in pair notation or under its
+  legacy E-name — and the citation carrying it; `none` if nothing is cited, or
+  `withdrawn` naming what superseded it. A basis with no citation is not a basis.
+  "Strongest" is not a total order: see §2 on which pairs the ranking convention
+  ranks and the evidence does not.
 - **Status** — **generated** from the Basis cell and the §4 register by
   `internal/propdoc.DeriveStatus`. Do not edit it by hand; run
   `go run ./cmd/propgen -write`.
@@ -357,8 +493,12 @@ The status function, in the order it applies:
    rule 5. Where a proposition has more than one row the count is reported as
    `REFUTED (n of m live)`, so discharging one of several counterexamples is
    visible here rather than only in prose.
-3. Otherwise the Basis decides: `ENFORCED E1`/`E2`/`E3`, `ASSERTED (E0)`, or
-   `UNPOPULATED` where nothing is cited.
+3. Otherwise the Basis decides. `asserted` coverage renders `ASSERTED (…)`,
+   naming the basis in parentheses — `ASSERTED (E0)` for the legacy spelling.
+   Anything else renders `ENFORCED` followed by the canonical spelling:
+   `ENFORCED E1`, `ENFORCED E2`, `ENFORCED E3`, or
+   `ENFORCED exhaustive/implementation` for a pair with no legacy name. A cell
+   citing nothing renders `UNPOPULATED` whatever it claims.
 
 A `SOUND` verdict and a `REFUTED` status are the healthy combination: the
 proposition is worth having and the system does not yet satisfy it.
@@ -510,7 +650,8 @@ such an implementation exists; I5 shows it is not the only one.
 
 Every refutation is recorded here with the proposition it breaks, the adversary
 capability it uses, and the artifact tracking its discharge. A refutation is
-removed from this register only when its discharge is evidenced at E1 or better.
+removed from this register only when its discharge is evidenced at coverage
+`chosen` or stronger with subject `implementation` (§2.1 rule 11).
 `H1` in the capability column means no adversary is required (§1.4).
 **A `Yes` requires re-derived evidence, not a closed issue** — §2.1 rule 11 — and
 `Yes` rows are audited on the cadence in §6.1, because a discharged row is the one

--- a/PROPERTIES.md
+++ b/PROPERTIES.md
@@ -1895,3 +1895,113 @@ states the standard it violated and puts a cadence on finding the next.
     years before a property document did. Recording it because the review standard
     rewards refutations and this is the first place where the useful output was a
     mitigation that decides nothing.
+
+### 2026-08-21 — the ladder ranked technique, and the strongest evidence had no rung
+
+69. **`Basis` records a pair, not an ordinal, and §2 is rewritten around it.**
+    Coverage ∈ {`asserted`, `chosen`, `sampled`, `exhaustive`} × Subject ∈
+    {`implementation`, `model`}. The old E0 < E1 < E2 < E3 ranked by *technique* —
+    did you use a generator, did you build a model — where what matters is what was
+    *established*. On the grid it is one path that switches subject at the top step:
+    `asserted` → `chosen/implementation` → `sampled/implementation` →
+    `exhaustive/`**`model`**. Three of the seven bases therefore had no rung, and
+    the strongest of the three, `exhaustive/implementation`, could only be filed as
+    E1 or E2 — *beneath* an exhaustive walk of an abstraction — because the top rung
+    had spent itself on a change of subject. The tell was the perverse ordering: an
+    exhaustive walk of a declared domain filing below a sampled walk of an
+    undeclared one. Filed as #130 off the #129 enumeration, which produced exactly
+    that result and had no honest cell to sit in.
+
+    Seven bases, not eight: `asserted` takes no subject, because where nothing was
+    executed there is no artifact the evidence was about. The collapse is stated in
+    §2 rather than left to be noticed, since a reader who counts the dimensions
+    expects eight — and it is what makes `ASSERTED (E0)` the only rendering asserted
+    coverage can produce, so `propdoc.Kind` needed no change.
+
+70. **The pair is strictly stronger than the ordinal in one direction and
+    incomparable in another, and §2 now says which.** `exhaustive/implementation`
+    beats `exhaustive/model` on faithfulness and is **incomparable to it on domain
+    size**: a bounded model state space can be orders of magnitude larger than any
+    implementation domain that can be enumerated. That is precisely why no single
+    number could hold #129. §2 states the total order triage wants *and* the four
+    places it ranks two bases the evidence does not — E2 vs E3, the pair above,
+    differing declared bounds, and the model subjects against `asserted`. A column
+    that cannot be totally ordered is more useful than one that can be and lies
+    about it.
+
+    Recorded honestly: that half is a **note, not a check**. Nothing in this
+    repository sorts propositions by basis, so the incomparability list cannot
+    fire, and §2 says what has to happen the first time something does — the order
+    and the list move into `internal/propdoc` together, and the list gets the guard
+    that makes it non-vacuous, namely that every pair it names must be one the order
+    actually ranks.
+
+71. **Removing the ordinal made three rules ill-formed, which is why they moved
+    with it.** Rule 1 was *"E3 without a faithfulness argument is E0"* — it demoted
+    a real result about a real artifact to "nothing was executed". It now says a
+    `model` subject does not transfer and a faithfulness argument does not rewrite
+    the subject: it *permits* recording an unargued model check as
+    `exhaustive/model`, and *forbids* reading an argued one as evidence about the
+    implementation. Rule 11 and §4's preamble said **"at E1 or better"**, and under
+    the old ladder E3 was better than E1 — so a discharge could have been claimed on
+    an exhaustive check of a *model*, declaring a counterexample in shipping code
+    gone without executing that code. No row was discharged that way; the ordinal
+    permitted it, which is enough. Both now read *coverage `chosen` or stronger,
+    subject `implementation`*, which is well formed because coverage alone **is**
+    totally ordered. Rule 8 and §3's legend: "tier" → "basis".
+
+72. **§2's own availability paragraph had been false since the day a fuzz target
+    merged, and the paragraph existed to prevent exactly that.** It asserted *"there
+    are no fuzz targets … no proposition may claim E2 until one exists"*, quoting two
+    commands. Re-run, the first now prints
+    `spec/environment_id_r7_fuzz_test.go:445:func FuzzR7NoSpuriousDistinctions`.
+    Item 14 of the first population added that paragraph so the tier could not be
+    "mistaken for available"; item 57 added the target; nothing connected them. A
+    section that asserts a technique's absence is a site the technique's arrival has
+    to update, and this is the relocated-rule failure committed by the author of the
+    rule against it. Replaced with the commands and their real output. R7 still
+    claims no basis, for the reason rule 2's second clause now states.
+
+73. **Rule 2 gains the R7 finding as a rule: a bound whose premise nothing in it can
+    satisfy makes the coverage `asserted`, whatever ran.** 46,546,540 executions,
+    green, over a domain in which no two *distinct* lockfiles can assemble the same
+    environment at all. An empty search space and a clean search are
+    indistinguishable in every number a run reports. So a `sampled` or `exhaustive`
+    claim states not only its bound but that the bound is **satisfiable** by
+    something the generator can produce — a question distinct, for an
+    implication-shaped property, from whether the transformation fired and whether
+    it was non-identity.
+
+74. **What fires, and what a green run here would not have caught.** No Basis cell
+    changed and no Status cell changed: E0–E3 stay canonical, `propgen` reports no
+    drift, and the distribution is identical, which is the evidence that this is a
+    change to what the column *means* and not to what it *says*.
+    `internal/propdoc/basis_pair_test.go` checks §2's seven-basis table against the
+    parser's registry in **both** directions — a spelling the document defines and
+    the tool rejects breaks an author who followed the document; one the tool accepts
+    and the document never defines is a basis nobody can look up, and only the first
+    is loud on its own. It states its own cardinality (7) rather than deriving it
+    from either side, per the rule that a generated table's cardinality is stated and
+    only its balance derived.
+
+    And it closes a hole the pair notation opens: the inherited distribution test
+    names **five** status kinds by hand, a bare list reads as the complete set, and a
+    pair-spelled cell with no legacy name derives a sixth that the prose would omit
+    with nothing objecting. The new test asserts the derived direction — whatever
+    kinds the register produces, the document states them — with a control proving
+    the search can fail.
+
+75. **Nine mutations, and the ninth was void in a way the #129 rule does not cover.**
+    The suite passed on its first run, so each check was probed by breaking what it
+    is about, with the failing check predicted first: drop a documented row, drop a
+    registry entry, misname a legacy tier, spell a pair inconsistently, break the
+    table header, stop canonicalising, revert `DeriveStatus`'s lookup, delete a kind
+    from the prose, and state a kind nothing claims. All nine went red, and the tree
+    was verified clean after each. But the canonicalisation mutant **did not
+    compile** (`declared and not used: k`), and `go test` exits 1 for a build failure
+    exactly as it does for a detected defect — so the first pass recorded it as red
+    with zero failing tests, and 8 of 9 nearly went into the record as 9 of 9. #129's
+    rule was *assert the patch applied*; the patch did apply. **The rule needs its
+    second half: assert the mutant builds.** Re-run as `k.Canonical()` →
+    `k.Spelling()`, which compiles, it produced the predicted 8 errors in the
+    canonicalisation test.

--- a/internal/propdoc/basis.go
+++ b/internal/propdoc/basis.go
@@ -1,0 +1,147 @@
+package propdoc
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Coverage is how much of a declared domain a proposition's evidence reached.
+// Coverage is totally ordered — asserted, chosen, sampled, exhaustive — which is
+// why "chosen or stronger" is a well-formed phrase about coverage alone.
+type Coverage string
+
+// The four coverage values defined in section 2 of the document.
+const (
+	// CoverageAsserted means nothing was executed: the property is stated in
+	// documentation or follows from the structure of the code.
+	CoverageAsserted Coverage = "asserted"
+	// CoverageChosen means example tests exercised the property on inputs the
+	// author picked, and the site the property is about ran.
+	CoverageChosen Coverage = "chosen"
+	// CoverageSampled means a generated run drew inputs from a declared domain.
+	CoverageSampled Coverage = "sampled"
+	// CoverageExhaustive means every member of a declared bounded domain ran.
+	CoverageExhaustive Coverage = "exhaustive"
+)
+
+// Subject is what a proposition's evidence was about. Subject is not an
+// ordering: a model result does not become an implementation result, with or
+// without a faithfulness argument (section 2.1 rule 1). The pair of a coverage
+// and a subject is therefore not totally ordered, which is the whole reason
+// Basis records a pair rather than a rung.
+type Subject string
+
+// The subject values defined in section 2 of the document.
+const (
+	// SubjectNone is the subject of CoverageAsserted, which has none: where
+	// nothing was executed there is no artifact the evidence was about.
+	SubjectNone Subject = ""
+	// SubjectModel means the evidence executed an abstraction of the code.
+	SubjectModel Subject = "model"
+	// SubjectImplementation means the evidence executed the code that ships.
+	SubjectImplementation Subject = "implementation"
+)
+
+// BasisKind is one of the seven bases section 2 defines: a coverage, the subject
+// it applies to, and the legacy E-name if that pair has one.
+type BasisKind struct {
+	Coverage Coverage
+	Subject  Subject
+	// Legacy is the E0-E3 name for this pair, or empty where the pair has none.
+	// Three of the seven have no legacy name, which is the defect that the
+	// one-dimensional ladder had and this pair does not: the strongest of the
+	// three, exhaustive/implementation, had to be filed below a model check.
+	Legacy string
+}
+
+// Spelling returns the pair notation for the kind: "coverage/subject", or just
+// the coverage where the subject is SubjectNone.
+func (k BasisKind) Spelling() string {
+	if k.Subject == SubjectNone {
+		return string(k.Coverage)
+	}
+	return string(k.Coverage) + "/" + string(k.Subject)
+}
+
+// Canonical returns the spelling a Basis cell normalises to: the legacy name
+// where one exists, so that the Status column reads the same whichever spelling
+// the author used, and the pair notation otherwise.
+func (k BasisKind) Canonical() string {
+	if k.Legacy != "" {
+		return k.Legacy
+	}
+	return k.Spelling()
+}
+
+// Bases returns the seven bases, in the order section 2 tabulates them. It is a
+// function rather than a package variable both because this package has no
+// globals and because a caller cannot then mutate the registry the parser reads.
+//
+// The count is 1 + 3*2 rather than 4*2: CoverageAsserted takes no subject, since
+// "asserted about the implementation" and "asserted about a model" distinguish
+// nothing measurable when nothing was executed.
+func Bases() []BasisKind {
+	return []BasisKind{
+		{CoverageAsserted, SubjectNone, "E0"},
+		{CoverageChosen, SubjectModel, ""},
+		{CoverageChosen, SubjectImplementation, "E1"},
+		{CoverageSampled, SubjectModel, ""},
+		{CoverageSampled, SubjectImplementation, "E2"},
+		{CoverageExhaustive, SubjectModel, "E3"},
+		{CoverageExhaustive, SubjectImplementation, ""},
+	}
+}
+
+// lookupBasis finds the kind a Basis cell's tier token names, accepting either
+// the legacy name or the pair notation.
+func lookupBasis(token string) (BasisKind, bool) {
+	for _, k := range Bases() {
+		if token == k.Legacy || token == k.Spelling() {
+			return k, true
+		}
+	}
+	return BasisKind{}, false
+}
+
+// Pair returns the coverage and subject a basis claims, and whether it claims
+// one at all: TierNone, TierWithdrawn and an unrecognised tier claim no basis.
+// The tier may be spelled either way, so a Basis built by hand rather than
+// parsed still decodes.
+func (b Basis) Pair() (Coverage, Subject, bool) {
+	k, ok := lookupBasis(b.Tier)
+	return k.Coverage, k.Subject, ok
+}
+
+// parseTier resolves one Basis cell's tier token to its canonical spelling.
+// Errors distinguish the three ways a pair can be malformed from an
+// unrecognised token, because the first three are an author following section 2
+// imprecisely and the fourth is a typo.
+func parseTier(token string, lineIdx int) (string, error) {
+	if k, ok := lookupBasis(token); ok {
+		return k.Canonical(), nil
+	}
+	cov, subj, hasSlash := strings.Cut(token, "/")
+	known := false
+	for _, k := range Bases() {
+		if string(k.Coverage) == cov {
+			known = true
+			break
+		}
+	}
+	if !known {
+		// Keeps the wording that section 2's legacy names are checked under, so
+		// a stray "E9" still reads as what it is.
+		return "", fmt.Errorf("propdoc: line %d: unknown evidence tier %q", lineIdx+1, token)
+	}
+	if Coverage(cov) == CoverageAsserted && hasSlash {
+		return "", fmt.Errorf("propdoc: line %d: coverage %q takes no subject "+
+			"(nothing was executed, so there is no artifact the evidence was about); write %q",
+			lineIdx+1, CoverageAsserted, CoverageAsserted)
+	}
+	if !hasSlash {
+		return "", fmt.Errorf("propdoc: line %d: coverage %q needs a subject: write %q or %q",
+			lineIdx+1, cov, cov+"/"+string(SubjectImplementation), cov+"/"+string(SubjectModel))
+	}
+	return "", fmt.Errorf("propdoc: line %d: unknown evidence subject %q in %q: want %q or %q",
+		lineIdx+1, subj, token, SubjectImplementation, SubjectModel)
+}

--- a/internal/propdoc/basis_pair_test.go
+++ b/internal/propdoc/basis_pair_test.go
@@ -1,0 +1,293 @@
+package propdoc
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+// The seven bases of section 2 are authored twice on purpose: once as a markdown
+// table a reader consults, once as the registry Bases returns and the parser
+// reads. That is not the two-copies-agreeing defect this package exists to
+// prevent, because the two are not derived from each other and the failure they
+// guard against is asymmetric and real: a spelling the document defines and the
+// tool rejects breaks an author who followed the document, and a spelling the
+// tool accepts and the document never defines is a basis nobody can look up.
+// Only one of those two directions is loud on its own, so both are checked here.
+
+// documentedBases parses section 2's basis table. It is bounded by the table's
+// header rather than by matching rows against the registry, because recognising
+// rows by what the registry already knows would make the "every documented row
+// is accepted" direction vacuous.
+func documentedBases(t *testing.T) []BasisKind {
+	t.Helper()
+	src, err := os.ReadFile(propertiesPath())
+	if err != nil {
+		t.Fatalf("read PROPERTIES.md: %v", err)
+	}
+	const header = "| Spelling in a Basis cell | Coverage | Subject | Legacy name |"
+	lines := strings.Split(string(src), "\n")
+	start := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == header {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		t.Fatalf("PROPERTIES.md has no basis table: expected a row %q", header)
+	}
+	var out []BasisKind
+	for _, line := range lines[start+2:] { // Skip the header and its separator.
+		if !strings.HasPrefix(strings.TrimSpace(line), "|") {
+			break
+		}
+		cells := splitCells(line)
+		if len(cells) != 6 {
+			t.Fatalf("basis table row has %d fields, want 6: %q", len(cells), line)
+		}
+		clean := func(i int) string {
+			return strings.Trim(strings.TrimSpace(cells[i]), "`*")
+		}
+		subject := clean(3)
+		if subject == "—" {
+			subject = string(SubjectNone)
+		}
+		legacy := clean(4)
+		if legacy == "none" {
+			legacy = ""
+		}
+		out = append(out, BasisKind{
+			Coverage: Coverage(clean(2)),
+			Subject:  Subject(subject),
+			Legacy:   legacy,
+		})
+		// The spelling column is derivable from the other two, so it is checked
+		// rather than read: a row whose spelling does not follow from its pair
+		// would teach an author a token the parser cannot resolve.
+		if got, want := clean(1), out[len(out)-1].Spelling(); got != want {
+			t.Errorf("basis table row %q spells the pair %q", got, want)
+		}
+	}
+	return out
+}
+
+// TestBasisTableMatchesRegistry checks section 2's table against Bases in both
+// directions, and states its own cardinality rather than deriving it from either
+// side — a count taken from the registry would shrink with the registry, and one
+// taken from the table would shrink with the table.
+func TestBasisTableMatchesRegistry(t *testing.T) {
+	const wantBases = 7 // 1 subjectless + 3 coverages x 2 subjects.
+
+	documented := documentedBases(t)
+	if len(documented) != wantBases {
+		t.Fatalf("section 2 tabulates %d bases, want %d", len(documented), wantBases)
+	}
+	registry := Bases()
+	if len(registry) != wantBases {
+		t.Fatalf("Bases returns %d kinds, want %d", len(registry), wantBases)
+	}
+
+	bySpelling := func(ks []BasisKind) map[string]BasisKind {
+		m := make(map[string]BasisKind, len(ks))
+		for _, k := range ks {
+			m[k.Spelling()] = k
+		}
+		return m
+	}
+	doc, reg := bySpelling(documented), bySpelling(registry)
+	if len(doc) != wantBases {
+		t.Errorf("section 2 tabulates a spelling twice: %d rows, %d distinct", len(documented), len(doc))
+	}
+	if len(reg) != wantBases {
+		t.Errorf("Bases returns a spelling twice: %d kinds, %d distinct", len(registry), len(reg))
+	}
+	for spelling, want := range doc {
+		got, ok := reg[spelling]
+		if !ok {
+			t.Errorf("section 2 defines %q and Bases does not: an author who follows the document writes a cell the parser rejects", spelling)
+			continue
+		}
+		if got != want {
+			t.Errorf("basis %q: section 2 says %+v, Bases says %+v", spelling, want, got)
+		}
+	}
+	for spelling := range reg {
+		if _, ok := doc[spelling]; !ok {
+			t.Errorf("Bases accepts %q and section 2 does not define it: a basis nobody can look up", spelling)
+		}
+	}
+
+	// The structural claims section 2 makes about the grid, which the row-by-row
+	// comparison above would pass even if both sides were wrong together.
+	legacy := map[string]string{}
+	subjectless := 0
+	for _, k := range registry {
+		if k.Subject == SubjectNone {
+			subjectless++
+			if k.Coverage != CoverageAsserted {
+				t.Errorf("basis %+v has no subject; only %q may", k, CoverageAsserted)
+			}
+		}
+		if k.Legacy == "" {
+			continue
+		}
+		if prev, dup := legacy[k.Legacy]; dup {
+			t.Errorf("legacy name %q names both %q and %q", k.Legacy, prev, k.Spelling())
+		}
+		legacy[k.Legacy] = k.Spelling()
+	}
+	if subjectless != 1 {
+		t.Errorf("%d bases take no subject, want exactly 1", subjectless)
+	}
+	if len(legacy) != 4 {
+		t.Errorf("%d bases carry a legacy name, want 4 (E0-E3); three of the seven have none", len(legacy))
+	}
+	for _, name := range []string{"E0", "E1", "E2", "E3"} {
+		if _, ok := legacy[name]; !ok {
+			t.Errorf("legacy name %q names no basis", name)
+		}
+	}
+}
+
+// TestBothSpellingsDeriveTheSameStatus is the point of canonicalising at parse:
+// the Basis column may be written either way, and the generated Status column
+// must not record which way the author chose.
+func TestBothSpellingsDeriveTheSameStatus(t *testing.T) {
+	for _, k := range Bases() {
+		if k.Legacy == "" {
+			continue
+		}
+		for _, spelling := range []string{k.Legacy, k.Spelling()} {
+			b, err := parseBasis(spelling+" `x_test.go:1`", 0)
+			if err != nil {
+				t.Fatalf("parseBasis(%q): %v", spelling, err)
+			}
+			if b.Tier != k.Canonical() {
+				t.Errorf("parseBasis(%q).Tier = %q, want the canonical %q", spelling, b.Tier, k.Canonical())
+			}
+			if got, want := DeriveStatus(b, 0, 0), DeriveStatus(Basis{Tier: k.Legacy, Citation: "x"}, 0, 0); got != want {
+				t.Errorf("%q derives %q; %q derives %q", spelling, got, k.Legacy, want)
+			}
+			// And the same for a Basis built by hand rather than parsed, which is
+			// how every caller outside this package constructs one. Parse
+			// canonicalises; a struct literal does not, so DeriveStatus has to
+			// resolve the spelling itself or the two paths disagree.
+			unparsed := DeriveStatus(Basis{Tier: spelling, Citation: "x"}, 0, 0)
+			if want := DeriveStatus(Basis{Tier: k.Canonical(), Citation: "x"}, 0, 0); unparsed != want {
+				t.Errorf("unparsed Basis{Tier: %q} derives %q, want %q", spelling, unparsed, want)
+			}
+		}
+	}
+}
+
+// TestBasisWithNoLegacyName covers the case the one-dimensional ladder had no
+// rung for, and which #129 produced: an exhaustive walk of a declared domain of
+// the shipping implementation. Under the ladder it had to be filed as E1 or E2 —
+// beneath an exhaustive check of a model — so the assertion here is that it is
+// expressible at all, and renders as itself.
+func TestBasisWithNoLegacyName(t *testing.T) {
+	b, err := parseBasis("exhaustive/implementation — `internal/agent/boot_matrix_test.go`", 0)
+	if err != nil {
+		t.Fatalf("parseBasis: %v", err)
+	}
+	if b.Tier != "exhaustive/implementation" {
+		t.Errorf("Tier = %q, want the pair notation kept", b.Tier)
+	}
+	cov, subj, ok := b.Pair()
+	if !ok || cov != CoverageExhaustive || subj != SubjectImplementation {
+		t.Errorf("Pair() = (%q, %q, %v), want (exhaustive, implementation, true)", cov, subj, ok)
+	}
+	if got, want := DeriveStatus(b, 0, 0), "ENFORCED exhaustive/implementation"; got != want {
+		t.Errorf("DeriveStatus = %q, want %q", got, want)
+	}
+	// A live refutation still outranks it — proof-standard rule 5 is about the
+	// register, and adding a stronger basis must not create an exemption.
+	if got, want := DeriveStatus(b, 1, 2), "REFUTED (1 of 2 live)"; got != want {
+		t.Errorf("with a live row, DeriveStatus = %q, want %q", got, want)
+	}
+}
+
+func TestParseTierRejections(t *testing.T) {
+	tests := []struct {
+		token, wantErr string
+	}{
+		// The control for the inherited unknown-tier case: a stray E-name must
+		// still read as an unknown tier rather than as a malformed pair.
+		{"E9", "unknown evidence tier"},
+		{"E4", "unknown evidence tier"},
+		{"witnessed/implementation", "unknown evidence tier"},
+		{"asserted/implementation", "takes no subject"},
+		{"asserted/model", "takes no subject"},
+		{"chosen", "needs a subject"},
+		{"exhaustive", "needs a subject"},
+		{"exhaustive/code", "unknown evidence subject"},
+		{"chosen/", "unknown evidence subject"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.token, func(t *testing.T) {
+			got, err := parseTier(tc.token, 0)
+			if err == nil {
+				t.Fatalf("parseTier(%q) = %q, want an error containing %q", tc.token, got, tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("parseTier(%q) error = %v, want it to contain %q", tc.token, err, tc.wantErr)
+			}
+		})
+	}
+	// The control: every documented spelling resolves, so the rejections above
+	// are rejecting something other than everything.
+	for _, k := range documentedBases(t) {
+		if _, err := parseTier(k.Spelling(), 0); err != nil {
+			t.Errorf("parseTier(%q): %v", k.Spelling(), err)
+		}
+		if k.Legacy == "" {
+			continue
+		}
+		if _, err := parseTier(k.Legacy, 0); err != nil {
+			t.Errorf("parseTier(%q): %v", k.Legacy, err)
+		}
+	}
+}
+
+// TestEveryDerivedKindIsStated closes the hole that pair notation opens in the
+// document's own distribution sentence. The inherited
+// TestPropertiesDistributionMatchesHeader checks five kinds by name; a bare list
+// of names reads as the complete set, and it is not — a Basis cell spelled as a
+// pair with no legacy name derives a Status kind that is in no such list, so the
+// prose would omit it and nothing would object. This asserts the derived
+// direction: whatever kinds the register produces, the prose states them.
+func TestEveryDerivedKindIsStated(t *testing.T) {
+	src, err := os.ReadFile(propertiesPath())
+	if err != nil {
+		t.Fatalf("read PROPERTIES.md: %v", err)
+	}
+	doc, err := Parse(src)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	dist := doc.Distribution()
+	if len(dist) == 0 {
+		t.Fatal("the register derives no statuses at all; this check would pass on an empty document")
+	}
+	flat := strings.Join(strings.Fields(string(src)), " ")
+	claim := func(kind string, n int) string {
+		verb := "are"
+		if n == 1 {
+			verb = "is"
+		}
+		return fmt.Sprintf("%d %s `%s`", n, verb, kind)
+	}
+	for kind, n := range dist {
+		if c := claim(kind, n); !strings.Contains(flat, c) {
+			t.Errorf("the register derives %q for %d propositions and PROPERTIES.md does not state %q",
+				kind, n, c)
+		}
+	}
+	// The control: the search can fail. Without this, a prose sentence that
+	// stated nothing would pass every assertion above the moment dist emptied.
+	if absent := claim("ENFORCED exhaustive/implementation", len(doc.Propositions())); strings.Contains(flat, absent) {
+		t.Errorf("PROPERTIES.md states %q, which no proposition claims; the control is wrong, not the document", absent)
+	}
+}

--- a/internal/propdoc/propdoc.go
+++ b/internal/propdoc/propdoc.go
@@ -20,8 +20,9 @@ import (
 	"strings"
 )
 
-// Tier values accepted in a proposition's Basis cell, in addition to the
-// evidence tiers E0 through E3 defined in section 2 of the document.
+// Tier values accepted in a proposition's Basis cell, in addition to the seven
+// bases defined in section 2 of the document — see Bases, and note that a basis
+// is a (Coverage, Subject) pair rather than a rung on a ladder.
 const (
 	// TierNone means no evidence is cited for the proposition.
 	TierNone = "none"
@@ -37,10 +38,14 @@ const (
 	DischargedPartially = "Partially"
 )
 
-// Basis is the authored half of a proposition's status: the highest evidence
-// tier claimed for it, and the citation carrying that claim.
+// Basis is the authored half of a proposition's status: the strongest basis
+// claimed for it, and the citation carrying that claim. "Strongest" is not a
+// total order — section 2 states the ranking convention and the pairs it ranks
+// that the evidence does not.
 type Basis struct {
-	// Tier is E0, E1, E2, E3, TierNone or TierWithdrawn.
+	// Tier is the canonical spelling of one of the seven bases — a legacy name
+	// E0 through E3, or pair notation such as "exhaustive/implementation" for a
+	// pair that has none — or TierNone or TierWithdrawn. Pair decodes it.
 	Tier string
 	// Citation is whatever the Basis cell says after the tier. For
 	// TierWithdrawn it names the replacement propositions.
@@ -127,8 +132,15 @@ func DeriveStatus(b Basis, live, total int) string {
 	if b.Tier == TierNone || b.Tier == "" || b.Citation == "" {
 		return "UNPOPULATED"
 	}
-	if b.Tier == "E0" {
-		return "ASSERTED (E0)"
+	// Asserted coverage enforces nothing, so it renders as what it is. Naming the
+	// basis in parentheses rather than hard-coding "E0" keeps the rendering keyed
+	// to the coverage; today asserted is the one basis whose pair has no subject
+	// and therefore exactly one spelling, so this can only print "ASSERTED (E0)".
+	if k, ok := lookupBasis(b.Tier); ok {
+		if k.Coverage == CoverageAsserted {
+			return "ASSERTED (" + k.Canonical() + ")"
+		}
+		return "ENFORCED " + k.Canonical()
 	}
 	return "ENFORCED " + b.Tier
 }
@@ -363,9 +375,16 @@ func parseBasis(cell string, lineIdx int) (Basis, error) {
 	}
 	tier, rest, _ := strings.Cut(text, " ")
 	switch tier {
-	case "E0", "E1", "E2", "E3", TierNone, TierWithdrawn:
+	case TierNone, TierWithdrawn:
 	default:
-		return Basis{}, fmt.Errorf("propdoc: line %d: unknown evidence tier %q", lineIdx+1, tier)
+		// Either spelling is accepted and normalised to the canonical one, so a
+		// cell written as "chosen/implementation" derives the same Status as one
+		// written "E1" and the column stays uniform.
+		canonical, err := parseTier(tier, lineIdx)
+		if err != nil {
+			return Basis{}, err
+		}
+		tier = canonical
 	}
 	citation := strings.TrimSpace(strings.TrimLeft(strings.TrimSpace(rest), "—:-"))
 	if tier == TierNone && citation != "" {


### PR DESCRIPTION
Closes #130. This is the ruling on #130 implemented: **Basis records a pair, not an ordinal.**

## The diagnosis, restated

`E0 < E1 < E2 < E3` ranked by *technique* — did you use a generator, did you build a model — where what matters is *what was established*. Traced onto the grid, the ladder is one path that switches subject at its top step:

```
asserted → chosen/implementation → sampled/implementation → exhaustive/MODEL
```

Three consequences, all of which bit:

- **Three of the seven bases had no rung.**
- **The strongest of the three had to file below a model check.** #129 enumerated all 112 cells of the four-dimensional `verifyBundles` domain and found four never-executed blocks, one of them `Verifier.Verify` returning an error, at 81.3% coverage with three jobs green. That is `exhaustive/implementation`, and the only tiers available for it were E1 and E2 — beneath an exhaustive walk of an abstraction, because the top rung had spent itself on a change of subject.
- **The perverse ordering**, which was the tell: an exhaustive walk of a declared domain filing below a sampled walk of an undeclared one.

## Seven cells, not eight

`asserted` takes no subject: where nothing was executed there is no artifact the evidence was *about*, so `asserted/implementation` and `asserted/model` distinguish nothing measurable. Stated in §2 rather than left to be noticed, since a reader who counts the dimensions expects eight. It is also what makes `ASSERTED (E0)` the only rendering asserted coverage can produce, so `propdoc.Kind` needed no change.

Coverage **is** totally ordered; Subject is not an ordering at all; the *pair* is what resists one. That is what makes "chosen or stronger" well formed and "E1 or better" not.

## Nothing the column says changed

E0–E3 stay canonical on four of the seven, both spellings parse, and `chosen/implementation` derives the same Status as `E1`. **No Basis cell and no Status cell changed** — `propgen` reports no drift, same 34 propositions, identical distribution. That is the evidence this changes what the column *means* rather than what it *says*.

## Ranking, and what it isn't

§2 states the total order triage wants (coverage, then subject `model` < `implementation`) **and** the four places it ranks two bases the evidence does not: E2 vs E3; `exhaustive/implementation` vs `exhaustive/model` (stronger on faithfulness, **incomparable on domain size** — which is why no single number could hold #129); any two bases with different declared bounds; and the model subjects against `asserted`.

Recorded honestly: **that half is a note, not a check.** Nothing in this repository sorts propositions by basis, so the incomparability list cannot fire. §2 says what has to happen the first time something does — the order and the list move into `internal/propdoc` together, and the list gets the guard that makes it non-vacuous: every pair it names must be one the order actually ranks.

## Four rules moved, because the ordinal's removal left them ill-formed

| Rule | Was | Now |
|---|---|---|
| 1 | "E3 without a faithfulness argument is E0" | A `model` subject does not transfer, and a faithfulness argument does not rewrite it. **Permits** recording an unargued model check as `exhaustive/model` rather than erasing a real result to "nothing was executed"; **forbids** reading an argued one as evidence about the implementation. |
| 2 | "A generator's domain is part of the claim" | The declared bound is part of the claim **in both dimensions**, plus the R7 finding as a rule — see below. |
| 8 | "A tier is a claim about a commit" | "A basis is …" |
| 11 + §4 preamble | "re-derived evidence at E1 or better" | coverage `chosen` or stronger, subject `implementation`. |

Rule 11 is a **narrowing and it is deliberate**: under the ladder E3 was better than E1, so a discharge could have been claimed on an exhaustive check of a *model* — a counterexample in shipping code declared gone without executing that code. No row was discharged that way. The ordinal permitted it, which is enough.

Rule 2's new second clause is the R7 finding promoted: **a bound no member of which can satisfy the premise makes the coverage `asserted`, whatever ran.** 46,546,540 executions, green, over a domain in which no two distinct lockfiles can assemble the same environment at all. An empty search space and a clean search are indistinguishable in every number a run reports.

## A false paragraph in §2, and who wrote it

§2 asserted *"there are no fuzz targets … no proposition may claim E2 until one exists"*, quoting two commands. Re-run:

```
$ grep -rn '^func Fuzz' --include='*_test.go' .
spec/environment_id_r7_fuzz_test.go:445:func FuzzR7NoSpuriousDistinctions(f *testing.F) {
$ grep -rn 'testing/quick\|gopter\|pgregory\|rapid' --include='*.go' .   # no output
```

False since that target merged. §7 item 14 added the paragraph so the tier could not be "mistaken for available"; item 57 added the target; nothing connected them. **A section that asserts a technique's absence is a site the technique's arrival has to update** — the relocated-rule failure, committed by the author of the rule against it. Replaced with the commands and their real output.

## What fires

`internal/propdoc/basis_pair_test.go` (new file; no inherited test modified — `git diff --name-status origin/main...HEAD -- '*_test.go'` shows one `A` and nothing else):

- **§2's table against the registry, in both directions.** A spelling the document defines and the tool rejects breaks an author who followed the document; one the tool accepts and the document never defines is a basis nobody can look up. Only the first is loud on its own. The table is located by its header rather than by matching rows against the registry, because recognising rows by what the registry already knows would make one direction vacuous.
- **Cardinality stated (7), not derived** from either side — a count taken from the registry shrinks with the registry. Balance-style structural claims *are* derived: exactly one subjectless basis, exactly four legacy names, no duplicate spelling or legacy name.
- **Both spellings derive one Status**, including for a `Basis` built as a struct literal rather than parsed.
- **`exhaustive/implementation` is expressible and renders as itself**, and a live register row still outranks it (rule 5 is about the register; a stronger basis must not create an exemption).
- **The hole the pair notation opens.** The inherited distribution test names **five** status kinds by hand; a bare list of names reads as the complete set, and a pair-spelled cell with no legacy name derives a sixth the prose would omit with nothing objecting. The new test asserts the derived direction — whatever kinds the register produces, the document states them — with a control proving the search can fail.

## Falsifiability: nine probes, and the ninth was void

The suite passed on its first run, so every check was probed by breaking what it is about, with the failing check predicted first. All nine went red; the tree was verified clean after each.

| Probe | Result |
|---|---|
| drop a documented row | `TestBasisTableMatchesRegistry` |
| drop a registry entry | + `TestParseTierRejections` |
| misname a legacy tier | both |
| spell a pair inconsistently | both |
| break the table header | both |
| stop canonicalising | `TestBothSpellingsDeriveTheSameStatus`, 8 errors |
| revert `DeriveStatus`'s lookup | same test, 4 errors |
| delete a kind from the prose | new test **+ the inherited one** |
| state a kind nothing claims | the control fires |

**The canonicalisation probe was void on the first attempt: it did not compile** (`declared and not used: k`), and `go test` exits 1 for a build failure exactly as it does for a detected defect — so the first pass recorded it red with zero failing tests, and 8 of 9 nearly entered the record as 9 of 9. #129's rule was *assert the patch applied*, and the patch **did** apply. **The rule needs its second half: assert the mutant builds.** Re-run as `k.Canonical()` → `k.Spelling()`, it produced the predicted 8 errors.

## Verification

- `go test -race ./...` → rc 0, 20 packages ok (status captured unpiped).
- `golangci-lint run ./internal/propdoc/...` → 0 issues.
- `go run ./cmd/propgen` → `34 propositions, 41 register rows, no drift`; distribution unchanged.

Travels alone, as ruled — no proposition cites #129 in this PR. T1 and T5 stay uncited until this lands.