### PR TITLE
docs(properties): a multi-route Basis cell reduces to its weakest route, not its strongest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -338,6 +338,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   timeout. Completes the two work items left unchecked in #36.
 
 ### Changed
+- **A `PROPERTIES.md` Basis cell covering several execution routes now reports the
+  weakest of them, not the strongest** (#135). §3 defined the column as *the strongest
+  basis claimed* — a max over the evidence. For a proposition quantifying over every
+  execution path but covered unequally across them, a max reports the best-covered
+  route's strength as the proposition's, and says nothing about which route that was.
+  Two cells were in exactly that shape: `T1` and `T5` both read
+  `exhaustive/implementation` on the strength of a 112-cell enumeration of the agent
+  boot route, while the `strata run` route under each of them is covered only by example
+  tests. The overstatement is silent, which is why it needed a rule rather than an edit.
+
+  **The reduction is a meet, and the correction to the obvious form of a meet is the
+  substance of the change.** A min over the covered routes is the honest answer, but a
+  min needs an order and the seven bases do not have one: coverage is totally ordered
+  and subject is not (§2.1 rule 1). So the rule is a **pair where all covered scopes
+  share a subject, the set of them otherwise, over the union of the declared bounds** —
+  and a route known to be uncovered can be declared with `none`, which collapses the
+  cell, because a floor over a union says nothing about a part of the domain no entry
+  names. New cell grammar: `tier @ scope — citation`, entries separated by `;`. A
+  single entry naming no scope is the whole of the old grammar and parses unchanged,
+  which is why 32 of the 34 propositions needed no edit.
+
+  Four obligations are enforced on a multi-scope cell, with a sentinel each: name every
+  scope, name none twice, cite every scope claiming a basis, and **lead with the entry
+  the cell reduces to** — because the reduction is derived and surfaces only in the
+  Status column, so the first entry is the only basis a reader of the Basis column sees.
+
+  **What the green does not cover, stated because the change's own corpus cannot cover
+  it.** Both scoped propositions are `REFUTED`, and a live refutation outranks any basis
+  (§2.1 rule 5), so neither Status cell moves: `go run ./cmd/propgen` reports `no drift`
+  and the identical distribution — `ASSERTED (E0) 1, ENFORCED E1 2, REFUTED 27,
+  UNPOPULATED 2, WITHDRAWN 2` — before and after. A corpus test asserting today's rows
+  still pass would therefore be vacuous in the exact sense: it passes equally if the
+  reduction is a max. The corpus test instead reads the *parsed* reduction and asserts it
+  **differs** from the max, and each constructed fixture records whether its own meet and
+  max coincide and fails when a row that was supposed to discriminate stops
+  discriminating. That assertion, not any expected value, is what caught the one mutation
+  whose failing set was wider than predicted.
+
+  **What changes per consumer**, enumerated from
+  `grep -rn 'propdoc\.' --include='*.go' .` (one caller, `cmd/propgen`) and from §6's
+  human procedure, which has no callers to grep:
+  - **`go run ./cmd/propgen` now exits 1 on a Basis cell whose entries lead with
+    anything but the entry they reduce to, repeat or omit a scope, or leave a scope
+    uncited** — six new exported sentinels, one per malformation, so a test asserts which
+    check fired.
+  - **A multi-scope cell written in the old prose style no longer parses at all.** Both
+    migrated cells carried their second route as prose after a semicolon; under the new
+    grammar that is a hard parse error, so a half-migrated document cannot reach `main`.
+    Anyone adding a route to an existing cell must give every route a scope.
+  - **§6's procedure gains a step**: when a proposition's evidence covers its routes
+    unequally, the cell states each route and its own basis, and the Status column shows
+    the floor (`weakest of N scopes`). Recording only the best-covered route is now a
+    rejected document, not a style choice.
+
+  No production behaviour changes: `internal/propdoc` and `cmd/propgen` are documentation
+  tooling, not part of any shipped command. Nine mutation probes, each failing-test set
+  predicted before the run, 9 red with 8 sets exact; one probe was VOID on its first cut
+  because the mutant did not compile, which `go test` reports with exit 1 exactly as it
+  reports a caught defect (§7 item 80).
 - **`PROPERTIES.md`'s rule 11 is enforced: a `Discharged: Yes` row that cites no
   evidence now fails the build** (#137). Rule 11 — *a closed issue is a fact about the
   tracker, not evidence about the tree* — was written in one session and never run

--- a/PROPERTIES.md
+++ b/PROPERTIES.md
@@ -31,8 +31,8 @@ finding is §0.2.
 > 2026-08-22, where `T7` moved from `REFUTED (1 of 4 live)` to
 > `REFUTED (3 of 4 live)` and every number above held — so it is stated once here
 > as what it is. `Distribution` tallies `Kind(status)`
-> (`internal/propdoc/propdoc.go:252`) and `Kind` discards the parenthesised detail
-> by construction (`:261`), so a movement expressible only in an `(n of m live)`
+> (`internal/propdoc/propdoc.go:339`) and `Kind` discards the parenthesised detail
+> by construction (`:348`), so a movement expressible only in an `(n of m live)`
 > count **cannot** appear in these totals. No future amendment demonstrates this
 > again; a movement that leaves the totals unchanged is the expected reading, and
 > the number to check is the cell.
@@ -506,7 +506,7 @@ consume *that*, and would owe the same guard for the part it used.
     nothing mechanical can close this gap.
 
     **Half of this rule is now enforced, and the boundary matters more than the
-    enforcement.** `propdoc.Doc.DischargeDefects` (`internal/propdoc/propdoc.go:363`)
+    enforcement.** `propdoc.Doc.DischargeDefects` (`internal/propdoc/propdoc.go:450`)
     reports every `Yes` row that names no basis or cites no artifact; `propgen`
     refuses to run and `TestPropertiesRegisterMeetsRule11` fails the build
     (`internal/propdoc/discharge_citation_test.go:143`). It is a report over a parsed
@@ -1005,6 +1005,18 @@ with the evidence. **Editing a Status cell directly is now a build failure rathe
 than a divergence nobody notices**, which is the point — the first population of
 this document maintained status beside the register, and the two disagreed within
 one PR.
+
+**When a proposition's evidence covers its routes unequally, the Basis cell says so
+per route.** A proposition quantifying over every execution path is rarely covered
+the same way on all of them, and one basis for the whole cell reports the
+best-covered route's strength as the proposition's. So write one entry per route —
+`tier @ scope — citation`, separated by `;` — lead with the entry the cell reduces
+to, and let the Status column derive the floor (`weakest of N scopes`). A route known
+to be uncovered is declared `none @ that route`, which collapses the cell to
+`UNPOPULATED` rather than leaving the gap to be inferred from the Evidence prose.
+§2.1 rule 12 states the reduction and the four obligations; `propgen` refuses a cell
+that breaks any of them. Recording only the best-covered route is a rejected
+document, not a style choice.
 
 A change to a proposition's text is an amendment with a date and a reason, not a
 silent edit: a proposition that quietly narrows until it is satisfied is not
@@ -2288,7 +2300,7 @@ states the standard it violated and puts a cadence on finding the next.
 
     **T7's live count moves 1 → 3 of 4, and this is the failure mode the derived column
     was supposed to prevent.** `Refutation.Live()` is `Discharged != "Yes"`
-    (`internal/propdoc/propdoc.go:87`), so both cells counted as discharged and §3
+    (`internal/propdoc/propdoc.go:117`), so both cells counted as discharged and §3
     reported `REFUTED (1 of 4 live)` — a false statement, in a trust proposition, sitting
     inside a *generated* cell. Deriving the column removed the drift between §3 and §4
     and could not remove the error, because the error was in the input the derivation
@@ -2309,7 +2321,7 @@ states the standard it violated and puts a cadence on finding the next.
     name, and putting the check in the wrong place was caught by a test written for
     something else.** Rule 11 has been enforceable since the day it was written and was
     not enforced, which is why item 78 exists. `Doc.DischargeDefects`
-    (`internal/propdoc/propdoc.go:363`) now reports every `Yes` row naming no basis or
+    (`internal/propdoc/propdoc.go:450`) now reports every `Yes` row naming no basis or
     citing no artifact, `propgen` refuses before it rewrites the Status column
     (`cmd/propgen/main.go:51-57`), and `TestPropertiesRegisterMeetsRule11`
     (`internal/propdoc/discharge_citation_test.go:143`) fails the build.
@@ -2384,9 +2396,136 @@ states the standard it violated and puts a cadence on finding the next.
     **The distribution caveat is restated as a property of the generator.** This is the
     fourth session in which a movement failed to appear in the header's totals (items 46,
     55, 62, and 78's `T7` count). `Distribution` tallies `Kind(status)`
-    (`internal/propdoc/propdoc.go:252`) and `Kind` discards parenthesised detail by
-    construction (`:261`), so a movement expressible only in an `(n of m live)` count
+    (`internal/propdoc/propdoc.go:339`) and `Kind` discards parenthesised detail by
+    construction (`:348`), so a movement expressible only in an `(n of m live)` count
     **cannot** appear there — it is derivable, not a tally of four coincidences. The block
     quote in the header now says so and says that no future amendment demonstrates it
     again. Four rediscoveries is the cost of recording a trap as a note: a note does not
     fire.
+80. **The Basis column was a max, and a max over unevenly covered routes overstates.**
+    §3 defined the cell as *the strongest basis claimed*. `T1` and `T5` each quantify over
+    every execution path and are covered unequally across them — 112 enumerated cells on
+    the agent boot route, example tests on the `strata run` route — so both cells read
+    `exhaustive/implementation`, and nothing in the column said which route that came from.
+    The overstatement is silent, which is what made it worth a rule rather than an edit
+    (#135, filed after #129's PR worked around it by naming the route in prose beside each
+    pair).
+
+    **The replacement is a meet, and the correction to the obvious form of it is the point.**
+    A min over covered routes is the honest reduction, but a min needs an order and the seven
+    bases do not have one: Coverage is totally ordered, Subject is not (rule 1). So the rule
+    is **a pair where all covered scopes share a Subject, the set otherwise, over the union of
+    the declared bounds** — and a scope known to be uncovered may be declared with `none`,
+    which collapses the cell, because a floor over a union says nothing about a part of the
+    domain no entry names. Stated as §2.1 rule 12; implemented as `Reduce`
+    (`internal/propdoc/basis.go:182`) and `parseBasis` (`internal/propdoc/propdoc.go:582`).
+
+    | Cell | Scopes | Old (max) | New (meet) | Status before | Status after |
+    |---|---|---|---|---|---|
+    | `T1` | 2 | `exhaustive/implementation` | `chosen/implementation` | `REFUTED (1 of 4 live)` | `REFUTED (1 of 4 live)` |
+    | `T5` | 3 | `exhaustive/implementation` | `chosen/implementation` | `REFUTED (1 of 4 live)` | `REFUTED (1 of 4 live)` |
+
+    **The two right-hand columns are the finding about this change's own evidence.** Both
+    scoped propositions are `REFUTED`, and a live refutation outranks any basis (rule 5), so
+    neither Status cell moves. `go run ./cmd/propgen` reports `no drift` and the identical
+    distribution — `ASSERTED (E0) 1, ENFORCED E1 2, REFUTED 27, UNPOPULATED 2, WITHDRAWN 2` —
+    before and after. **The document's own green therefore says nothing about whether the
+    reduction is right**, and a corpus test asserting today's rows pass would have been
+    vacuous in the precise sense: it would pass equally if `Reduce` returned the max. So the
+    corpus test asserts the *parsed reduction* and asserts it **differs from the max**
+    (`internal/propdoc/basis_scope_test.go:460`), and the renderings are covered by
+    constructed cells (`:376`). Cardinality stated: 2 multi-scope cells, 32 single-scope,
+    34 propositions.
+
+    **The migration was forced, not offered.** Both cells carried their second route as prose
+    after a semicolon, and under the new grammar neither parses — six inherited tests went red
+    on the unmigrated document, which is how a half-migrated document is prevented rather
+    than discouraged. Recorded as a test in its own right (`:560`).
+
+    **The guard §2 promised in advance came due, and the promise was well drafted.** The
+    ranking note said no tool consumed the basis ordering, that the list of pairs the order
+    ranks and the evidence does not was therefore "a note, and notes do not fire", and that
+    the first consumer would owe a guard making the list non-vacuous. `Reduce` is that
+    consumer. The guard exists (`:192`) and the answers are narrower than the promise
+    anticipated: `Reduce` consumes the **Coverage** order only and refuses items 1 and 2
+    outright; item 4 is *not* refused, because `asserted` is the bottom of the coverage order
+    and a floor over coverage is defined for it, while item 4's complaint is about usefulness,
+    which `Reduce` does not compute; and **item 3 is not expressible as a pair of bases at
+    all** — it is a statement about two cells — so its answer is structural, every entry
+    carrying its own scope, enforced separately (`:364`). Three of four ranked pairs
+    machine-checked, the fourth stated as inexpressible rather than silently dropped.
+
+    **Nine mutation probes, all nine red, eight failing sets predicted exactly.** The two
+    departures are worth more than the eight matches. Probe C ranked `chosen` as high as `exhaustive`
+    and I predicted one failing test; three failed, because the tie also disables the
+    lead-with-the-reduction rule (the meet equals the first entry, so a strongest-first cell
+    is accepted) and because two separate tests assert their own fixtures *discriminate* — each
+    row records whether its meet and max coincide and fails if a supposedly discriminating row
+    stops discriminating. That assertion, not any expected value, is what caught the probe: a
+    `Reduce` returning the max passes every value assertion on any row where the two agree.
+    Probe H was **VOID** on its first cut — removing `uncovered ||` orphaned the variable and
+    the mutant did not compile, which `go test` reports with exit 1 exactly as it reports a
+    caught defect — and went red at the predicted set after being re-cut as a value swap, per
+    the standing corollary that a probe should swap an expression rather than delete the only
+    use of something.
+
+    `zsh /tmp/mutprobe_135.sh` (baseline green asserted first; patch asserted to apply exactly
+    once; mutant asserted to build; tree restored from a `trap`):
+
+    | Probe | Mutation | Predicted | Failing | Verdict |
+    |---|---|---|---|---|
+    | A | meet becomes max | 10 | 10 | RED |
+    | B | subject agreement inverted | 4 | 4 | RED |
+    | C | `chosen` ranks as high as `exhaustive` | 1 | 3 | RED |
+    | D | weakest-first check disabled | 1 | 1 | RED |
+    | E | scope-uniqueness never records | 1 | 1 | RED |
+    | F | `@` recognised anywhere, not as a prefix | 1 | 1 | RED |
+    | G | scope count dropped from the status | 1 | 1 | RED |
+    | H | uncovered scope no longer collapses the cell | 2 | 2 | RED |
+    | I | the reported set is built wrong | 2 | 2 | RED |
+
+    Nine probes, seven distinct failing sets, sizes 1 to 10 — output that varies with its
+    input, which is the instrument check. The three that coincide are D, E and F, each caught
+    by the grammar table alone. Probe A's 10 is the whole package, the shape to expect from
+    inverting the reduction itself, since every corpus test parses the document through it.
+
+    **And a defect in the practice, found by this change and not fixed by it: seven
+    `path:line` citations elsewhere in this document were invalidated by inserting code above
+    their targets, and nothing checks them.**
+
+    | Anchor as written | Target | Actually at | Cited | Broken by |
+    |---|---|---|---|---|
+    | `propdoc.go:252` | `out[Kind(status)]++` | `:339` | 2× | this change |
+    | `propdoc.go:261` | `func Kind` | `:348` | 2× | this change |
+    | `propdoc.go:363` | `DischargeDefects` | `:450` | 2× | this change |
+    | `propdoc.go:87` | `Refutation.Live` | `:117` | 1× | never correct |
+
+    Seven citation instances across four cited lines, enumerated by extracting every anchor the
+    diff removes:
+
+    ```sh
+    git diff -U0 -- PROPERTIES.md | grep '^-' | grep -o '[a-z_]*\.go:[0-9]*\|`:[0-9]*`' | sort | uniq -c
+    ```
+
+    Six were broken by inserting code above their targets in this change. The seventh,
+    `propdoc.go:87` for `Refutation.Live`, was **already wrong when it was written**: at
+    `041e50f` `Live()` was at line 95. All are repaired here, and only the
+    pointers changed — every claim they support is unchanged, which is why repairing them
+    inside §7 is not rewriting the log.
+
+    **This is not a new issue; it is a measurement that contradicts an existing one's
+    premise.** #105 already scopes a citation checker and states that its level 1 — the
+    path resolves, the line is within the file, a `func <Name>(` sits at the line where a
+    test name is given — **finds zero defects today**, and therefore that level 1 is
+    insurance against future drift rather than a bug-finder. Five of these seven instances
+    are written repo-relative and land inside the file and within its length, and none of
+    the seven names a symbol; the remaining two are written bare (`` `:261` ``), the form
+    #105 measures as not machine-resolvable at all. So **level 1 as scoped is green on every
+    one of them** — silent on five and unable to read two. The class is not a dangling
+    pointer but a
+    pointer at the wrong valid line, and its base rate is not zero: seven instances in this
+    document, six of them created by one commit, in the one file this change happened to
+    touch. What separates a checkable citation from an uncheckable one is whether it names
+    what it points at, which is why #105's *"make test names mandatory alongside line
+    numbers"* is the part that buys the detection — recorded on #105 rather than filed
+    again here. (2026-08-22, #135.)

--- a/PROPERTIES.md
+++ b/PROPERTIES.md
@@ -326,13 +326,42 @@ not:
    nothing about the code, and `asserted` at least does not imply otherwise.
 
 **A column that cannot be totally ordered is more useful than one that can be and
-lies about it.** Note what this ranking is not: nothing in this repository
-consumes it. No tool sorts propositions by basis, so the list above is a note,
-and notes do not fire. The first time something does sort by basis — a triage
-script, a dashboard, a release gate — the order and this list move into
-`internal/propdoc` together, and the list acquires the guard that makes it
-non-vacuous: **every pair named here must be one the order actually ranks**, or
-the caveat is a caveat about nothing.
+lies about it.**
+
+**Something now consumes part of this ordering, and the guard promised here has
+come due** (2026-08-22, #135; §7 item 80). The paragraph that stood here said
+nothing in the repository consumed the ranking, that the list above was therefore
+a note and notes do not fire, and that the first consumer would bring the list into
+`internal/propdoc` with a guard making it non-vacuous. `propdoc.Reduce` is that
+consumer, and the guard is
+`internal/propdoc/basis_scope_test.go:192 TestReduceRefusesSection2sIncomparablePairs`.
+What it consumes is narrower than "sorting by basis", and the difference is the
+whole reason the four cases above survive intact:
+
+- **`Reduce` consumes the order on `Coverage` alone** — `BasisKind.Rank`,
+  `internal/propdoc/basis.go:102` — which §2 states is total and means it. It never
+  consults the tie-break by subject, because it refuses to compare two bases whose
+  subjects differ instead of ranking them.
+- **It computes a meet, not a sort.** A floor over a set of scopes is not a ranking
+  of one scope against another: it reports the weakest thing true anywhere in the
+  union, which is well defined even where the scopes cover different domains.
+- **Items 1 and 2 are refused**, and the guard asserts the refusal names both bases
+  rather than discarding one. **Item 4 is not refused**, and the guard states why in
+  the narrowest terms available: `asserted` is the bottom of the *coverage* order, so
+  a floor over coverage is defined for it. Item 4's complaint is about *usefulness* —
+  whether something that ran but was not about the code beats a bare assertion — and
+  `Reduce` does not compute a usefulness ranking and does not claim to.
+- **Item 3 is not expressible as a pair of bases at all.** It says that comparing the
+  Basis cells of two propositions whose bounds differ compares nothing, which is a
+  statement about two *cells*. `Reduce`'s answer to it is structural rather than a
+  verdict: every entry carries its own scope, and a multi-entry cell that declines to
+  name them is rejected
+  (`internal/propdoc/basis_scope_test.go:364 TestParseBasisRejectsUnscopedMultiEntryCells`).
+
+Still true, and still a note: **no tool sorts propositions by basis.** Nothing
+ranks one proposition against another, and the seven-way order remains
+unconsumed — a triage script, a dashboard or a release gate would be the first to
+consume *that*, and would owe the same guard for the part it used.
 
 ### 2.1 Rules
 
@@ -506,6 +535,49 @@ the caveat is a caveat about nothing.
     comparing subjects, which is the §6.1 audit obligation and nothing else. So the
     green from `TestPropertiesRegisterMeetsRule11` bounds the closure-for-citation
     conflation only, and must not be read as covering the class above.
+12. **A proposition covered unevenly across its domain reduces to its weakest
+    covered scope, not its strongest.** Where a proposition quantifies over several
+    execution routes, one basis for the whole cell cannot say that one route was
+    enumerated and another merely exercised. The Basis cell therefore takes one
+    entry per scope — `tier @ scope — citation`, entries separated by semicolons —
+    and the basis it claims is the **meet** over them.
+
+    The reason is that the old definition was a **max**. §3 defined the Basis cell as
+    *the strongest basis claimed*, so a proposition covered exhaustively on one route
+    and by three examples on another reported `exhaustive/implementation`, and nothing
+    in the column said which route that came from. The overstatement is silent, which
+    is the property that makes it worth a rule rather than a correction.
+
+    **A meet needs an order, and the seven bases do not have one.** Coverage is
+    totally ordered; Subject is not (rule 1). So:
+
+    - Where every covered scope shares a Subject, the reduction is a **pair**: the
+      lowest coverage reached on any of them, with that Subject.
+    - Where they do not, there is **no meet**, and the reduction is the **set** of
+      bases claimed. Status renders the set rather than choosing from it.
+    - In both cases the reduction is over the **union of the declared bounds**, and
+      says nothing about a part of the domain no entry names. A scope known to be
+      uncovered may be declared with `none`, which collapses the whole cell: nothing
+      is established over the union however well covered the rest is.
+
+    Four things a multi-scope cell must do, each enforced with its own error so the
+    author is told which one was missed: name every scope, name none of them twice,
+    cite every scope that claims a basis, and **lead with the entry it reduces to**.
+    The last is not cosmetic. The reduction is derived and appears only in the
+    generated Status column, so the first entry is the only basis a reader of the
+    Basis column actually sees — a cell leading with its strongest scope reproduces
+    the overstatement with every derived number correct.
+
+    Enforced by `internal/propdoc.parseBasis` and `Reduce`
+    (`internal/propdoc/basis.go:182`, `internal/propdoc/propdoc.go:582`), tested at
+    `internal/propdoc/basis_scope_test.go:42`. Two cells are scoped today, `T1` and
+    `T5`, each reducing from `exhaustive/implementation` to `chosen/implementation`;
+    the other 32 are single-scope and unchanged. **What the document's own green does
+    not show:** both scoped propositions are `REFUTED`, and a live refutation
+    outranks any basis (rule 5), so neither Status cell displays its reduction and
+    the generated column is byte-identical before and after this rule. The
+    renderings are covered by constructed cells, not by this document — see §7
+    item 80. (Added 2026-08-22, #135.)
 
 ---
 
@@ -517,12 +589,22 @@ Three columns, two authored and one generated:
   `SOUND`, `TOO WEAK` (satisfiable by an implementation that still has the defect
   the proposition was written to exclude — the broken implementation is named),
   `TOO STRONG`, or `ILL-FORMED` (with the falsifiable replacement).
-- **Basis** — *authored.* The strongest basis claimed for the proposition — a
-  (coverage, subject) pair from §2, written either in pair notation or under its
-  legacy E-name — and the citation carrying it; `none` if nothing is cited, or
-  `withdrawn` naming what superseded it. A basis with no citation is not a basis.
-  "Strongest" is not a total order: see §2 on which pairs the ranking convention
-  ranks and the evidence does not.
+- **Basis** — *authored.* What the proposition's evidence establishes across the
+  domain the cell declares: a (coverage, subject) pair from §2, written either in
+  pair notation or under its legacy E-name, and the citation carrying it; `none` if
+  nothing is cited, or `withdrawn` naming what superseded it. A basis with no
+  citation is not a basis.
+
+  Where the cell names one scope it claims one basis. Where it names several —
+  `tier @ scope — citation`, semicolon-separated — the basis is the **meet** over
+  them, the weakest reached on any scope the cell covers, and the cell leads with
+  that entry. This was *the strongest basis claimed* until 2026-08-22, which is a
+  **max** and overstates a proposition covered unevenly across its routes; §2.1
+  rule 12 states the replacement and §7 item 80 the correction. Neither "strongest"
+  nor "weakest" is a total order over the seven bases: Coverage is ordered and
+  Subject is not, so where the scopes' subjects differ there is no meet and the set
+  is reported instead. See §2 on which pairs the ranking convention ranks and the
+  evidence does not.
 - **Status** — **generated** from the Basis cell and the §4 register by
   `internal/propdoc.DeriveStatus`. Do not edit it by hand; run
   `go run ./cmd/propgen -write`.
@@ -535,12 +617,24 @@ The status function, in the order it applies:
    rule 5. Where a proposition has more than one row the count is reported as
    `REFUTED (n of m live)`, so discharging one of several counterexamples is
    visible here rather than only in prose.
-3. Otherwise the Basis decides. `asserted` coverage renders `ASSERTED (…)`,
+3. Otherwise the Basis decides — the **meet** over the cell's scopes, per §2.1
+   rule 12, not the strongest of them. `asserted` coverage renders `ASSERTED (…)`,
    naming the basis in parentheses — `ASSERTED (E0)` for the legacy spelling.
    Anything else renders `ENFORCED` followed by the canonical spelling:
    `ENFORCED E1`, `ENFORCED E2`, `ENFORCED E3`, or
    `ENFORCED exhaustive/implementation` for a pair with no legacy name. A cell
    citing nothing renders `UNPOPULATED` whatever it claims.
+4. A cell naming more than one scope says so in the status, because a basis that is
+   the weakest of several routes must not read as a claim about all of them:
+   `ENFORCED E1 (weakest of 2 scopes)`, or
+   `ASSERTED (E0, weakest of 2 scopes)`. Where the scopes share no Subject there is
+   no meet and the set is named:
+   `ENFORCED (no meet over 2 scopes: chosen/model, exhaustive/implementation)`.
+   Where one scope is declared uncovered: `UNPOPULATED (a scope of 2 is uncovered)`.
+   All of this is parenthesised detail, so the distribution the header quotes tallies
+   these with their single-scope counterparts and does not grow a bucket — except the
+   no-meet case, whose class is `ENFORCED` with no basis, since that is what it is.
+   No cell renders any of these today; see §2.1 rule 12 on why, and §7 item 80.
 
 A `SOUND` verdict and a `REFUTED` status are the healthy combination: the
 proposition is worth having and the system does not yet satisfy it.
@@ -595,11 +689,11 @@ This group is the core of Strata's differentiating claim.
 
 | # | Proposition | Verdict | Basis | Status | Evidence |
 |---|-------------|---------|-------|--------|----------|
-| **T1** | *No unverified mount.* There exists no execution path from *layer declared in a lockfile* to *layer mounted in an assembled environment* that does not pass a successful signature verification under the trust policy in force. | **TOO WEAK** | exhaustive/implementation — `internal/agent/boot_matrix_test.go:464`, **the agent boot route only**; the `strata run` route stands at chosen/implementation, `cmd/strata/run_verify_test.go:370,519` | REFUTED (1 of 4 live) | *The most important finding in this review.* Broken-but-satisfying implementation: ship an agent whose default policy is `allow-unverified`, and route every layer through a verifier that returns success when a layer names no bundle. Every mount then "passes a successful verification under the trust policy in force" and T1 holds — which is precisely the shape of the five fail-opens this document was written about. T1 defers its content to "the policy in force" and never says what the policy is when the operator selects nothing. It is only worth having when read together with T5's second sentence, and it should be restated to quantify over the *default* configuration (see H1, §1.4). Status under that reading: refuted at `internal/agent/agent.go:285` (nil verifier ⇒ skip — still open, #93) and, at `339329fb`, `:285-293` (layer with `Bundle: ""` dropped from the set; empty set ⇒ success — #92, **closed by #104**, which replaces the filter with a refusal naming every bundle-less layer at `:310-323`; witnessed at `internal/agent/verify_bundles_test.go:187,252,291` and `cmd/strata-agent/s3_bundle_contract_test.go:22`). Probe 3 on #92 boots READY with a verifier that refuses every artifact, `VerifierCalled=false`. Closed on the `strata run` route by #55: `cmd/strata/run_verify_test.go:519 TestRunRun_MissingKeyIsARefusalNotASkip`, `:370 TestVerifyRunLayers_ReportsEveryFailure`. **Basis raised 2026-08-21 (#129), and it is route-scoped for a reason T1's own text creates.** `TestBootMatrix_DecisionSurface` enumerates all 112 cells of the agent boot route's decision surface — `Config.Verifier` × the bytes a bundle fetch yields × `layer.Bundle` × content-against-`SHA256` — asserting per cell which check fired, whether `Mount` was reached, and how many times the verifier was called. That last is what makes it T1 evidence rather than T5-only: *"`Run` returned nil"* does not distinguish verification succeeding from verification never happening, which is the whole of #92. **20 of the 112 cells reach the mount with nothing verified**, pinned as a literal so the hole cannot shrink without a diff. Two limits on what this cites. (a) It covers the **agent** route; T1 quantifies over *every* execution path, and the `strata run` route is covered separately and only at `chosen`. A single Basis cell holding "the strongest basis" cannot say that without saying which route, which is why this one does — §2.1 rule 2, the declared bound is part of the claim. (b) The table's expectation ladder makes a boot with no verifier a **refusal**, so it measures T1 under the strengthened reading rule 9 prescribes and not under T1's literal text, which a fail-open still satisfies — the `TOO WEAK` verdict, unchanged. The 20 cells therefore carry `knownOpen` and assert *today's* behaviour, failing loudly when #93(a) closes rather than certifying it. |
+| **T1** | *No unverified mount.* There exists no execution path from *layer declared in a lockfile* to *layer mounted in an assembled environment* that does not pass a successful signature verification under the trust policy in force. | **TOO WEAK** | chosen/implementation @ the `strata run` route — `cmd/strata/run_verify_test.go:370,519`; exhaustive/implementation @ the agent boot route — `internal/agent/boot_matrix_test.go:464` | REFUTED (1 of 4 live) | *The most important finding in this review.* Broken-but-satisfying implementation: ship an agent whose default policy is `allow-unverified`, and route every layer through a verifier that returns success when a layer names no bundle. Every mount then "passes a successful verification under the trust policy in force" and T1 holds — which is precisely the shape of the five fail-opens this document was written about. T1 defers its content to "the policy in force" and never says what the policy is when the operator selects nothing. It is only worth having when read together with T5's second sentence, and it should be restated to quantify over the *default* configuration (see H1, §1.4). Status under that reading: refuted at `internal/agent/agent.go:285` (nil verifier ⇒ skip — still open, #93) and, at `339329fb`, `:285-293` (layer with `Bundle: ""` dropped from the set; empty set ⇒ success — #92, **closed by #104**, which replaces the filter with a refusal naming every bundle-less layer at `:310-323`; witnessed at `internal/agent/verify_bundles_test.go:187,252,291` and `cmd/strata-agent/s3_bundle_contract_test.go:22`). Probe 3 on #92 boots READY with a verifier that refuses every artifact, `VerifierCalled=false`. Closed on the `strata run` route by #55: `cmd/strata/run_verify_test.go:519 TestRunRun_MissingKeyIsARefusalNotASkip`, `:370 TestVerifyRunLayers_ReportsEveryFailure`. **Basis raised 2026-08-21 (#129), and it is route-scoped for a reason T1's own text creates.** `TestBootMatrix_DecisionSurface` enumerates all 112 cells of the agent boot route's decision surface — `Config.Verifier` × the bytes a bundle fetch yields × `layer.Bundle` × content-against-`SHA256` — asserting per cell which check fired, whether `Mount` was reached, and how many times the verifier was called. That last is what makes it T1 evidence rather than T5-only: *"`Run` returned nil"* does not distinguish verification succeeding from verification never happening, which is the whole of #92. **20 of the 112 cells reach the mount with nothing verified**, pinned as a literal so the hole cannot shrink without a diff. Two limits on what this cites. (a) It covers the **agent** route; T1 quantifies over *every* execution path, and the `strata run` route is covered separately and only at `chosen`. The Basis cell says so per route rather than in prose, and reduces to the weaker of the two — §2.1 rule 2 and rule 12, the declared bound is part of the claim (#135). (b) The table's expectation ladder makes a boot with no verifier a **refusal**, so it measures T1 under the strengthened reading rule 9 prescribes and not under T1's literal text, which a fail-open still satisfies — the `TOO WEAK` verdict, unchanged. The 20 cells therefore carry `knownOpen` and assert *today's* behaviour, failing loudly when #93(a) closes rather than certifying it. |
 | **T2** | *Verification soundness.* Verification succeeds for a layer only if a signature exists, by an identity admitted by the trust policy, over the digest of the exact bytes that will be mounted. | SOUND | E1 — `cmd/strata/run_verify_test.go:466` | REFUTED | The "exact bytes" clause is the load-bearing part and it is satisfied deliberately: `cmd/strata/run.go` adds a check absent from `trust.VerifyLayer` — that the bundle attests *this lockfile's* digest — with the reason stated in its doc comment (*"a missing cosign must not be the difference between 'wrong layer's bundle' and 'accepted'"*). Witnessed by `cmd/strata/run_verify_test.go:466 TestRunRun_RefusesLayerWhoseBundleAttestsAnotherArtifact`. For the *lockfile*, no signature verification exists at all (#60), so T2 does not hold of the artifact that names the layer set. Weakness worth recording: "an identity admitted by the trust policy" is satisfied here by possession of one `--key`; there is no identity policy to admit or refuse anything. |
 | **T3** | *Transparency binding.* A transparency-log entry accepted as evidence for artifact *A* has a body that corresponds to *A*'s attestation. Under **A4**, the existence of the referenced entry is not itself evidence about *A*. | SOUND | E1 — `cmd/strata/verify_rekor_test.go:80,147,217` | REFUTED (2 of 3 live) | Discharged for the verify command by #59, which replaced a log-index existence check that discarded the bundle: `cmd/strata/verify_rekor_test.go:80 TestVerifyRekorEntries_PassesTheBundle`, with `:217 TestVerifyRekorEntries_BadIndexIsNotVerified` and `:147 TestVerifyRekorEntries_UnfetchableBundleIsAFailure` as the failing controls. Refuted on the resolver path: stage 7 holds a bundle *URI*, not bundle bytes, so it cannot compare anything (#85). Two open objections to the *evidence*, not to the proposition: #88 — the `hashedrekord` body shape is inferred from our own `Log`, so writer and verifier can be wrong together, which is rule 3's tautology at the level of a design; #86 — `TestStage7_RekorVerification` asserts a negative case its body never exercises, which is rule 6. |
 | **T4** | *Trust-anchor independence.* The root of trust used to verify artifacts is not obtained from the authority that serves those artifacts. Under **A1**, an attacker who can replace an artifact cannot also replace the material that decides who may sign it. | SOUND | none | REFUTED (2 of 2 live) | #62 — the agent fetches its cosign public key from the same S3 bucket that serves the layers, so A1 alone replaces both. #63 — `ec2runner` downloads the cosign binary itself with no checksum or signature check, which is the §1.2 clause "obtaining the verification binary is in scope under A3" paying out. |
-| **T5** | *Fail-closed.* Any inability to complete verification — absent tool, absent key, absent bundle, absent log entry, network failure, unparseable material — results in refusal. Degradation to a weaker check occurs only when a weaker policy has been explicitly selected by the operator. | SOUND | exhaustive/implementation — `internal/agent/boot_matrix_test.go:464`, **the agent boot route only**; the `strata run` and verifier-construction routes stand at chosen/implementation, `cmd/strata/run_verify_test.go:264`, `cmd/strata-agent/cosign_verifier_test.go:127,187,249` | REFUTED (1 of 4 live) | The strongest proposition in this document: it names absence alongside invalidity, so A5 cannot slip past it, and it fixes the default in its second sentence, which is what T1 fails to do. Refuted at `internal/agent/agent.go:285` (#93, still open) and, at `339329fb`, `:285-293` (#92) — an absent bundle was a skip, not a refusal. **#104 closes the #92 half**: absence is now refused at `:310-323`, witnessed at `internal/agent/verify_bundles_test.go:187,252,291` and `cmd/strata-agent/s3_bundle_contract_test.go:22`. Enforced at E1 on the routes already fixed: `cmd/strata/run_verify_test.go:264 TestNewRunVerifier_NeverReturnsANilVerifier` (#55) and `cmd/strata-agent/cosign_verifier_test.go:127 TestResolveVerifier_NilVerifierOnlyWithAnExplicitOptOut`, `:187 TestAllowUnverified_DefaultsToClosed`, `:249 TestProductionPrereqs_ClosedByDefault` (#56). **Basis raised 2026-08-21 (#129), agent route only.** T5's list of failure modes — *absent tool, absent key, absent bundle, absent log entry, network failure, unparseable material* — is close to an enumeration of a domain, and `TestBootMatrix_DecisionSurface` now runs one: the bundle-bytes dimension covers no fetcher, valid-for-this-content, valid-for-*other*-content, `(nil, nil)`, non-JSON, well-formed JSON with the wrong media type, and a fetch error, crossed with four verifier dispositions, `layer.Bundle` empty or named, and content matching or not matching its declared `SHA256` — 112 cells, each asserting *which* check fired rather than merely that one did. Where T5's own list stops short of the shipping surface, the enumeration is derived from the code's inputs and covers more (valid-for-other-content is a substitution, not an inability), and where it goes beyond this route it is not covered here at all: **an absent cosign binary and an absent Rekor entry are neither of them dimensions of this table**, so T5's "absent tool" and "absent log entry" clauses remain at `chosen` on the routes cited above. **20 of the 112 cells reach the mount unverified** because `Verifier` or `BundleFetcher` is nil (#93(a), open), which is the same live half that keeps T5 refuted; they assert today's behaviour and fail when it changes. |
+| **T5** | *Fail-closed.* Any inability to complete verification — absent tool, absent key, absent bundle, absent log entry, network failure, unparseable material — results in refusal. Degradation to a weaker check occurs only when a weaker policy has been explicitly selected by the operator. | SOUND | chosen/implementation @ the `strata run` route — `cmd/strata/run_verify_test.go:264`; chosen/implementation @ verifier construction — `cmd/strata-agent/cosign_verifier_test.go:127,187,249`; exhaustive/implementation @ the agent boot route — `internal/agent/boot_matrix_test.go:464` | REFUTED (1 of 4 live) | The strongest proposition in this document: it names absence alongside invalidity, so A5 cannot slip past it, and it fixes the default in its second sentence, which is what T1 fails to do. Refuted at `internal/agent/agent.go:285` (#93, still open) and, at `339329fb`, `:285-293` (#92) — an absent bundle was a skip, not a refusal. **#104 closes the #92 half**: absence is now refused at `:310-323`, witnessed at `internal/agent/verify_bundles_test.go:187,252,291` and `cmd/strata-agent/s3_bundle_contract_test.go:22`. Enforced at E1 on the routes already fixed: `cmd/strata/run_verify_test.go:264 TestNewRunVerifier_NeverReturnsANilVerifier` (#55) and `cmd/strata-agent/cosign_verifier_test.go:127 TestResolveVerifier_NilVerifierOnlyWithAnExplicitOptOut`, `:187 TestAllowUnverified_DefaultsToClosed`, `:249 TestProductionPrereqs_ClosedByDefault` (#56). **Basis raised 2026-08-21 (#129), and scoped per route 2026-08-22 (#135): the cell now reduces to `chosen/implementation`, the weakest of its three routes, rather than reporting the strongest.** T5's list of failure modes — *absent tool, absent key, absent bundle, absent log entry, network failure, unparseable material* — is close to an enumeration of a domain, and `TestBootMatrix_DecisionSurface` now runs one: the bundle-bytes dimension covers no fetcher, valid-for-this-content, valid-for-*other*-content, `(nil, nil)`, non-JSON, well-formed JSON with the wrong media type, and a fetch error, crossed with four verifier dispositions, `layer.Bundle` empty or named, and content matching or not matching its declared `SHA256` — 112 cells, each asserting *which* check fired rather than merely that one did. Where T5's own list stops short of the shipping surface, the enumeration is derived from the code's inputs and covers more (valid-for-other-content is a substitution, not an inability), and where it goes beyond this route it is not covered here at all: **an absent cosign binary and an absent Rekor entry are neither of them dimensions of this table**, so T5's "absent tool" and "absent log entry" clauses remain at `chosen` on the routes cited above. **20 of the 112 cells reach the mount unverified** because `Verifier` or `BundleFetcher` is nil (#93(a), open), which is the same live half that keeps T5 refuted; they assert today's behaviour and fail when it changes. |
 | **T6** | *Policy explicitness.* The trust policy under which a result was produced is recorded alongside that result, so that a verification outcome is interpretable without knowledge of the invoking environment. | **ILL-FORMED** | none | REFUTED | "Recorded alongside that result" names neither an artifact nor a lifetime. A line on stderr satisfies it on one reading and no durable record satisfies it on another, so as written it cannot be failed. Falsifiable form: *the lockfile, or an attestation deposited with it, carries a field naming the trust policy in force, and a consumer reading only the artifact can determine what was checked.* Under that form: refuted by absence. `grep -rn 'TrustPolicy\|VerifiedAt' --include='*.go' . \| grep -v _test.go` returns 0 lines, and no lockfile field records what was checked. Filed as #100. |
 | **T7** | *Command-name honesty.* A command's name and documented behaviour do not claim a stronger check than it performs. A flag that purports to disable a check disables a check that was otherwise performed. | **TOO WEAK** | E1 — `cmd/strata/run_verify_test.go:350,497` | REFUTED (3 of 4 live) | Broken-but-satisfying implementation: keep the fail-open and fix the *documentation*. T7 constrains names and docs, so the cheapest way to satisfy it is to document the weakness while leaving the command called `verify` and the behaviour unchanged — the operator's attention is displaced exactly as before. Repair: pair T7 with a requirement that a weaker check announces itself **at use time**, not only in prose. `strata run --no-verify` already meets the repaired form (`cmd/strata/run.go:184` prints the warning; `cmd/strata/run_verify_test.go:350 TestVerifyRunLayers_NoVerifyAnnouncesTheSkip` with `:497 TestRunRun_NoVerifyReachesTheMount` as its pair), and so does `STRATA_AGENT_ALLOW_UNVERIFIED` (#56). `strata verify` does not: without `--rekor` it performs presence checks only (`cmd/strata/verify.go:82-98 collectPresenceFailures`) under a name that claims verification — #60. And `verifyBundles`'s doc comment stated the skip as intended design (`internal/agent/agent.go:272-283`) — T7's broken-but-satisfying implementation occurring in the wild rather than as a hypothetical: the weakness was documented accurately and the behaviour left alone, so T7 as written was *satisfied* by the artifact that recorded the fail-open. #104 rewrites the comment and inverts the behaviour together, which is the only combination that discharges anything. |
 | **T8** | *(new)* *Freshness.* A verifier can determine that the artifact set it has been given is the current one, and refuses a set that is older than a stated bound. | SOUND | none | REFUTED | Added 2026-08-21 (§7). §5 asked for group T to be checked against TUF's taxonomy; **A6 was in the model and no proposition used it.** Doing the check: nothing records a freshness threshold, an expiry, or a timestamp/snapshot role, so rollback and freeze both succeed against a genuinely signed old artifact, and `strata update` moves forward only when a human runs it. Filed as #101. |

--- a/PROPERTIES.md
+++ b/PROPERTIES.md
@@ -2504,8 +2504,15 @@ states the standard it violated and puts a cadence on finding the next.
     diff removes:
 
     ```sh
-    git diff -U0 -- PROPERTIES.md | grep '^-' | grep -o '[a-z_]*\.go:[0-9]*\|`:[0-9]*`' | sort | uniq -c
+    git diff -U0 4d5ba47^..4d5ba47 -- PROPERTIES.md | grep '^-' \
+      | grep -o '[a-z_]*\.go:[0-9]*\|`:[0-9]*`' | sort | uniq -c
     ```
+
+    The range is the repair commit alone, and it has to be: widened to include this change's
+    first commit the same command reports twelve anchors, because rewriting the `T1` and `T5`
+    cells re-emits every citation inside them as a removal. A diff-based enumeration of
+    citations counts *lines touched*, not citations broken, unless the range is the one that
+    touched only pointers.
 
     Six were broken by inserting code above their targets in this change. The seventh,
     `propdoc.go:87` for `Refutation.Live`, was **already wrong when it was written**: at

--- a/internal/propdoc/basis.go
+++ b/internal/propdoc/basis.go
@@ -92,6 +92,152 @@ func Bases() []BasisKind {
 	}
 }
 
+// Rank returns the position of a basis's coverage in the coverage order:
+// asserted 0, chosen 1, sampled 2, exhaustive 3.
+//
+// This is the ordering on Coverage alone, which section 2 states is total and
+// means it. It is *not* the seven-basis sorting convention, which ranks pairs the
+// evidence does not — Reduce refuses to compare two bases differing in Subject
+// rather than consulting a rank for them.
+func (k BasisKind) Rank() int {
+	switch k.Coverage {
+	case CoverageAsserted:
+		return 0
+	case CoverageChosen:
+		return 1
+	case CoverageSampled:
+		return 2
+	case CoverageExhaustive:
+		return 3
+	}
+	// An unrecognised coverage ranks at the bottom rather than panicking: a
+	// hand-built BasisKind carrying a typo should weaken a meet, never strengthen
+	// one, and Reduce's whole purpose is to not overstate.
+	return 0
+}
+
+// ScopedBasis is one entry of a Basis cell: a basis, the part of the
+// proposition's domain that basis covers, and the citation carrying it.
+//
+// A proposition quantifying over several execution routes is not covered equally
+// on all of them, and one basis for the whole cell cannot say so — which is the
+// defect this type exists to remove (#135).
+type ScopedBasis struct {
+	// Tier is the canonical spelling of one of the seven bases, or TierNone for a
+	// scope declared uncovered.
+	Tier string
+	// Scope is the declared bound: which part of the proposition's domain this
+	// entry covers. Empty only for a single-entry cell, whose scope is whatever
+	// the proposition's own text quantifies over.
+	Scope string
+	// Citation is the evidence for this scope.
+	Citation string
+}
+
+// Reduction is what a Basis cell's entries reduce to: the honest floor over the
+// scopes the cell covers.
+//
+// The reduction is a **meet** (greatest lower bound), not a max. A max over
+// unevenly covered scopes reports the best-covered scope's strength as the
+// proposition's, which overstates silently and is what #135 was filed about. A
+// meet reports the weakest, which is the most that holds everywhere the cell
+// claims to cover.
+//
+// But a meet needs an order, and the seven bases do not have one: Coverage is
+// totally ordered and Subject is not (§2.1 rule 1). So the meet exists only where
+// all covered scopes share a Subject, and where they do not there is no single
+// answer to report — hence Set, and hence Comparable.
+type Reduction struct {
+	// Meet is the greatest lower bound of the covered scopes' bases. Valid only
+	// when Comparable; the zero BasisKind otherwise.
+	Meet BasisKind
+	// Set is every distinct basis the cell claims, in the order section 2
+	// tabulates them. Always populated, and it is the whole of the answer when
+	// Comparable is false.
+	Set []BasisKind
+	// Comparable reports whether a meet exists — that is, whether every covered
+	// scope whose evidence executed something shares a Subject with every other.
+	Comparable bool
+	// Scopes is the union of the declared bounds, in cell order. It is part of the
+	// claim, not decoration: the reduction is a floor over *these* scopes and says
+	// nothing about a part of the domain no entry names (§2.1 rule 2 and rule 10).
+	Scopes []string
+}
+
+// Reduce returns what a set of scoped bases reduces to, and whether any entry
+// named a basis at all.
+//
+// asserted is the bottom of the coverage order and is treated as comparable with
+// every other basis, because the incomparability of Subject arises from *what was
+// executed* and asserted executed nothing: there is no model-versus-implementation
+// disagreement to have. Note what this does and does not claim. It is a floor on
+// **coverage**. It is not a claim that a `model` result outranks asserted in
+// usefulness — section 2's ranking note says it does not, and this function does
+// not consult that ranking.
+//
+// TierNone short-circuits the whole reduction: a scope declared uncovered means
+// nothing is established over the union, however well covered the other scopes
+// are. That is the mechanism by which a cell can state the bound honestly instead
+// of leaving an uncovered route to be inferred from prose.
+func Reduce(entries []ScopedBasis) (Reduction, bool) {
+	var r Reduction
+	var kinds []BasisKind
+	uncovered := false
+	for _, e := range entries {
+		if e.Scope != "" {
+			r.Scopes = append(r.Scopes, e.Scope)
+		}
+		if e.Tier == TierNone {
+			uncovered = true
+			continue
+		}
+		if k, ok := lookupBasis(e.Tier); ok {
+			kinds = append(kinds, k)
+		}
+	}
+	if uncovered || len(kinds) == 0 {
+		return r, false
+	}
+
+	// Distinct, in section 2's order, so two cells claiming the same bases report
+	// the same set whatever order they were authored in.
+	for _, b := range Bases() {
+		for _, k := range kinds {
+			if k == b {
+				r.Set = append(r.Set, b)
+				break
+			}
+		}
+	}
+
+	// Subject agreement, checked over the entries that executed something.
+	r.Comparable = true
+	subject := SubjectNone
+	for _, k := range kinds {
+		if k.Coverage == CoverageAsserted {
+			continue
+		}
+		if subject == SubjectNone {
+			subject = k.Subject
+			continue
+		}
+		if k.Subject != subject {
+			r.Comparable = false
+		}
+	}
+	if !r.Comparable {
+		return r, true
+	}
+
+	r.Meet = kinds[0]
+	for _, k := range kinds[1:] {
+		if k.Rank() < r.Meet.Rank() {
+			r.Meet = k
+		}
+	}
+	return r, true
+}
+
 // lookupBasis finds the kind a Basis cell's tier token names, accepting either
 // the legacy name or the pair notation.
 func lookupBasis(token string) (BasisKind, bool) {

--- a/internal/propdoc/basis_scope_test.go
+++ b/internal/propdoc/basis_scope_test.go
@@ -1,0 +1,579 @@
+package propdoc
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+// Tests for per-scope bases and the meet (#135).
+//
+// The defect being fixed is that a Basis cell held one basis for a proposition
+// quantifying over several execution routes, and section 3 defined that basis as
+// the strongest claimed — a **max**. A max over unevenly covered routes reports
+// the best-covered route's strength as the proposition's, which overstates and
+// does so silently, because nothing in the document says which routes the number
+// came from.
+//
+// The replacement is a meet. Two things make it more than a sign flip:
+//
+//   - Coverage is totally ordered and Subject is not, so a meet exists only where
+//     the covered scopes share a Subject. Where they do not there is no answer to
+//     report and the set is reported instead.
+//   - The reduction is over the scopes the cell *names*. A part of the domain no
+//     entry names is not covered by the number, which is why an entry may declare
+//     a scope uncovered and why that collapses the whole cell.
+
+// maxByRank is what the old definition computed, and the tests below use it to
+// assert their own fixtures are discriminating: a row whose meet equals its max
+// cannot tell a meet implementation from a max one.
+func maxByRank(kinds []BasisKind) BasisKind {
+	out := kinds[0]
+	for _, k := range kinds[1:] {
+		if k.Rank() > out.Rank() {
+			out = k
+		}
+	}
+	return out
+}
+
+func TestReduceIsAMeetNotAMax(t *testing.T) {
+	impl, model := SubjectImplementation, SubjectModel
+	entry := func(tier, scope string) ScopedBasis {
+		return ScopedBasis{Tier: tier, Scope: scope, Citation: "`x_test.go:1`"}
+	}
+	for _, tc := range []struct {
+		name string
+		in   []ScopedBasis
+		// wantMeet is the pair the entries reduce to, spelled as Spelling().
+		wantMeet   string
+		wantSubj   Subject
+		comparable bool
+		ok         bool
+		// coincides marks a row where the meet and the max are the same basis, so
+		// the row is deliberately not discriminating and the assertion below that
+		// they differ is skipped for it.
+		coincides bool
+	}{
+		{
+			name:       "one entry reduces to itself",
+			in:         []ScopedBasis{entry("E1", "the only route")},
+			wantMeet:   "chosen/implementation",
+			wantSubj:   impl,
+			comparable: true, ok: true, coincides: true,
+		},
+		{
+			name:       "T1's shape: exhaustive on one route, chosen on the other",
+			in:         []ScopedBasis{entry("E1", "strata run"), entry("exhaustive/implementation", "agent boot")},
+			wantMeet:   "chosen/implementation",
+			wantSubj:   impl,
+			comparable: true, ok: true,
+		},
+		{
+			name: "the same two the other way round, because a meet is not the last entry either",
+			in: []ScopedBasis{
+				entry("exhaustive/implementation", "agent boot"), entry("E1", "strata run"),
+			},
+			wantMeet:   "chosen/implementation",
+			wantSubj:   impl,
+			comparable: true, ok: true,
+		},
+		{
+			name: "T5's shape: three routes, two of them at the same basis",
+			in: []ScopedBasis{
+				entry("E1", "strata run"), entry("E1", "verifier construction"),
+				entry("exhaustive/implementation", "agent boot"),
+			},
+			wantMeet:   "chosen/implementation",
+			wantSubj:   impl,
+			comparable: true, ok: true,
+		},
+		{
+			name: "sampled between the two, so the meet is not simply the first or the extreme",
+			in: []ScopedBasis{
+				entry("E2", "b"), entry("exhaustive/implementation", "a"), entry("E2", "c"),
+			},
+			wantMeet:   "sampled/implementation",
+			wantSubj:   impl,
+			comparable: true, ok: true,
+		},
+		{
+			name:       "asserted is the bottom of the coverage order, so it wins the meet",
+			in:         []ScopedBasis{entry("E0", "documented only"), entry("exhaustive/implementation", "agent boot")},
+			wantMeet:   "asserted",
+			wantSubj:   SubjectNone,
+			comparable: true, ok: true,
+		},
+		{
+			name:       "a model scope and an implementation scope have no meet",
+			in:         []ScopedBasis{entry("chosen/model", "the state machine"), entry("exhaustive/implementation", "agent boot")},
+			comparable: false, ok: true,
+		},
+		{
+			name:       "two model scopes do have one, since they share a Subject",
+			in:         []ScopedBasis{entry("chosen/model", "a"), entry("E3", "b")},
+			wantMeet:   "chosen/model",
+			wantSubj:   model,
+			comparable: true, ok: true,
+		},
+		{
+			name: "an uncovered scope collapses the cell however well covered the rest is",
+			in: []ScopedBasis{
+				{Tier: TierNone, Scope: "the lockfile route"},
+				entry("exhaustive/implementation", "agent boot"),
+			},
+			ok: false,
+		},
+		{
+			name: "no entry names a basis at all",
+			in:   []ScopedBasis{},
+			ok:   false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			red, ok := Reduce(tc.in)
+			if ok != tc.ok {
+				t.Fatalf("Reduce ok = %v, want %v", ok, tc.ok)
+			}
+			if !ok {
+				return
+			}
+			if red.Comparable != tc.comparable {
+				t.Fatalf("Comparable = %v, want %v (set %v)", red.Comparable, tc.comparable, red.Set)
+			}
+			if !tc.comparable {
+				if len(red.Set) < 2 {
+					t.Errorf("an incomparable reduction reported %d bases; the set is the whole answer "+
+						"here and must name every basis claimed", len(red.Set))
+				}
+				return
+			}
+			if got := red.Meet.Spelling(); got != tc.wantMeet {
+				t.Errorf("Meet = %q, want %q", got, tc.wantMeet)
+			}
+			if red.Meet.Subject != tc.wantSubj {
+				t.Errorf("Meet subject = %q, want %q", red.Meet.Subject, tc.wantSubj)
+			}
+
+			// The row's own teeth. A Reduce that took the max would satisfy every
+			// assertion above on any row where the two coincide, so each row states
+			// which it is and the discriminating ones are checked to discriminate.
+			kinds := make([]BasisKind, 0, len(tc.in))
+			for _, e := range tc.in {
+				if k, known := lookupBasis(e.Tier); known {
+					kinds = append(kinds, k)
+				}
+			}
+			max := maxByRank(kinds)
+			switch {
+			case tc.coincides && max != red.Meet:
+				t.Errorf("row is marked as one where the meet and the max coincide, but they are %q and %q",
+					red.Meet.Spelling(), max.Spelling())
+			case !tc.coincides && max == red.Meet:
+				t.Errorf("the meet and the max are both %q, so this row cannot tell a meet from a max; "+
+					"either mark it coincides or give it entries that differ", max.Spelling())
+			}
+		})
+	}
+}
+
+// TestReduceRefusesSection2sIncomparablePairs is the guard section 2 promised in
+// advance and this change makes due.
+//
+// The ranking note there ends: "nothing in this repository consumes it. No tool
+// sorts propositions by basis, so the list above is a note, and notes do not fire.
+// The first time something does sort by basis … the list acquires the guard that
+// makes it non-vacuous: every pair named here must be one the order actually
+// ranks." Reduce is the first consumer. It consumes the Coverage order only, so
+// each of the four pairs gets the disposition it actually has, and one of them is
+// not expressible as a pair of bases at all — which is stated rather than skipped.
+func TestReduceRefusesSection2sIncomparablePairs(t *testing.T) {
+	cited := func(tier string, i int) ScopedBasis {
+		return ScopedBasis{Tier: tier, Scope: fmt.Sprintf("scope %d", i), Citation: "`x_test.go:1`"}
+	}
+	for _, tc := range []struct {
+		item int
+		pair [2]string
+		// wantRefused is whether Reduce declines to compare the pair.
+		wantRefused bool
+		// wantMeet is checked only where the pair is not refused.
+		wantMeet string
+		why      string
+	}{
+		{
+			item: 1, pair: [2]string{"sampled/implementation", "exhaustive/model"}, wantRefused: true,
+			why: "legacy E2 vs E3: sampling the code that ships against exhausting an abstraction of it",
+		},
+		{
+			item: 2, pair: [2]string{"exhaustive/implementation", "exhaustive/model"}, wantRefused: true,
+			why: "incomparable on domain size; the pair #129 could not hold in one number",
+		},
+		{
+			item: 4, pair: [2]string{"chosen/model", "asserted"}, wantRefused: false, wantMeet: "asserted",
+			why: "not refused, and the reason is narrow: asserted is the bottom of the *coverage* order, " +
+				"so a floor over coverage is well defined. Section 2's complaint about this pair is about " +
+				"usefulness — whether something that ran but was not about the code beats a bare assertion — " +
+				"and Reduce does not compute a usefulness ranking and does not claim to.",
+		},
+	} {
+		t.Run(fmt.Sprintf("item %d: %s vs %s", tc.item, tc.pair[0], tc.pair[1]), func(t *testing.T) {
+			red, ok := Reduce([]ScopedBasis{cited(tc.pair[0], 1), cited(tc.pair[1], 2)})
+			if !ok {
+				t.Fatalf("Reduce declined to read the pair at all: %v", tc.why)
+			}
+			if refused := !red.Comparable; refused != tc.wantRefused {
+				t.Fatalf("Reduce refused = %v, want %v — %s", refused, tc.wantRefused, tc.why)
+			}
+			if tc.wantRefused {
+				// Non-vacuity for this row: a refusal must still name both bases, or
+				// the caveat is enforced by discarding the information it is about.
+				if len(red.Set) != 2 {
+					t.Errorf("a refused pair reported %d bases, want both named", len(red.Set))
+				}
+				return
+			}
+			if got := red.Meet.Spelling(); got != tc.wantMeet {
+				t.Errorf("Meet = %q, want %q — %s", got, tc.wantMeet, tc.why)
+			}
+		})
+	}
+	// Item 3 of the same list — "any two bases with different declared bounds" — is
+	// deliberately absent from the table, and this is the record of why rather than
+	// an omission. It is not a pair of bases: it says that comparing the bases of two
+	// propositions whose bounds differ compares nothing, which is a statement about
+	// two *cells* and has no encoding as two BasisKinds. Reduce's answer to it is
+	// structural instead of a verdict — every entry carries its own scope, and the
+	// reduction is a floor over the union of those scopes rather than a ranking of
+	// one scope against another. TestParseBasisRejectsUnscopedMultiEntryCells is
+	// where that structural answer is enforced.
+	t.Log("section 2 ranking note item 3 is not expressible as a pair of bases; see the comment above")
+}
+
+func TestParseBasisScopedGrammar(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cell string
+		want error // nil means the cell must parse
+		// tier is checked on the cells that parse.
+		tier   string
+		scopes int
+	}{
+		{
+			name:   "the single-entry grammar is untouched",
+			cell:   "E1 — `cmd/strata/run_verify_test.go:466`",
+			tier:   "E1",
+			scopes: 0,
+		},
+		{
+			name:   "a single entry may still name its bound",
+			cell:   "E1 @ the `strata run` route — `cmd/strata/run_verify_test.go:466`",
+			tier:   "E1",
+			scopes: 1,
+		},
+		{
+			name: "T1's cell reduces to the weaker route",
+			cell: "chosen/implementation @ the `strata run` route — `cmd/strata/run_verify_test.go:370,519`; " +
+				"exhaustive/implementation @ the agent boot route — `internal/agent/boot_matrix_test.go:464`",
+			tier:   "E1",
+			scopes: 2,
+		},
+		{
+			name: "an @ inside a citation is a citation, not a bound",
+			cell: "E1 — `cmd/strata/formations/hpc-mpi@2026.03.yaml`",
+			tier: "E1",
+		},
+		{
+			name: "scopes with no meet reduce to incomparable rather than to the better one",
+			cell: "chosen/model @ the state machine — `m_test.go:1`; " +
+				"exhaustive/implementation @ the agent boot route — `b_test.go:2`",
+			tier:   TierIncomparable,
+			scopes: 2,
+		},
+		{
+			name: "an uncovered scope collapses the cell and cites nothing for itself",
+			cell: "none @ the lockfile route; exhaustive/implementation @ the agent boot route — `b_test.go:2`",
+			tier: TierNone, scopes: 2,
+		},
+		{
+			name: "an unnamed scope in a multi-entry cell",
+			cell: "E1 — `a_test.go:1`; exhaustive/implementation @ agent boot — `b_test.go:2`",
+			want: ErrBasisScopeUnnamed,
+		},
+		{
+			name: "the same scope claimed twice, which puts strongest-wins back on the reader",
+			cell: "E1 @ agent boot — `a_test.go:1`; exhaustive/implementation @ agent boot — `b_test.go:2`",
+			want: ErrBasisScopeRepeated,
+		},
+		{
+			name: "an entry claiming a basis and citing nothing",
+			cell: "E1 @ strata run — ; exhaustive/implementation @ agent boot — `b_test.go:2`",
+			want: ErrBasisScopeUncited,
+		},
+		{
+			name: "leading with the strongest scope, which is the overstatement this grammar removes",
+			cell: "exhaustive/implementation @ agent boot — `b_test.go:2`; E1 @ strata run — `a_test.go:1`",
+			want: ErrBasisNotWeakestFirst,
+		},
+		{
+			name: "leading with a covered scope while another is declared uncovered",
+			cell: "exhaustive/implementation @ agent boot — `b_test.go:2`; none @ the lockfile route",
+			want: ErrBasisNotWeakestFirst,
+		},
+		{
+			name: "withdrawn is a fact about a proposition, not about one of its scopes",
+			cell: "withdrawn @ agent boot — I6; E1 @ strata run — `a_test.go:1`",
+			want: ErrBasisWithdrawnScoped,
+		},
+		{
+			name: "a scope opened and never closed",
+			cell: "E1 @ the agent boot route `b_test.go:2`",
+			want: ErrBasisScopeUnterminated,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := parseBasis(tc.cell, 0)
+			if tc.want != nil {
+				switch {
+				case err == nil:
+					t.Fatalf("cell parsed to %+v; want %v", b, tc.want)
+				case !errors.Is(err, tc.want):
+					t.Fatalf("cell rejected for the wrong reason: got %v, want %v", err, tc.want)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("cell was rejected: %v", err)
+			}
+			if b.Tier != tc.tier {
+				t.Errorf("Tier = %q, want %q", b.Tier, tc.tier)
+			}
+			if len(b.Scoped) != tc.scopes {
+				t.Errorf("len(Scoped) = %d, want %d", len(b.Scoped), tc.scopes)
+			}
+		})
+	}
+}
+
+// TestParseBasisRejectsUnscopedMultiEntryCells is the structural answer to section
+// 2's ranking-note item 3, asserted on its own rather than as one row of a table:
+// a cell claiming several bases cannot decline to say which domain each covers.
+// Without this the reduction would be a floor over an unstated union, which is the
+// same defect one level down from the one #135 was filed about.
+func TestParseBasisRejectsUnscopedMultiEntryCells(t *testing.T) {
+	for _, cell := range []string{
+		"E1 — `a_test.go:1`; exhaustive/implementation — `b_test.go:2`",
+		"E1 @ strata run — `a_test.go:1`; exhaustive/implementation — `b_test.go:2`",
+		"E1 — `a_test.go:1`; exhaustive/implementation @ agent boot — `b_test.go:2`",
+	} {
+		if _, err := parseBasis(cell, 0); !errors.Is(err, ErrBasisScopeUnnamed) {
+			t.Errorf("cell %q: got %v, want %v", cell, err, ErrBasisScopeUnnamed)
+		}
+	}
+}
+
+func TestDeriveStatusRendersTheReduction(t *testing.T) {
+	scoped := func(tiers ...string) []ScopedBasis {
+		out := make([]ScopedBasis, 0, len(tiers))
+		for i, tier := range tiers {
+			out = append(out, ScopedBasis{
+				Tier: tier, Scope: fmt.Sprintf("scope %d", i), Citation: "`x_test.go:1`",
+			})
+		}
+		return out
+	}
+	for _, tc := range []struct {
+		name     string
+		basis    Basis
+		want     string
+		wantKind string
+	}{
+		{
+			name:     "a single-scope cell renders as it always did",
+			basis:    Basis{Tier: "E1", Citation: "`x_test.go:1`"},
+			want:     "ENFORCED E1",
+			wantKind: "ENFORCED E1",
+		},
+		{
+			name: "a multi-scope cell says what its basis is the weakest of",
+			basis: Basis{Tier: "E1", Citation: "`x_test.go:1`",
+				Scoped: scoped("E1", "exhaustive/implementation")},
+			want: "ENFORCED E1 (weakest of 2 scopes)",
+			// The count is parenthesised detail, so the distribution the document
+			// quotes does not grow a bucket for it.
+			wantKind: "ENFORCED E1",
+		},
+		{
+			name: "an incomparable cell names the set rather than choosing from it",
+			basis: Basis{Tier: TierIncomparable, Citation: "`x_test.go:1`",
+				Scoped: scoped("chosen/model", "exhaustive/implementation")},
+			want:     "ENFORCED (no meet over 2 scopes: chosen/model, exhaustive/implementation)",
+			wantKind: "ENFORCED",
+		},
+		{
+			name: "a multi-scope asserted cell keeps the ASSERTED class",
+			basis: Basis{Tier: "E0", Citation: "`p.go:1`",
+				Scoped: scoped("E0", "exhaustive/implementation")},
+			want:     "ASSERTED (E0, weakest of 2 scopes)",
+			wantKind: "ASSERTED (E0)",
+		},
+		{
+			name: "an uncovered scope reports why it is unpopulated",
+			basis: Basis{Tier: TierNone, Citation: "`x_test.go:1`",
+				Scoped: scoped(TierNone, "exhaustive/implementation")},
+			want:     "UNPOPULATED (a scope of 2 is uncovered)",
+			wantKind: "UNPOPULATED",
+		},
+		{
+			name: "a live refutation still outranks every basis, however many scopes",
+			basis: Basis{Tier: "E1", Citation: "`x_test.go:1`",
+				Scoped: scoped("E1", "exhaustive/implementation")},
+			want:     "REFUTED",
+			wantKind: "REFUTED",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			live, total := 0, 0
+			if tc.want == "REFUTED" {
+				live, total = 1, 1
+			}
+			got := DeriveStatus(tc.basis, live, total)
+			if got != tc.want {
+				t.Errorf("DeriveStatus = %q, want %q", got, tc.want)
+			}
+			if k := Kind(got); k != tc.wantKind {
+				t.Errorf("Kind(%q) = %q, want %q", got, k, tc.wantKind)
+			}
+		})
+	}
+}
+
+// TestPropertiesScopedCellsReduceToTheirWeakestRoute is the corpus check, and it
+// is deliberately about the parsed reduction rather than the Status column.
+//
+// Neither scoped proposition's Status shows its basis: both are REFUTED, and a live
+// refutation outranks any basis (proof-standard rule 5). So this change moves no
+// Status cell and the generated column is byte-identical before and after it —
+// which means the document's own green says nothing at all about whether the
+// reduction is right. This test reads the reduction where it exists.
+func TestPropertiesScopedCellsReduceToTheirWeakestRoute(t *testing.T) {
+	src, err := os.ReadFile(propertiesPath())
+	if err != nil {
+		t.Fatalf("read PROPERTIES.md: %v", err)
+	}
+	doc, err := Parse(src)
+	if err != nil {
+		t.Fatalf("Parse PROPERTIES.md: %v", err)
+	}
+
+	want := map[string]struct {
+		tier   string
+		scopes int
+		// wasMax is what the old definition reported for this cell, and asserting
+		// it differs from the reduction is what makes the row evidence that the
+		// change moved a number rather than renamed one.
+		wasMax string
+	}{
+		"T1": {tier: "E1", scopes: 2, wasMax: "exhaustive/implementation"},
+		"T5": {tier: "E1", scopes: 3, wasMax: "exhaustive/implementation"},
+	}
+
+	scoped := map[string]*Proposition{}
+	single := 0
+	for _, p := range doc.Propositions() {
+		if len(p.Basis.Scoped) > 1 {
+			scoped[p.ID] = p
+			continue
+		}
+		single++
+	}
+	if len(scoped) != len(want) {
+		t.Fatalf("the document has %d multi-scope Basis cells, want %d (%v) — if a cell was added, "+
+			"add it here with the basis it reduces to", len(scoped), len(want), keysOf(scoped))
+	}
+	// Cardinality stated, so a parser that silently stopped reading section 3 cannot
+	// pass by finding both scoped rows and nothing else.
+	if got, wantTotal := single+len(scoped), len(doc.Propositions()); got != wantTotal {
+		t.Fatalf("counted %d propositions, want %d", got, wantTotal)
+	}
+	t.Logf("%d propositions: %d single-scope cells, %d multi-scope", len(doc.Propositions()), single, len(scoped))
+
+	for id, w := range want {
+		p, ok := scoped[id]
+		if !ok {
+			t.Errorf("%s is no longer a multi-scope cell", id)
+			continue
+		}
+		if p.Basis.Tier != w.tier {
+			t.Errorf("%s reduces to %q, want %q", id, p.Basis.Tier, w.tier)
+		}
+		if len(p.Basis.Scoped) != w.scopes {
+			t.Errorf("%s names %d scopes, want %d", id, len(p.Basis.Scoped), w.scopes)
+		}
+		red, ok := Reduce(p.Basis.Scoped)
+		if !ok || !red.Comparable {
+			t.Errorf("%s does not reduce: ok=%v comparable=%v", id, ok, red.Comparable)
+			continue
+		}
+		// The teeth on the live document: the reduction must differ from the max the
+		// old definition took, or this row is consistent with nothing having changed.
+		kinds := make([]BasisKind, 0, len(p.Basis.Scoped))
+		for _, e := range p.Basis.Scoped {
+			if k, known := lookupBasis(e.Tier); known {
+				kinds = append(kinds, k)
+			}
+		}
+		max := maxByRank(kinds)
+		if max.Spelling() != w.wasMax {
+			t.Errorf("%s: the strongest scope is %q, want %q — the row records what the old "+
+				"definition reported and that no longer matches the cell", id, max.Spelling(), w.wasMax)
+		}
+		if max == red.Meet {
+			t.Errorf("%s: meet and max are both %q, so this row does not witness the correction",
+				id, max.Spelling())
+		}
+		// And the bound, recorded where the green is read: the rendering path that
+		// prints the reduction is not reached by this document.
+		if live, _ := doc.counts(id); live == 0 {
+			t.Errorf("%s is no longer refuted, so its Status now renders the reduction; "+
+				"this test's premise that the corpus cannot exercise that path has expired", id)
+		}
+	}
+	t.Log("neither scoped proposition's Status shows its basis (both REFUTED), so the multi-scope " +
+		"renderings are covered by TestDeriveStatusRendersTheReduction and not by this document")
+}
+
+func keysOf(m map[string]*Proposition) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// TestScopedGrammarRejectsTheCellsAsTheyWere records that the migration was
+// forced rather than chosen. Both cells carried their second route in prose, and
+// the reader had to notice a semicolon and a sentence to learn that the leading
+// `exhaustive/implementation` covered one route of several. Under the new grammar
+// those cells do not parse, so no document can be half-migrated.
+func TestScopedGrammarRejectsTheCellsAsTheyWere(t *testing.T) {
+	for _, cell := range []string{
+		// Verbatim from PROPERTIES.md at 041e50f.
+		"exhaustive/implementation — `internal/agent/boot_matrix_test.go:464`, **the agent boot route only**; " +
+			"the `strata run` route stands at chosen/implementation, `cmd/strata/run_verify_test.go:370,519`",
+		"exhaustive/implementation — `internal/agent/boot_matrix_test.go:464`, **the agent boot route only**; " +
+			"the `strata run` and verifier-construction routes stand at chosen/implementation, " +
+			"`cmd/strata/run_verify_test.go:264`, `cmd/strata-agent/cosign_verifier_test.go:127,187,249`",
+	} {
+		_, err := parseBasis(cell, 0)
+		if err == nil {
+			t.Errorf("the pre-migration cell still parses, so a cell can claim a strongest basis "+
+				"over unstated routes: %q", cell)
+			continue
+		}
+		if !strings.Contains(err.Error(), "unknown evidence tier") {
+			t.Logf("rejected for a different reason than the tier of its second entry: %v", err)
+		}
+	}
+}

--- a/internal/propdoc/propdoc.go
+++ b/internal/propdoc/propdoc.go
@@ -9,9 +9,13 @@
 // authoritative. Discharging one of a proposition's two counterexamples used to
 // leave its Status cell untouched, which made a real movement unreportable.
 //
-// The authored inputs are the Basis cell (the highest evidence tier claimed,
-// with its citation) and the register rows. Everything in the Status column is
-// output.
+// The authored inputs are the Basis cell (one or more scoped bases, each with its
+// citation) and the register rows. Everything in the Status column is output.
+//
+// A Basis cell claiming several scopes reduces to the **weakest** of them, not the
+// strongest — see Reduce. A proposition quantifying over several execution routes
+// is rarely covered equally on all of them, and reporting the best-covered route's
+// strength as the proposition's overstates silently (#135).
 package propdoc
 
 import (
@@ -31,6 +35,10 @@ const (
 	// TierWithdrawn means the proposition has been superseded and is no longer
 	// measured; the citation names what replaced it.
 	TierWithdrawn = "withdrawn"
+	// TierIncomparable is the reduction of a multi-scope Basis cell whose scopes
+	// do not share a Subject, so no meet exists. It is not a tier an author may
+	// write: parseBasis derives it, and Reduce's Set names the bases it stands for.
+	TierIncomparable = "incomparable"
 )
 
 // Discharge values accepted in a register row's Discharged cell.
@@ -40,18 +48,32 @@ const (
 	DischargedPartially = "Partially"
 )
 
-// Basis is the authored half of a proposition's status: the strongest basis
-// claimed for it, and the citation carrying that claim. "Strongest" is not a
-// total order — section 2 states the ranking convention and the pairs it ranks
-// that the evidence does not.
+// Basis is the authored half of a proposition's status: what the cell claims, and
+// the citation carrying the claim.
+//
+// Where the cell claims one basis, Tier is it. Where the cell claims a basis per
+// scope, Tier is what those scopes **reduce** to — the meet, per Reduce — and
+// Scoped holds the entries the reduction was taken over. Reading Tier therefore
+// cannot overstate, which reading "the strongest claimed" did (#135). "Strongest"
+// was never a total order either: section 2 states the ranking convention and the
+// pairs it ranks that the evidence does not.
 type Basis struct {
 	// Tier is the canonical spelling of one of the seven bases — a legacy name
 	// E0 through E3, or pair notation such as "exhaustive/implementation" for a
-	// pair that has none — or TierNone or TierWithdrawn. Pair decodes it.
+	// pair that has none — or TierNone, TierWithdrawn or TierIncomparable. Pair
+	// decodes it.
 	Tier string
-	// Citation is whatever the Basis cell says after the tier. For
+	// Citation is whatever the Basis cell says after the tier, or for a
+	// multi-scope cell every entry's citation joined with "; ". For
 	// TierWithdrawn it names the replacement propositions.
 	Citation string
+	// Scoped holds the cell's entries when it names any scope at all, in cell
+	// order. Nil for a Basis built by hand and for a single-entry cell that names
+	// no scope, whose Tier and Citation are the whole claim.
+	//
+	// len(Scoped) > 1 is what makes Tier a reduction rather than a transcription,
+	// and DeriveStatus says so in the status it renders.
+	Scoped []ScopedBasis
 }
 
 // Proposition is one row of a section 3 group table.
@@ -105,6 +127,44 @@ var (
 	// the case "Yes — closed completed" is, where the only thing offered is a
 	// fact about the tracker.
 	ErrDischargeNoCitation = errors.New("propdoc: a Discharged: Yes cell must cite the evidence, not the closure")
+)
+
+// Rejection reasons for a multi-scope Basis cell, exported for the same reason as
+// the discharge sentinels above: a test asserts which authoring mistake was
+// caught, not merely that one was.
+//
+// All but ErrBasisScopeUnterminated apply only to a cell claiming more than one
+// scope, that one being a malformed entry wherever it appears. A single-entry cell
+// naming no scope parses exactly as it did before per-scope bases existed, which is
+// why the twelve such cells in the document needed no edit (#135).
+var (
+	// ErrBasisScopeUnnamed is returned when a multi-scope cell leaves an entry's
+	// bound unnamed. A set of bases over unnamed scopes says nothing: the pair
+	// says *how* a domain was covered and only the bound says *which* domain
+	// (§2.1 rules 2 and 10).
+	ErrBasisScopeUnnamed = errors.New("propdoc: every entry of a multi-scope Basis cell must name its scope with @")
+	// ErrBasisScopeRepeated is returned when two entries name the same scope.
+	// Two bases for one scope puts the choice between them back on the reader,
+	// and the strongest-wins reading is the one this grammar exists to remove.
+	ErrBasisScopeRepeated = errors.New("propdoc: two entries of a Basis cell name the same scope; merge them")
+	// ErrBasisScopeUncited is returned when an entry of a multi-scope cell cites
+	// nothing. A basis with no citation is not a basis, per section 3, and
+	// per-scope bases mean per-scope evidence.
+	ErrBasisScopeUncited = errors.New("propdoc: every entry of a multi-scope Basis cell must cite its evidence")
+	// ErrBasisNotWeakestFirst is returned when a multi-scope cell does not lead
+	// with the entry it reduces to. The reduction is not written in the cell — it
+	// is derived — so the only thing a reader's eye lands on is the first entry,
+	// and a cell leading with its strongest scope reproduces the overstatement
+	// even though every derived number is right.
+	ErrBasisNotWeakestFirst = errors.New("propdoc: a multi-scope Basis cell must lead with the scope it reduces to")
+	// ErrBasisWithdrawnScoped is returned when withdrawn appears as one entry of
+	// a multi-scope cell. Withdrawal is a fact about the whole proposition — it
+	// is no longer measured — so it cannot be true of one scope and not another.
+	ErrBasisWithdrawnScoped = errors.New("propdoc: withdrawn describes a whole proposition and cannot be one scope of a Basis cell")
+	// ErrBasisScopeUnterminated is returned when an entry opens a scope with @ and
+	// never closes it with an em dash, so the citation cannot be told from the
+	// bound.
+	ErrBasisScopeUnterminated = errors.New("propdoc: a Basis entry opening a scope with @ must close it with an em dash before its citation")
 )
 
 // dischargeCitation matches a backtick-quoted span naming a file, optionally
@@ -184,6 +244,12 @@ func (d *Doc) Register() []Refutation { return d.reg }
 //   - Otherwise the authored tier decides, and a tier with no citation is not
 //     a tier.
 //
+// Where the Basis cell claims more than one scope, the tier that decides is the
+// **meet** over those scopes and the rendered status says how many scopes it is the
+// weakest of, so that a number derived from unevenly covered routes cannot be read
+// as a claim about the whole domain (#135). Where the scopes do not share a Subject
+// there is no meet, and the status names the set instead of picking from it.
+//
 // The function is total: every input yields a status, so no proposition can be
 // left without one.
 func DeriveStatus(b Basis, live, total int) string {
@@ -200,7 +266,25 @@ func DeriveStatus(b Basis, live, total int) string {
 		return "REFUTED"
 	}
 	if b.Tier == TierNone || b.Tier == "" || b.Citation == "" {
+		if n := len(b.Scoped); n > 1 && b.Tier == TierNone {
+			return fmt.Sprintf("UNPOPULATED (a scope of %d is uncovered)", n)
+		}
 		return "UNPOPULATED"
+	}
+	// A cell claiming several scopes reports what its tier is the weakest of.
+	// Parenthesised so that Kind tallies it with the single-scope statuses: this
+	// is detail about the claim, not a different class of claim.
+	scopes := ""
+	if n := len(b.Scoped); n > 1 {
+		scopes = fmt.Sprintf(", weakest of %d scopes", n)
+	}
+	if b.Tier == TierIncomparable {
+		red, _ := Reduce(b.Scoped)
+		names := make([]string, 0, len(red.Set))
+		for _, k := range red.Set {
+			names = append(names, k.Spelling())
+		}
+		return fmt.Sprintf("ENFORCED (no meet over %d scopes: %s)", len(b.Scoped), strings.Join(names, ", "))
 	}
 	// Asserted coverage enforces nothing, so it renders as what it is. Naming the
 	// basis in parentheses rather than hard-coding "E0" keeps the rendering keyed
@@ -208,7 +292,10 @@ func DeriveStatus(b Basis, live, total int) string {
 	// and therefore exactly one spelling, so this can only print "ASSERTED (E0)".
 	if k, ok := lookupBasis(b.Tier); ok {
 		if k.Coverage == CoverageAsserted {
-			return "ASSERTED (" + k.Canonical() + ")"
+			return "ASSERTED (" + k.Canonical() + scopes + ")"
+		}
+		if scopes != "" {
+			return "ENFORCED " + k.Canonical() + " (" + strings.TrimPrefix(scopes, ", ") + ")"
 		}
 		return "ENFORCED " + k.Canonical()
 	}
@@ -482,14 +569,55 @@ func parseProposition(cells []string, lineIdx int) (*Proposition, error) {
 	}, nil
 }
 
-// parseBasis reads a Basis cell: a tier token, then an optional citation
-// separated by an em dash, a colon or whitespace.
+// parseBasis reads a Basis cell: one or more entries separated by semicolons,
+// each a tier token, an optional "@ scope" closed by an em dash, and a citation.
+//
+//	E1 — `x_test.go:1`
+//	chosen/implementation @ the `strata run` route — `a_test.go:1`; exhaustive/implementation @ the agent boot route — `b_test.go:2`
+//
+// A cell with one entry and no scope is the whole of the old grammar, and parses
+// to the same Basis it always did — Scoped stays nil. A cell with several entries
+// reduces to their meet (Reduce), and the returned Tier is that reduction rather
+// than any one entry's claim.
 func parseBasis(cell string, lineIdx int) (Basis, error) {
 	text := strings.TrimSpace(cell)
 	if text == "" {
 		return Basis{}, fmt.Errorf("propdoc: line %d: empty Basis cell", lineIdx+1)
 	}
-	tier, rest, _ := strings.Cut(text, " ")
+	parts := strings.Split(text, ";")
+	entries := make([]ScopedBasis, 0, len(parts))
+	for _, part := range parts {
+		if strings.TrimSpace(part) == "" {
+			return Basis{}, fmt.Errorf("propdoc: line %d: Basis cell has an empty entry; "+
+				"a semicolon separates two scoped bases", lineIdx+1)
+		}
+		e, err := parseBasisEntry(part, lineIdx)
+		if err != nil {
+			return Basis{}, err
+		}
+		entries = append(entries, e)
+	}
+
+	if len(entries) == 1 {
+		e := entries[0]
+		if e.Tier == TierNone && e.Citation != "" {
+			return Basis{}, fmt.Errorf("propdoc: line %d: tier %q carries a citation %q; "+
+				"cite a tier or claim none", lineIdx+1, TierNone, e.Citation)
+		}
+		b := Basis{Tier: e.Tier, Citation: e.Citation}
+		if e.Scope != "" {
+			b.Scoped = entries
+		}
+		return b, nil
+	}
+	return reduceCell(entries, lineIdx)
+}
+
+// parseBasisEntry reads one entry of a Basis cell. The scope is recognised only
+// when @ is the first thing after the tier token, so a citation containing an @ —
+// a formation filename, say — is not mistaken for a bound.
+func parseBasisEntry(text string, lineIdx int) (ScopedBasis, error) {
+	tier, rest, _ := strings.Cut(strings.TrimSpace(text), " ")
 	switch tier {
 	case TierNone, TierWithdrawn:
 	default:
@@ -498,16 +626,102 @@ func parseBasis(cell string, lineIdx int) (Basis, error) {
 		// written "E1" and the column stays uniform.
 		canonical, err := parseTier(tier, lineIdx)
 		if err != nil {
-			return Basis{}, err
+			return ScopedBasis{}, err
 		}
 		tier = canonical
 	}
-	citation := strings.TrimSpace(strings.TrimLeft(strings.TrimSpace(rest), "—:-"))
-	if tier == TierNone && citation != "" {
-		return Basis{}, fmt.Errorf("propdoc: line %d: tier %q carries a citation %q; "+
-			"cite a tier or claim none", lineIdx+1, TierNone, citation)
+	rest = strings.TrimSpace(rest)
+	var scope string
+	if strings.HasPrefix(rest, "@") {
+		bound, cited, ok := strings.Cut(rest[1:], "—")
+		if !ok {
+			// TierNone is exempt, and only TierNone: a scope declared uncovered has
+			// nothing to cite, so there is nothing for the em dash to separate. Every
+			// other tier claims evidence, and an entry that opens a bound and never
+			// closes it leaves the bound and the citation indistinguishable.
+			if tier != TierNone {
+				return ScopedBasis{}, fmt.Errorf("propdoc: line %d: entry %q: %w",
+					lineIdx+1, strings.TrimSpace(text), ErrBasisScopeUnterminated)
+			}
+			bound, cited = rest[1:], ""
+		}
+		scope, rest = strings.TrimSpace(bound), cited
+		if scope == "" {
+			return ScopedBasis{}, fmt.Errorf("propdoc: line %d: entry %q names an empty scope: %w",
+				lineIdx+1, strings.TrimSpace(text), ErrBasisScopeUnnamed)
+		}
 	}
-	return Basis{Tier: tier, Citation: strings.TrimSpace(citation)}, nil
+	citation := strings.TrimSpace(strings.TrimLeft(strings.TrimSpace(rest), "—:-"))
+	return ScopedBasis{Tier: tier, Scope: scope, Citation: citation}, nil
+}
+
+// reduceCell applies the rules a multi-scope Basis cell must satisfy and returns
+// the Basis its entries reduce to.
+//
+// The rules are not stylistic. Unnamed or repeated scopes make the reduction
+// meaningless or ambiguous; an uncited entry contributes a tier on no evidence; and
+// a cell not leading with its reduction leaves the overstatement in the one place a
+// reader actually looks, since the reduction itself is derived and appears only in
+// the generated Status column.
+//
+// TierNone is the one tier exempt from the citation requirement, and required to
+// carry no citation: it declares a scope *uncovered*, and an uncovered scope has
+// nothing to cite. That is the same rule the single-entry path applies to a bare
+// "none" cell.
+func reduceCell(entries []ScopedBasis, lineIdx int) (Basis, error) {
+	seen := make(map[string]bool, len(entries))
+	var citations []string
+	for _, e := range entries {
+		if e.Tier == TierWithdrawn {
+			return Basis{}, fmt.Errorf("propdoc: line %d: %w", lineIdx+1, ErrBasisWithdrawnScoped)
+		}
+		if e.Scope == "" {
+			return Basis{}, fmt.Errorf("propdoc: line %d: the entry claiming %q names no scope: %w",
+				lineIdx+1, e.Tier, ErrBasisScopeUnnamed)
+		}
+		if seen[e.Scope] {
+			return Basis{}, fmt.Errorf("propdoc: line %d: scope %q is claimed twice: %w",
+				lineIdx+1, e.Scope, ErrBasisScopeRepeated)
+		}
+		seen[e.Scope] = true
+		switch {
+		case e.Tier == TierNone && e.Citation != "":
+			return Basis{}, fmt.Errorf("propdoc: line %d: scope %q is declared uncovered and cites "+
+				"%q; cite a tier or claim none", lineIdx+1, e.Scope, e.Citation)
+		case e.Tier != TierNone && e.Citation == "":
+			return Basis{}, fmt.Errorf("propdoc: line %d: scope %q claims %q and cites nothing: %w",
+				lineIdx+1, e.Scope, e.Tier, ErrBasisScopeUncited)
+		}
+		if e.Citation != "" {
+			citations = append(citations, e.Citation)
+		}
+	}
+
+	// Every case below leads with the entry the cell reduces to, and the check is
+	// the same check: an uncovered scope is the weakest thing a cell can say, a
+	// meet is the weakest of what it claims, and an incomparable cell has no
+	// weakest entry to lead with — so that case carries no ordering rule and
+	// DeriveStatus prints the whole set instead.
+	b := Basis{Citation: strings.Join(citations, "; "), Scoped: entries}
+	red, ok := Reduce(entries)
+	if !ok {
+		if entries[0].Tier != TierNone {
+			return Basis{}, fmt.Errorf("propdoc: line %d: the cell leads with %q while a scope is "+
+				"declared uncovered: %w", lineIdx+1, entries[0].Tier, ErrBasisNotWeakestFirst)
+		}
+		b.Tier = TierNone
+		return b, nil
+	}
+	if !red.Comparable {
+		b.Tier = TierIncomparable
+		return b, nil
+	}
+	if first, known := lookupBasis(entries[0].Tier); !known || first != red.Meet {
+		return Basis{}, fmt.Errorf("propdoc: line %d: the cell leads with %q but reduces to %q: %w",
+			lineIdx+1, entries[0].Tier, red.Meet.Canonical(), ErrBasisNotWeakestFirst)
+	}
+	b.Tier = red.Meet.Canonical()
+	return b, nil
 }
 
 func parseRefutation(cells []string, lineIdx int) (Refutation, error) {


### PR DESCRIPTION
Closes #135.

## What was wrong

§3 defined the Basis column as *"the strongest basis claimed"* — a **max** over the evidence. For a proposition quantifying over several execution routes that are covered unequally, a max reports the best-covered route's strength as the proposition's, and the column says nothing about which route that was.

Two cells were in exactly that shape. `T1` (*no unverified mount*) and `T5` (*fail-closed*) both read `exhaustive/implementation`, on the strength of `TestBootMatrix_DecisionSurface`'s 112-cell enumeration of the **agent boot** route. The `strata run` route under each of them is covered by example tests only. #129's PR worked around this by naming the route in prose beside the pair, which is a note, and notes do not fire.

## What replaces it

The reduction is a **meet** (greatest lower bound), not a max. The correction to the obvious form of a meet is the substance:

A min needs an order, and the seven bases do not have one — Coverage is totally ordered, Subject is not (§2.1 rule 1). So the rule is **a pair where all covered scopes share a Subject, the set of them otherwise, over the union of the declared bounds.** A route known to be uncovered is declared `none @ that route`, which collapses the cell, because a floor over a union says nothing about a part of the domain no entry names.

`asserted` is the bottom and comparable with everything, because Subject's incomparability arises from *what was executed* and asserted executed nothing. That is a floor on **coverage** and not a usefulness ranking, which is how §2's ranking-note item 4 survives intact.

New grammar: `tier @ scope — citation`, entries separated by `;`. **A single entry naming no scope is the whole of the old grammar and parses unchanged**, which is why 32 of the 34 propositions needed no edit.

Four obligations are enforced on a multi-scope cell, a sentinel each: name every scope, name none twice, cite every scope claiming a basis, and **lead with the entry the cell reduces to** — because the reduction is derived and surfaces only in the Status column, so the first entry is the only basis a reader of the Basis column sees.

## The bound on this PR's own green — stated before the evidence, not after

| Cell | Scopes | Old (max) | New (meet) | Status before | Status after |
|---|---|---|---|---|---|
| `T1` | 2 | `exhaustive/implementation` | `chosen/implementation` | `REFUTED (1 of 4 live)` | `REFUTED (1 of 4 live)` |
| `T5` | 3 | `exhaustive/implementation` | `chosen/implementation` | `REFUTED (1 of 4 live)` | `REFUTED (1 of 4 live)` |

Both scoped propositions are `REFUTED`, and a live refutation outranks any basis (§2.1 rule 5), so **neither Status cell moves.**

```
$ go run ./cmd/propgen
PROPERTIES.md: 34 propositions, 41 register rows, no drift
  ASSERTED (E0)  1
  ENFORCED E1    2
  REFUTED        27
  UNPOPULATED    2
  WITHDRAWN      2
```

Byte-identical before and after. **The document's own green therefore says nothing about whether the reduction is right**, and a corpus test asserting today's rows still pass would be vacuous in the exact sense: it passes equally if `Reduce` returns the max.

So the corpus test reads the **parsed reduction** and asserts it *differs* from the max (`internal/propdoc/basis_scope_test.go:460`), and the renderings are covered by constructed cells (`:376`). Cardinality stated: **2** multi-scope cells, **32** single-scope, **34** propositions — the test asserts `single + len(scoped) == len(doc.Propositions())` so the population cannot drift under it. It also asserts both propositions remain `REFUTED`, so the premise *"the corpus cannot exercise the rendering path"* fails loudly when it expires rather than silently going stale.

Each constructed fixture additionally records **whether its own meet and max coincide**, and fails when a row that was supposed to discriminate stops discriminating. That assertion, not any expected value, is what caught the one mutation whose failing set was wider than predicted.

## Migration was forced, not offered

Both cells carried their second route as prose after a semicolon. Under the new grammar neither parses, and six inherited tests went red on the unmigrated document (`propdoc: line 598: unknown evidence tier "the"`). That is how a half-migrated document is prevented rather than discouraged, and it is recorded as a test in its own right (`:560`, both cells verbatim from `041e50f`).

## §2's pre-armed guard came due

The ranking note said no tool consumed the basis ordering, that the list of pairs *the order ranks and the evidence does not* was therefore "a note, and notes do not fire", and that the first consumer would owe a guard making the list non-vacuous. `Reduce` is that consumer, and the guard is `TestReduceRefusesSection2sIncomparablePairs` (`:192`). The answers are narrower than the promise anticipated:

- **Items 1 and 2 are refused outright** — and the assertion names both bases, so a refusal for the wrong reason is not evidence for the right one.
- **Item 4 is not refused.** `asserted` is the bottom of the coverage order and a floor over coverage is defined for it; item 4's complaint is about usefulness, which `Reduce` does not compute. The test carries that distinction as a `why` string rather than leaving the omission to be read as an oversight.
- **Item 3 is not expressible as a pair of bases at all** — it is a statement about two cells — so its answer is structural (every entry carries its own scope), enforced separately at `:364`, and its absence from the guard table is a comment and a `t.Log` rather than a gap.

Three of four ranked pairs machine-checked; the fourth stated as inexpressible rather than silently dropped.

## Mutation probes

`zsh /tmp/mutprobe_135.sh` — baseline green asserted first, patch asserted to apply exactly once, **mutant asserted to build**, tree restored from a `trap`, never piped into `head`.

| Probe | Mutation | Predicted | Failing | Verdict |
|---|---|---|---|---|
| A | meet becomes max | 10 | 10 | RED |
| B | subject agreement inverted | 4 | 4 | RED |
| C | `chosen` ranks as high as `exhaustive` | 1 | 3 | RED |
| D | weakest-first check disabled | 1 | 1 | RED |
| E | scope-uniqueness never records | 1 | 1 | RED |
| F | `@` recognised anywhere, not as a prefix | 1 | 1 | RED |
| G | scope count dropped from the status | 1 | 1 | RED |
| H | uncovered scope no longer collapses the cell | 2 | 2 | RED |
| I | the reported set is built wrong | 2 | 2 | RED |

**9 red, 8 failing sets predicted exactly.** The two departures are worth more than the eight matches:

- **Probe C** was predicted to break one test and broke three. The tie also disables the lead-with-the-reduction rule (the meet equals the first entry, so a strongest-first cell is wrongly accepted), and two separate tests object because their fixtures stop discriminating. A `Reduce` returning the max passes every *value* assertion on any row where meet and max agree — the discriminating-power assertion is what has teeth.
- **Probe H was VOID on its first cut.** Removing `uncovered ||` orphaned the variable, so the mutant did not compile — which `go test` reports with exit 1 exactly as it reports a caught defect. Re-cut as a value swap (`uncovered = true` → `= false`) it went red at the predicted set. This is the third occasion the build-assertion has turned a false RED into a VOID.

Seven distinct failing sets over nine probes, sizes 1 to 10: output that varies with its input. The three that coincide are D, E and F, each caught by the grammar table alone. Probe A's 10 is the whole package, the shape to expect from inverting the reduction itself, since every corpus test parses the document through it.

## A defect in the practice, found here and deliberately not fixed here

Seven `path:line` citations elsewhere in `PROPERTIES.md` pointed at the wrong line. **Six were broken by this PR's first commit**, by inserting code above their targets; the seventh, `propdoc.go:87` for `Refutation.Live`, was **wrong when it was written** — at `041e50f` `Live()` was at line 95. All repaired in `4d5ba47`; only the pointers changed, so no claim they support is altered.

This is not a new issue. **It contradicts the premise of an existing one.** #105 scopes a citation checker and measures its level 1 — path resolves, line within file, `func <Name>(` at the line where a test name is given — as finding **zero defects today**, concluding level 1 is insurance rather than a bug-finder. Level 1 as scoped is **green on all seven**: five land inside their file and within its length, and the two written bare (`` `:261` ``) are in the form #105 already measures as not machine-resolvable at all. The class is not a dangling pointer but a pointer at a *valid wrong* line, and its base rate is not zero — seven instances in the one file this PR touched. Recorded on [#105](https://github.com/scttfrdmn/strata/issues/105#issuecomment-5382212069) with the measurement and what it reorders in that issue's scope (test names alongside line numbers is a prerequisite for detection, not a tidy-up).

## What changes per consumer

Enumerated from `grep -rn 'propdoc\.' --include='*.go' .` (one caller, `cmd/propgen`) and from §6's human procedure, which has no callers to grep:

- **`go run ./cmd/propgen` exits 1** on a Basis cell that leads with anything but the entry it reduces to, repeats or omits a scope, or leaves a scope uncited. Six new exported sentinels, one per malformation.
- **A multi-scope cell in the old prose style no longer parses at all**, so a half-migrated document cannot reach `main`.
- **§6 gains an authoring step**: unequal coverage is stated per route, with the floor derived into Status (`weakest of N scopes`); recording only the best-covered route is a rejected document, not a style choice.

**No production behaviour changes** — `internal/propdoc` and `cmd/propgen` are documentation tooling, not part of any shipped command.

## Propositions moved

**None.** `T1` and `T5` are `REFUTED` before and after, with the same live-row counts. Their *Basis* claims are corrected downward, which is the point: the document previously claimed more than it had.

## Verification

| Check | Result |
|---|---|
| `go test ./...` | pass |
| `go run ./cmd/propgen` | `no drift`, distribution unchanged |
| `go vet ./...` | clean |
| `gofmt -l ./cmd ./internal` | no output |
| `golangci-lint run ./internal/propdoc/... ./cmd/propgen/...` | `0 issues.` |
| inherited test files modified | none — `git diff --name-status origin/main...HEAD -- '*_test.go' \| awk '$1 != "A"'` is empty |

Local golangci-lint is **2.13.0**; CI pins **v2.11.3** (`.github/workflows/ci.yml:90`). The local run is therefore not a substitute for the CI job.
