### PR TITLE
chore: enforce PROPERTIES.md rule 11 — a Discharged: Yes row must cite its evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -338,6 +338,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   timeout. Completes the two work items left unchecked in #36.
 
 ### Changed
+- **`PROPERTIES.md`'s rule 11 is enforced: a `Discharged: Yes` row that cites no
+  evidence now fails the build** (#137). Rule 11 — *a closed issue is a fact about the
+  tracker, not evidence about the tree* — was written in one session and never run
+  against the rows already in the table, so two cells reading verbatim `Yes — closed
+  completed` survived the amendment naming that exact string until an audit found them
+  (§7 item 78). `propdoc.Doc.DischargeDefects` reports every `Yes` row that names no
+  basis or cites no artifact; `cmd/propgen` refuses before it rewrites the Status
+  column, and `TestPropertiesRegisterMeetsRule11` fails the build. Two exported
+  sentinels, one per half of the rule, so a test asserts *which* check fired — a
+  rejection from the wrong reason is not evidence for the right one.
+
+  **It is a report over a parsed document, not a parse error, and that placement was
+  corrected rather than chosen.** The check first went into `parseRefutation`, which
+  turned the inherited `TestPropertiesGuardCanFail` red: that test proves the derivation
+  reads the register by flipping a live row to `Yes`, and a rule-11 guard in the parser
+  makes such a document unreadable — including by the tool that would fix it. `Unknown`
+  already had the right shape.
+
+  **What the green does not cover** is stated in rule 11 and in
+  `checkDischargeCitation`'s doc comment: a row can name a basis, cite a real path, and
+  track a genuinely closed issue whose fix and closure are both correct, and still be
+  false, because the issue can be about a different claim than the counterexample beside
+  it — *subject divergence*. Two instances known (`P4`/#54, `T7`/#48); every component of
+  each is true; neither was found by a check, and no parser can find the next one.
+
+  Measured before it was scoped: 6 `Yes` rows, **0 failing today and 2 of 8 failing one
+  commit earlier**. One of the three `Partially` rows would be reported and is out of
+  scope as **#142**, because a `Discharged` change travels alone.
+
+  **What changes per consumer**, enumerated from
+  `grep -rn 'propdoc\.' --include='*.go' .` (one caller, `cmd/propgen`) and from §6's
+  human procedure, which is the other consumer and has no callers to grep:
+  - **`go run ./cmd/propgen` now exits 1 on a register row marked `Yes` without a basis
+    and a citation**, naming the line and the tracking artifact, where it previously
+    rewrote the Status column from that row. Anyone amending §4 sees the refusal before
+    the column is regenerated.
+  - **`go test ./internal/propdoc/` now fails on such a row**, so the document cannot
+    reach `main` carrying one.
+
+  No production behaviour changes: `internal/propdoc` and `cmd/propgen` are documentation
+  tooling, not part of any shipped command. Ten mutation probes, each failing-test set
+  predicted before the run, 10 for 10 (§7 item 79).
 - **Two `Discharged: Yes` register rows are corrected to `No` and `Partially` on
   re-derived evidence** (#137). §2.1 rule 11 says a closed issue is a fact about the
   tracker, not evidence about the tree; it was added after the rows it now governs and

--- a/PROPERTIES.md
+++ b/PROPERTIES.md
@@ -25,6 +25,17 @@ finding is §0.2.
 > propositions stopped claiming more than their evidence supports, which is the
 > instrument working — so the totals cannot be read as a direction of travel in
 > either direction.
+>
+> **This is a property of the generator, not a caveat about four occasions.** It
+> has now been rediscovered four times — §7 items 46, 55 and 62, and item 79 on
+> 2026-08-22, where `T7` moved from `REFUTED (1 of 4 live)` to
+> `REFUTED (3 of 4 live)` and every number above held — so it is stated once here
+> as what it is. `Distribution` tallies `Kind(status)`
+> (`internal/propdoc/propdoc.go:252`) and `Kind` discards the parenthesised detail
+> by construction (`:261`), so a movement expressible only in an `(n of m live)`
+> count **cannot** appear in these totals. No future amendment demonstrates this
+> again; a movement that leaves the totals unchanged is the expected reading, and
+> the number to check is the cell.
 
 Provenance for every measurement in this document unless stated otherwise:
 
@@ -464,6 +475,37 @@ the caveat is a caveat about nothing.
     Two representations agreeing is not evidence that either is right; a generated
     field removes drift, not error. The audit obligation in §6.1 exists because
     nothing mechanical can close this gap.
+
+    **Half of this rule is now enforced, and the boundary matters more than the
+    enforcement.** `propdoc.Doc.DischargeDefects` (`internal/propdoc/propdoc.go:363`)
+    reports every `Yes` row that names no basis or cites no artifact; `propgen`
+    refuses to run and `TestPropertiesRegisterMeetsRule11` fails the build
+    (`internal/propdoc/discharge_citation_test.go:143`). It is a report over a parsed
+    document rather than a parse error, because a policy violation must not make the
+    document unreadable by the tool that would fix it. The occasion was that this rule
+    was written in one session and never run against the rows already in the table:
+    two cells reading verbatim `Yes — closed completed` survived the amendment that
+    names that exact string, for a day, and were found by an audit rather than by a
+    check (§7 item 78).
+
+    **What no check here can see: subject divergence.** A row can name a basis, cite a
+    real path, and track a genuinely closed issue whose fix is real and whose closure
+    is correct — and still be false, because the issue is about a *different claim*
+    than the counterexample beside it. Every component is true and the row is not.
+    Two instances are known, and each was found by a different accident rather than by
+    any check:
+
+    | Row | Tracking | What the row claimed | What the closed issue was about |
+    |---|---|---|---|
+    | `P4` | #54 | Stage 7 refuses profiles resolved against the **shipped catalog** | `file://` **scheme dispatch**, which a fixture registry exercises (§7 item 38) |
+    | `T7` | #48 | `packages:` entries are **unattested** | that those entries **will not be installed** by `strata run` (§7 item 78) |
+
+    A syntactic check cannot reach this: the discharge is well-formed by every
+    criterion available to a parser, and the divergence lives between the row's
+    subject and the issue's. Finding it means reading the tracked artifact and
+    comparing subjects, which is the §6.1 audit obligation and nothing else. So the
+    green from `TestPropertiesRegisterMeetsRule11` bounds the closure-for-citation
+    conflation only, and must not be read as covering the class above.
 
 ---
 
@@ -2168,3 +2210,89 @@ states the standard it violated and puts a cadence on finding the next.
     counterexample beside it, so no parser can find the next one. The guard that **is**
     mechanical — a `Discharged` cell beginning `Yes` with no citation — is filed as the
     next change, stated as failing on 2 of 8 rows before these two were fixed.
+
+79. **The mechanical half of rule 11 becomes a check, the unmechanical half gets a
+    name, and putting the check in the wrong place was caught by a test written for
+    something else.** Rule 11 has been enforceable since the day it was written and was
+    not enforced, which is why item 78 exists. `Doc.DischargeDefects`
+    (`internal/propdoc/propdoc.go:363`) now reports every `Yes` row naming no basis or
+    citing no artifact, `propgen` refuses before it rewrites the Status column
+    (`cmd/propgen/main.go:51-57`), and `TestPropertiesRegisterMeetsRule11`
+    (`internal/propdoc/discharge_citation_test.go:143`) fails the build.
+
+    **Measured before it was scoped**, on `1a7646f`, because a check whose false-positive
+    rate is unknown is a hypothesis:
+
+    ```
+    $ awk -F'|' '/^\| /{c=$6; gsub(/^ +| +$/,"",c);
+        if (c ~ /^(Yes|No|Partially)/){split(c,a," "); n[a[1]]++}} END{for(k in n) print k, n[k]}' PROPERTIES.md
+    Partially 3
+    Yes 6
+    No 32
+    ```
+
+    Six `Yes` rows, **0 failing today** and **2 of 8 failing at `cc6e0c4`** — the check is
+    introduced against the population it was built for, and that population was fixed one
+    commit earlier, which is why the corpus test is the weaker of the two claims in its
+    file. Of the three `Partially` rows one (`I6` / #51) names neither a basis nor a path
+    for its discharged half and would be reported; the check is scoped to `Yes` and that
+    row is **#142**, because a `Discharged` change travels alone.
+
+    **The placement was wrong and an unrelated test said so.** The check first went into
+    `parseRefutation`, where the cell was already being split — placement by convenience.
+    `TestPropertiesGuardCanFail` then went red: that test proves the derivation reads the
+    register by taking the first live row and flipping its cell to `Yes`, and the row it
+    picks is `P4`/#54, whose reopened cell names no basis. A rule-11 guard in the parser
+    makes a document containing an unjustified discharge **unreadable** — by `propgen`,
+    which is the tool that would fix it, and by any test constructing a hypothetical
+    register. `Unknown` already had the right shape: a report over a parsed document, with
+    the enforcement in a test. Two things worth keeping: a policy check does not belong in
+    a parser, and the control that caught it was written for a different purpose, which is
+    the second time in two days that a control outside the instrument caught the
+    instrument (§7 item 78's mutant, stopped by the pre-commit gate's named-path staging).
+
+    **Ten mutation probes, each failing set predicted before the run, 10 for 10** — full
+    output at `/tmp/mutout_rule11.txt`, restore in a `trap ... EXIT` per item 78:
+
+    | Probe | Mutation | Failing tests |
+    |---|---|---|
+    | A | scope widened from `Yes` to `Yes`+`Partially` | `CheckDischargeCitation`, `PropertiesRegisterMeetsRule11` |
+    | B | basis check condition inverted | `CheckDischargeCitation`, `PropertiesRegisterMeetsRule11`, `DischargeReportRejectsTheRegisterAsItWas` |
+    | C | rule 11's two halves checked in the other order | `CheckDischargeCitation`, `DischargeReportRejectsTheRegisterAsItWas` |
+    | D | error message reports the 0-based line | `DischargeGuardReportsItsLine` |
+    | E | `DischargeDefect.Line` reports the 0-based line | `DischargeReportRejectsTheRegisterAsItWas` |
+    | F | citation pattern loosened to any backticked span | `CheckDischargeCitation`, `DischargeCitationPatternIsNotSatisfiedByProse` |
+    | G | basis pattern accepts any E-digit | `DischargeBasisPatternCoversEveryBasis` |
+    | H | basis pattern loses the three pair-only spellings | `CheckDischargeCitation`, `DischargeBasisPatternCoversEveryBasis` |
+    | I | `DischargeDefects` stops at the first defect | `DischargeReportRejectsTheRegisterAsItWas` |
+    | J | `DischargeDefects` collects the rows that passed | `PropertiesRegisterMeetsRule11`, `DischargeReportRejectsTheRegisterAsItWas` |
+
+    Two of these are about the tests rather than the guard. **I** is why the fixture
+    carries two offending rows: with one, a report that stopped after the first defect was
+    undetectable. **H** is a stated bound — `PropertiesRegisterMeetsRule11` does **not**
+    fail under H, because all six live `Yes` cells spell `E1` and none uses pair notation,
+    so the corpus cannot witness a basis pattern that has lost `chosen/model`,
+    `sampled/model` or `exhaustive/implementation`. That is what
+    `TestDischargeBasisPatternCoversEveryBasis` is for, and it iterates `Bases()` rather
+    than a hand-written list of E-names, which is the only form that covers the three
+    spellings with no legacy name.
+
+    **Subject divergence gets its name in rule 11, and the boundary is stated where the
+    green is read.** The class: a row marked discharged against a valid closed issue whose
+    fix is real and whose closure is correct, where the issue's subject differs from the
+    counterexample beside it. Every component true, the row false. Both known instances
+    are now tabulated in rule 11 — `P4`/#54 (item 38) and `T7`/#48 (item 78) — and each
+    was found by a different accident, neither by a check. No parser can reach it, so
+    `TestPropertiesRegisterMeetsRule11`'s green bounds the closure-for-citation conflation
+    only. Recorded in rule 11 itself rather than only here, because the place a bound has
+    to be legible is beside the thing whose green invites the wider reading.
+
+    **The distribution caveat is restated as a property of the generator.** This is the
+    fourth session in which a movement failed to appear in the header's totals (items 46,
+    55, 62, and 78's `T7` count). `Distribution` tallies `Kind(status)`
+    (`internal/propdoc/propdoc.go:252`) and `Kind` discards parenthesised detail by
+    construction (`:261`), so a movement expressible only in an `(n of m live)` count
+    **cannot** appear there — it is derivable, not a tally of four coincidences. The block
+    quote in the header now says so and says that no future amendment demonstrates it
+    again. Four rediscoveries is the cost of recording a trap as a note: a note does not
+    fire.

--- a/cmd/propgen/main.go
+++ b/cmd/propgen/main.go
@@ -45,6 +45,16 @@ func run(path string, write bool) error {
 	if unknown := doc.Unknown(); len(unknown) > 0 {
 		return fmt.Errorf("register names propositions section 3 does not state: %v", unknown)
 	}
+	// Reported before the Status column is touched: a row whose discharge is not
+	// justified makes every count derived from it wrong, so rewriting the column
+	// on top of one would publish a number the register does not support.
+	if defects := doc.DischargeDefects(); len(defects) > 0 {
+		for _, def := range defects {
+			fmt.Fprintf(os.Stderr, "%s:%d: %s: %v\n", path, def.Line, def.Tracking, def.Err)
+		}
+		return fmt.Errorf("%d register row(s) marked %q without naming and citing their evidence "+
+			"(section 2.1 rule 11)", len(defects), propdoc.DischargedYes)
+	}
 
 	drifts := doc.Drifts()
 	if len(drifts) == 0 {

--- a/internal/propdoc/discharge_citation_test.go
+++ b/internal/propdoc/discharge_citation_test.go
@@ -1,0 +1,311 @@
+package propdoc
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+// Tests for the §2.1 rule 11 parse guard: a register row may be marked
+// `Discharged: Yes` only on evidence it names and cites, and "closed completed"
+// is neither.
+//
+// The rows are constructed here rather than taken from PROPERTIES.md on purpose.
+// A guard measured only against the current document says nothing about what it
+// would do to the next row — and the whole reason this guard exists is that rule
+// 11 was written and never run against the rows already in the table (#137).
+// TestDischargeGuardAcceptsTheCurrentRegister below adds the corpus check as a
+// separate claim.
+
+// TestCheckDischargeCitation is the must-reject / must-accept table. Each
+// rejection asserts *which* reason fired: a cell missing both halves must be
+// reported as missing the basis, not accepted because some other check caught
+// it, and a rejection from the wrong reason is not evidence for the right one.
+func TestCheckDischargeCitation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cell string
+		want error // nil means the cell must be accepted
+	}{
+		{
+			name: "the closure string, which is what rule 11 names",
+			cell: "Yes — closed completed",
+			want: ErrDischargeNoBasis,
+		},
+		{
+			name: "a bare Yes offers nothing at all",
+			cell: "Yes",
+			want: ErrDischargeNoBasis,
+		},
+		{
+			name: "a basis with no artifact is a claim about strength only",
+			cell: "Yes — E1, verified by hand on the release branch",
+			want: ErrDischargeNoCitation,
+		},
+		{
+			name: "an issue reference is not an artifact citation",
+			cell: "Yes — E1, fixed by #104 and confirmed",
+			want: ErrDischargeNoCitation,
+		},
+		{
+			name: "a backticked command is not an artifact citation",
+			cell: "Yes — chosen/implementation, `go test ./internal/agent/`",
+			want: ErrDischargeNoCitation,
+		},
+		{
+			name: "an artifact with no basis leaves rule 11's floor unstated",
+			cell: "Yes — see `internal/agent/verify_bundles_test.go:291`",
+			want: ErrDischargeNoBasis,
+		},
+		{
+			name: "a path outside backticks is prose, not a citation",
+			cell: "Yes — E1, internal/agent/verify_bundles_test.go:291",
+			want: ErrDischargeNoCitation,
+		},
+		{
+			name: "legacy basis name with a Go path",
+			cell: "Yes — E1, `cmd/strata/run_verify_test.go:264,350,519`",
+			want: nil,
+		},
+		{
+			name: "pair spelling with a Go path",
+			cell: "Yes — exhaustive/implementation, `internal/agent/boot_matrix_test.go:88`",
+			want: nil,
+		},
+		{
+			name: "a non-Go artifact is a legitimate citation",
+			cell: "Yes — E1, `.github/workflows/ci.yml:90` pins the version the run installs",
+			want: nil,
+		},
+		{
+			name: "two citations and prose between them",
+			cell: "Yes — E1, `internal/agent/verify_bundles_test.go:291` (empty bytes refused) and " +
+				"`cmd/strata-agent/s3_bundle_contract_test.go:22` (the shipped fetcher)",
+			want: nil,
+		},
+		// The two cells below are why the guard is keyed on Discharged rather
+		// than applied to every cell: No and Partially rows carry no discharge
+		// to justify. Partially is a deliberate, measured exclusion (#142), not
+		// an oversight — see checkDischargeCitation's doc comment.
+		{
+			name: "No needs no citation",
+			cell: "No",
+			want: nil,
+		},
+		{
+			name: "Partially is out of scope today even with nothing cited",
+			cell: "Partially — validated out of band; the install still ignores the pin",
+			want: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			discharged, rest, _ := strings.Cut(tc.cell, " ")
+			err := checkDischargeCitation(discharged, rest, 0)
+			switch {
+			case tc.want == nil && err != nil:
+				t.Errorf("cell %q was rejected: %v", tc.cell, err)
+			case tc.want != nil && err == nil:
+				t.Errorf("cell %q was accepted; want %v", tc.cell, tc.want)
+			case tc.want != nil && !errors.Is(err, tc.want):
+				t.Errorf("cell %q rejected for the wrong reason: got %v, want %v", tc.cell, err, tc.want)
+			}
+		})
+	}
+}
+
+// TestDischargeGuardReportsItsLine checks the part of the error a reader acts
+// on. A guard that rejects the document without saying where costs more than it
+// saves, and the line number is off-by-one-able: parseRefutation counts from
+// zero and the message must count from one.
+func TestDischargeGuardReportsItsLine(t *testing.T) {
+	err := checkDischargeCitation(DischargedYes, "— closed completed", 684)
+	if err == nil {
+		t.Fatal("want a rejection")
+	}
+	if !strings.Contains(err.Error(), "line 685") {
+		t.Errorf("error does not name line 685 (0-based 684): %v", err)
+	}
+	if !strings.Contains(err.Error(), "closed completed") {
+		t.Errorf("error does not quote the offending cell: %v", err)
+	}
+}
+
+// TestPropertiesRegisterMeetsRule11 is the enforcement: it is what makes rule 11
+// a check rather than a paragraph. The rule was written in an earlier session and
+// nothing ran it against the rows already in the table, which is how two
+// `Yes — closed completed` cells survived the change that forbade exactly that
+// string (#137). This test is the arrow pointed the other way.
+//
+// It is deliberately the *weaker* of the two claims in this file: it says only
+// that today's rows pass. TestDischargeReportRejectsTheRegisterAsItWas below is
+// the one that shows the report can fire at all.
+func TestPropertiesRegisterMeetsRule11(t *testing.T) {
+	src, err := os.ReadFile(propertiesPath())
+	if err != nil {
+		t.Fatalf("read PROPERTIES.md: %v", err)
+	}
+	doc, err := Parse(src)
+	if err != nil {
+		t.Fatalf("Parse PROPERTIES.md: %v", err)
+	}
+
+	// The premise, asserted before the absence of defects is read: a register with
+	// no Yes rows would pass this test without exercising the check once, and so
+	// would a register the parser had stopped reading partway through.
+	yes := 0
+	for _, r := range doc.Register() {
+		if r.Discharged == DischargedYes {
+			yes++
+		}
+	}
+	if yes == 0 {
+		t.Fatal("the register has no Discharged: Yes rows, so this test exercised nothing")
+	}
+
+	for _, def := range doc.DischargeDefects() {
+		t.Errorf("PROPERTIES.md:%d: %s is marked %q but %v\n    cell: %s",
+			def.Line, def.Tracking, DischargedYes, def.Err, def.Cell)
+	}
+	t.Logf("rule 11 checked %d Discharged: %s rows of %d", yes, DischargedYes, len(doc.Register()))
+}
+
+// TestDischargeReportRejectsTheRegisterAsItWas is the check with teeth. The two
+// cells this report was built for are gone from the document — #141 replaced
+// them — so a clean report on today's register is equally consistent with the
+// report working and with DischargeDefects returning nil unconditionally. This
+// reconstructs a register containing the T7 row as it read before #141 and
+// requires exactly that row to be named.
+//
+// The fixture carries four rows for three separate reasons, none of which a
+// one-row document could establish: the compliant Yes row must be absent from the
+// report, the No row must be absent for a different reason, and there are **two**
+// offending rows so that a report which stopped at the first is distinguishable
+// from one that reports them all. The two offend differently, one per half of
+// rule 11, so the sentinels are read off a single report.
+func TestDischargeReportRejectsTheRegisterAsItWas(t *testing.T) {
+	const head = "## 3. Propositions\n\n| # | P | Verdict | Basis | Status | Evidence |\n" +
+		"|---|---|---|---|---|---|\n" +
+		"| **T7** | the resolver expanded unattested formations | SOUND | none | REFUTED | e |\n" +
+		"| **I1** | bundles are verified before use | SOUND | none | REFUTED | e |\n" +
+		"| **P4** | stage 7 refuses profiles resolved offline | SOUND | none | REFUTED | e |\n" +
+		"| **R1** | resolution is deterministic | SOUND | none | REFUTED | e |\n"
+	const regHead = "\n## 4. Refutation register\n\n" +
+		"| Proposition | Counterexample | Capability | Tracking | Discharged |\n" +
+		"|---|---|---|---|---|\n"
+	// The first offender is verbatim what T7/#49's Discharged cell read at
+	// 6555716: no basis and no citation.
+	const noBasis = "| T7 | expanded an unattested formation silently | H1 | #49 | Yes — closed completed |\n"
+	// The second names a basis and still cites nothing, which is the near miss
+	// either side of "closed completed" — a stronger-looking cell that offers the
+	// reader no artifact to check.
+	const noCitation = "| P4 | resolved offline against the shipped catalog | H1 | #54 | Yes — E1, confirmed by hand against the fixture registry |\n"
+	const compliant = "| I1 | accepted an empty bundle | H2 | #59 | Yes — E1, `internal/agent/verify_bundles_test.go:291` |\n"
+	const undischarged = "| R1 | ResolvedAt is wall-clock | H1 | #61 | No |\n"
+
+	src := head + regHead + compliant + noBasis + undischarged + noCitation
+	doc, err := Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("Parse the reconstructed register: %v", err)
+	}
+	if got := len(doc.Register()); got != 4 {
+		t.Fatalf("the fixture parsed %d register rows, want 4 — it no longer represents the "+
+			"case this test is about", got)
+	}
+
+	// Line numbers derived from the fixture rather than counted by hand, so
+	// editing it cannot silently point an assertion at the wrong row.
+	lineOf := func(row string) int {
+		return strings.Count(src[:strings.Index(src, row)], "\n") + 1
+	}
+	want := []DischargeDefect{
+		{Line: lineOf(noBasis), Tracking: "#49", Err: ErrDischargeNoBasis},
+		{Line: lineOf(noCitation), Tracking: "#54", Err: ErrDischargeNoCitation},
+	}
+
+	defects := doc.DischargeDefects()
+	if len(defects) != len(want) {
+		t.Fatalf("want the %d offending rows reported and no others, got %d: %+v",
+			len(want), len(defects), defects)
+	}
+	for i, w := range want {
+		got := defects[i]
+		if got.Tracking != w.Tracking {
+			t.Errorf("defect %d names %q, want the offending row %s", i, got.Tracking, w.Tracking)
+		}
+		if !errors.Is(got.Err, w.Err) {
+			t.Errorf("defect %d (%s) was reported for the wrong reason: %v", i, w.Tracking, got.Err)
+		}
+		if got.Line != w.Line {
+			t.Errorf("defect %d (%s) points at line %d, want %d", i, w.Tracking, got.Line, w.Line)
+		}
+	}
+	if !strings.Contains(defects[0].Cell, "closed completed") {
+		t.Errorf("the report does not quote the offending cell: %q", defects[0].Cell)
+	}
+}
+
+// TestDischargeCitationPatternIsNotSatisfiedByProse guards the regexp itself.
+// A citation pattern loose enough to match ordinary prose would accept every
+// cell, which is the failure mode where the guard reports green forever.
+func TestDischargeCitationPatternIsNotSatisfiedByProse(t *testing.T) {
+	for _, prose := range []string{
+		"closed completed",
+		"`the resolver` refuses it now",
+		"confirmed against the shipped catalog",
+		"`strata verify --packages` validates against PyPI out of band",
+		"E1, no longer reachable",
+	} {
+		if dischargeCitation.MatchString(prose) {
+			t.Errorf("the citation pattern matches prose %q, so it cannot distinguish a citation "+
+				"from a claim", prose)
+		}
+	}
+	// And the converse, so a pattern that matches nothing does not pass this
+	// test by being useless.
+	for _, cite := range []string{
+		"`internal/agent/agent.go:310-323`",
+		"`spec/docsnippets_test.go`",
+		"`.github/workflows/ci.yml:90`",
+		"`cmd/strata/formations/hpc-mpi@2026.03.yaml`",
+	} {
+		if !dischargeCitation.MatchString(cite) {
+			t.Errorf("the citation pattern does not match %q, which is a citation the register uses", cite)
+		}
+	}
+}
+
+// TestDischargeBasisPatternCoversEveryBasis ties the guard's basis pattern to
+// section 2's grid rather than to a hand-written list. Bases() is the parser's
+// registry and basis_pair_test.go already holds it to the document's table in
+// both directions, so iterating it means the guard accepts exactly the bases the
+// document defines — including the three that have no legacy name, which a
+// hand-written list of E-names would silently omit.
+//
+// Both spellings are checked because a cell may be authored either way: the
+// parser normalises a Basis cell's tier, but a Discharged cell is prose and this
+// guard reads it as written.
+func TestDischargeBasisPatternCoversEveryBasis(t *testing.T) {
+	for _, b := range Bases() {
+		for _, spelling := range []string{b.Spelling(), b.Canonical()} {
+			if !dischargeBasis.MatchString(spelling) {
+				t.Errorf("the basis pattern does not match %q, a basis section 2 defines", spelling)
+			}
+		}
+	}
+	// Non-vacuity: the loop above is over a registry, so assert it was not empty
+	// and that it did carry all seven — a Bases() returning one element would
+	// pass every assertion above.
+	if got := len(Bases()); got != 7 {
+		t.Fatalf("Bases() returned %d bases, want the 7 of section 2; the loop above checked %d", got, got)
+	}
+	// A pattern matching any capital-E-digit would accept "E9"; any
+	// slash-separated pair would accept "guessed/implementation"; and a bare
+	// coverage is not a basis, since section 2 gives every coverage but asserted
+	// a subject.
+	for _, notABasis := range []string{"E4", "E9", "guessed/implementation", "chosen/guess", "exhaustive", "chosen"} {
+		if dischargeBasis.MatchString(notABasis) {
+			t.Errorf("the basis pattern matches %q, which section 2 does not define", notABasis)
+		}
+	}
+}

--- a/internal/propdoc/propdoc.go
+++ b/internal/propdoc/propdoc.go
@@ -15,7 +15,9 @@
 package propdoc
 
 import (
+	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 )
@@ -79,12 +81,80 @@ type Refutation struct {
 	// Discharged is DischargedYes, DischargedNo or DischargedPartially.
 	Discharged string
 
+	// evidence is the rest of the Discharged cell after that token: for a
+	// discharged row, the basis and citation rule 11 requires. It is kept
+	// unexported because DischargeDefects is the only reader, and a second
+	// exported spelling of the cell would be a second thing to keep in step.
+	evidence string
+
 	lineIdx int
 }
 
 // Live reports whether the refutation is still standing. Partially discharged
 // counts as live: a counterexample half-answered still refutes.
 func (r Refutation) Live() bool { return r.Discharged != DischargedYes }
+
+// Rejection reasons for a Discharged: Yes cell, exported so a test can assert
+// which check fired rather than that some check did. A rejection from the wrong
+// reason is not evidence for the right one.
+var (
+	// ErrDischargeNoBasis is returned when a Yes cell names no basis, so the
+	// reader cannot tell whether the evidence meets rule 11's floor.
+	ErrDischargeNoBasis = errors.New("propdoc: a Discharged: Yes cell must name the basis of its evidence")
+	// ErrDischargeNoCitation is returned when a Yes cell cites no artifact —
+	// the case "Yes — closed completed" is, where the only thing offered is a
+	// fact about the tracker.
+	ErrDischargeNoCitation = errors.New("propdoc: a Discharged: Yes cell must cite the evidence, not the closure")
+)
+
+// dischargeCitation matches a backtick-quoted span naming a file, optionally
+// with line numbers. The extension list is wider than the current corpus needs
+// (every citation today is a .go path) so that citing a workflow, a recipe or a
+// document is not a rejection.
+var dischargeCitation = regexp.MustCompile("`[^`]*[\\w./-]+\\.(?:go|md|ya?ml|sh|json)(?::[\\d,-]+)?[^`]*`")
+
+// dischargeBasis matches any of the seven bases of section 2, in either
+// spelling. Legacy E0-E3 name four of them; the other three have pair
+// spellings only.
+var dischargeBasis = regexp.MustCompile(`\b(?:E[0-3]|asserted|(?:chosen|sampled|exhaustive)/(?:model|implementation))\b`)
+
+// checkDischargeCitation is the per-cell predicate behind DischargeDefects: it
+// applies section 2.1 rule 11 to one Discharged cell. A row may be marked Yes
+// only on re-derived evidence, and it cites that evidence rather than the
+// closure. Rule 11 makes two demands — the evidence is at coverage `chosen` or
+// stronger with subject `implementation`, and the row cites it — so the cell has
+// to say both which basis and which artifact, and each missing half gets its own
+// error.
+//
+// # What this cannot catch
+//
+// A cell can name a basis, cite a real path, track a genuinely closed issue, and
+// still be false, because the closed issue can be about a *different claim* than
+// the counterexample beside it. Two instances are known — P4/#54 (the row was
+// about the embedded catalog, #54 fixed file:// scheme dispatch) and T7/#48 (the
+// row says `packages:` entries are unattested, #48 added a not-installed
+// warning). Every component of such a row is true. Nothing here, and no parser,
+// can see it: finding it means reading the tracked issue and comparing subjects.
+// This function's green is therefore not evidence about that class.
+//
+// Scope, measured on 1a7646f: the check runs on Yes only. Of the three
+// Partially cells, one (I6/#51) names neither a basis nor a path for its
+// discharged half and would be reported; that row needs a re-derivation, and a
+// Discharged change travels alone, so it is #142 rather than a change here.
+func checkDischargeCitation(discharged, rest string, lineIdx int) error {
+	if discharged != DischargedYes {
+		return nil
+	}
+	if !dischargeBasis.MatchString(rest) {
+		return fmt.Errorf("propdoc: line %d: Discharged cell is %q with no basis named: %w",
+			lineIdx+1, strings.TrimSpace(discharged+" "+rest), ErrDischargeNoBasis)
+	}
+	if !dischargeCitation.MatchString(rest) {
+		return fmt.Errorf("propdoc: line %d: Discharged cell is %q with no artifact cited: %w",
+			lineIdx+1, strings.TrimSpace(discharged+" "+rest), ErrDischargeNoCitation)
+	}
+	return nil
+}
 
 // Doc is a parsed PROPERTIES.md.
 type Doc struct {
@@ -259,6 +329,52 @@ func (d *Doc) Unknown() []string {
 	return out
 }
 
+// DischargeDefect describes a register row marked Discharged: Yes whose cell does
+// not meet section 2.1 rule 11.
+type DischargeDefect struct {
+	// Line is the 1-indexed line of the register row.
+	Line int
+	// Tracking is the row's Tracking cell, so the reader can go to the artifact.
+	Tracking string
+	// Cell is the Discharged cell as written.
+	Cell string
+	// Err wraps ErrDischargeNoBasis or ErrDischargeNoCitation, so a caller can
+	// tell which of rule 11's two demands the row fails.
+	Err error
+}
+
+// DischargeDefects returns every register row marked Discharged: Yes that names
+// no basis or cites no artifact, in document order — the "closed completed" case
+// rule 11 was written against, and the near misses either side of it.
+//
+// This is a report rather than a parse error, and the distinction is the whole
+// design. Rule 11 is a policy about what a row may claim, not a statement about
+// whether the row can be read; making a violation a parse failure would mean a
+// document with one unjustified discharge could not be read *at all* — not by
+// propgen, which is the tool that would regenerate its Status column, and not by
+// a test constructing a hypothetical register to prove some other check can fail.
+// Unknown has the same shape for the same reason. The enforcement lives where it
+// belongs, in a CI test asserting this slice is empty, so a rule-11 violation
+// fails the build with a message naming the row rather than aborting every reader
+// of the document.
+//
+// The predicate is checkDischargeCitation, whose doc comment states what it
+// cannot see.
+func (d *Doc) DischargeDefects() []DischargeDefect {
+	var out []DischargeDefect
+	for _, r := range d.reg {
+		if err := checkDischargeCitation(r.Discharged, r.evidence, r.lineIdx); err != nil {
+			out = append(out, DischargeDefect{
+				Line:     r.lineIdx + 1,
+				Tracking: r.Tracking,
+				Cell:     strings.TrimSpace(r.Discharged + " " + r.evidence),
+				Err:      err,
+			})
+		}
+	}
+	return out
+}
+
 // section identifiers used while scanning.
 type section int
 
@@ -399,7 +515,7 @@ func parseRefutation(cells []string, lineIdx int) (Refutation, error) {
 		return Refutation{}, fmt.Errorf("propdoc: line %d: register row has %d fields, want %d",
 			lineIdx+1, len(cells), registerCells)
 	}
-	discharged, _, _ := strings.Cut(strings.TrimSpace(cells[5]), " ")
+	discharged, rest, _ := strings.Cut(strings.TrimSpace(cells[5]), " ")
 	switch discharged {
 	case DischargedYes, DischargedNo, DischargedPartially:
 	default:
@@ -421,6 +537,7 @@ func parseRefutation(cells []string, lineIdx int) (Refutation, error) {
 		Capability: strings.Trim(strings.TrimSpace(cells[3]), "`*"),
 		Tracking:   strings.TrimSpace(cells[4]),
 		Discharged: discharged,
+		evidence:   rest,
 		lineIdx:    lineIdx,
 	}, nil
 }


### PR DESCRIPTION
## What

§2.1 rule 11 of `PROPERTIES.md` says an issue closing is a fact about the tracker, not
evidence about the code: a register row may be marked `Discharged: Yes` only on
re-derived evidence at coverage `chosen` or stronger with subject `implementation`, and
**the row cites that evidence rather than the closure**. That rule has been enforceable
since the day it was written and was not enforced. Two cells reading verbatim
`Yes — closed completed` survived the amendment that names that exact string, for a day,
and were found by an audit (#141, §7 item 78) rather than by a check.

This is the check.

- `propdoc.Doc.DischargeDefects` reports every `Yes` row that names no basis or cites no
  artifact.
- `cmd/propgen` refuses **before** it rewrites the Status column — a row whose discharge
  is unjustified makes every count derived from it wrong.
- `TestPropertiesRegisterMeetsRule11` fails the build.
- Two exported sentinels, `ErrDischargeNoBasis` and `ErrDischargeNoCitation`, one per
  half of the rule, so a test asserts *which* check fired. A rejection from the wrong
  reason is not evidence for the right one.

## The guard is stated failing on the population it was built for

Measured on `1a7646f` before the check was scoped, because a prescribed check whose
false-positive rate is unknown is a hypothesis:

| Discharged | Rows | Failing today (`1a7646f`) | Failing one commit earlier (`cc6e0c4`) |
|---|---|---|---|
| `Yes` | 6 | **0** | **2 of 8** |
| `Partially` | 3 | 1 — out of scope | 1 |
| `No` | 32 | n/a — not checked | n/a |

```
$ awk -F'|' '/^\| /{c=$6; gsub(/^ +| +$/,"",c);
    if (c ~ /^(Yes|No|Partially)/){split(c,a," "); n[a[1]]++}} END{for(k in n) print k, n[k]}' PROPERTIES.md
Partially 3
Yes 6
No 32
```

**The two rows this check exists for are gone** — #141 replaced them one commit before
this branch. So a clean report on today's register is equally consistent with the check
working and with `DischargeDefects` returning `nil` unconditionally, which is why the
corpus test is explicitly the *weaker* of the two claims in its file and why
`TestDischargeReportRejectsTheRegisterAsItWas` reconstructs the register as it read at
`6555716` and requires the offending rows to be named.

The one `Partially` row that would be reported (`I6` / #51, names neither a basis nor a
path for its discharged half) is **#142**, not a change here: a `Discharged` change
travels alone.

## What this check cannot catch — read this before reading the green

The check catches a **syntactic non-citation**. It cannot catch a **citation to work
about something else**.

A row can name a basis, cite a real path, and track a genuinely closed issue whose fix
is real and whose closure is correct — and still be false, because the issue can be
about a *different claim* than the counterexample beside it. Every component is true and
the row is not. The class is named **subject divergence** and both known instances are
now tabulated in rule 11:

| Row | Tracking | What the row claimed | What the closed issue was about |
|---|---|---|---|
| `P4` | #54 | Stage 7 refuses profiles resolved against the **shipped catalog** | `file://` **scheme dispatch**, which a fixture registry exercises (§7 item 38) |
| `T7` | #48 | `packages:` entries are **unattested** | that those entries **will not be installed** by `strata run` (§7 item 78) |

Each was found by a different accident. **Neither was found by a check, and no parser
can find the next one** — the discharge is well-formed by every criterion available to a
parser, and the divergence lives between the row's subject and the issue's. Finding it
means reading the tracked artifact and comparing subjects, which is the §6.1 audit
obligation and nothing else.

So `TestPropertiesRegisterMeetsRule11`'s green bounds the closure-for-citation
conflation **only**. It is stated in rule 11 itself, in `checkDischargeCitation`'s doc
comment, and here, because the place a bound has to be legible is beside the thing whose
green invites the wider reading.

## The placement was wrong, and a test written for something else said so

The check first went into `parseRefutation`, where the cell was already being split —
placement by convenience. `TestPropertiesGuardCanFail` (inherited, unmodified) then went
red:

```
--- FAIL: TestPropertiesGuardCanFail (0.00s)
    propdoc_test.go:159: Parse mutated: propdoc: line 683: Discharged cell is "Yes — **reopened 2026-08-21**. […]" with no basis named: propdoc: a Discharged: Yes cell must name the basis of its evidence
```

That test proves the derivation reads the register by taking the first live row and
flipping its cell to `Yes`. A rule-11 guard in the parser makes a document containing an
unjustified discharge **unreadable** — by `propgen`, which is the tool that would fix
it, and by any test constructing a hypothetical register.

Rule 11 is a policy about what a row may claim, not a statement about whether the row
can be read. `Doc.Unknown` already had the right shape: a report over a parsed document,
with the enforcement in a test. Two things worth keeping — a policy check does not
belong in a parser, and **the control that caught it was written for a different
purpose**, which is the second time in two days that a control outside the instrument
caught the instrument (§7 item 78's mutant, stopped by the pre-commit gate's named-path
staging).

## Ten mutation probes, each failing set predicted before the run

Restore in a `trap ... EXIT` handler, never in-band, and the harness redirected to a
file rather than piped — both rules from §7 item 78, where a `| head` SIGPIPE'd a harness
and left a mutant in the working tree.

| Probe | Mutation | Failing tests | Predicted |
|---|---|---|---|
| A | scope widened from `Yes` to `Yes`+`Partially` | `CheckDischargeCitation`, `PropertiesRegisterMeetsRule11` | ✓ |
| B | basis check condition inverted | `CheckDischargeCitation`, `PropertiesRegisterMeetsRule11`, `DischargeReportRejects…` | ✓ |
| C | rule 11's two halves checked in the other order | `CheckDischargeCitation`, `DischargeReportRejects…` | ✓ |
| D | error message reports the 0-based line | `DischargeGuardReportsItsLine` | ✓ |
| E | `DischargeDefect.Line` reports the 0-based line | `DischargeReportRejects…` | ✓ |
| F | citation pattern loosened to any backticked span | `CheckDischargeCitation`, `DischargeCitationPatternIsNotSatisfiedByProse` | ✓ |
| G | basis pattern accepts any E-digit | `DischargeBasisPatternCoversEveryBasis` | ✓ |
| H | basis pattern loses the three pair-only spellings | `CheckDischargeCitation`, `DischargeBasisPatternCoversEveryBasis` | ✓ |
| I | `DischargeDefects` stops at the first defect | `DischargeReportRejects…` | ✓ |
| J | `DischargeDefects` collects the rows that passed | `PropertiesRegisterMeetsRule11`, `DischargeReportRejects…` | ✓ |

10 for 10, and the observed sets **vary across probes**, which is the instrument check:
uniform output across a batch means the harness is not reporting on its input.

Two probes are about the tests rather than the guard:

- **I** is why the fixture carries **two** offending rows rather than one. With one, a
  report that stopped after the first defect was undetectable.
- **H** is a stated bound. `PropertiesRegisterMeetsRule11` does **not** fail under H,
  because all six live `Yes` cells spell `E1` and none uses pair notation — the corpus
  cannot witness a basis pattern that has lost `chosen/model`, `sampled/model` or
  `exhaustive/implementation`. That is what `TestDischargeBasisPatternCoversEveryBasis`
  is for, and it iterates `Bases()` rather than a hand-written list of E-names, which is
  the only form covering the three spellings with no legacy name.

## Also in this PR

**The distribution caveat becomes a property of the generator.** Four sessions have now
rediscovered that a movement can leave the header's totals unchanged (§7 items 46, 55,
62, and 78's `T7` moving `REFUTED (1 of 4 live)` → `REFUTED (3 of 4 live)` with every
header number holding). It is derivable, not a tally of coincidences: `Distribution`
tallies `Kind(status)` (`internal/propdoc/propdoc.go:252`) and `Kind` discards
parenthesised detail by construction (`:261`), so a movement expressible only in an
`(n of m live)` count **cannot** appear there. The header block quote now states it once
and states that no future amendment demonstrates it again. Four rediscoveries is what
recording a trap as a note costs — a note does not fire.

## What changes per consumer

Enumerated from `grep -rn 'propdoc\.' --include='*.go' .` (one Go caller, `cmd/propgen`)
and from §6's audit procedure, which is the other consumer and has no callers to grep:

- **`go run ./cmd/propgen` now exits 1** on a register row marked `Yes` without a basis
  and a citation, naming the line and the tracking artifact, where it previously rewrote
  the Status column from that row.
- **`go test ./internal/propdoc/` now fails** on such a row, so the document cannot reach
  `main` carrying one.

No production behaviour changes: `internal/propdoc` and `cmd/propgen` are documentation
tooling, not part of any shipped command. No inherited test file is modified —
`git diff --name-status origin/main...HEAD -- '*_test.go'` is one `A` line.
