### PR TITLE
fix: widen EnvironmentID to the fields the assembler reads (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -338,6 +338,91 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   timeout. Completes the two work items left unchecked in #36.
 
 ### Changed
+- **`EnvironmentID` now covers the fields the assembler actually reads** (#145,
+  closing #117, #118, #120, #121, #122, #123). The six issues above each
+  described the identity as too *narrow* — a sound subset missing a field. It was
+  not a subset. Cross-tabulating what the hash covered against what the assembler
+  reads found it misaligned in both directions: of the five things hashed, two are
+  read by no assembler at all (`on_ready`, which has no in-tree executor — #69 —
+  and each package entry's `sha256`, which the installer ignores in favour of
+  resolving `name@version` — #98), while ten fields that decide what lands on
+  `PATH`, in `/etc/profile.d/strata.sh` and in the module list were absent. No
+  patch to any one issue would have surfaced that, which is why they are resolved
+  by one decision rather than six patches.
+
+  The two hashed-but-unread fields stay hashed, under rule 3 of the decision: the
+  identity commits to the *instruction* and not to its outcome. An `on_ready:`
+  block is part of what the lockfile says to do even while nothing runs it.
+
+  Now hashed, with the consumer that made each one content: `profile` (becomes
+  `$STRATA_PROFILE` in every login shell), each layer's `id` (its mount point),
+  `name` and `version` (the `$STRATA_ENV/<name>/<version>/bin` entry on `PATH`),
+  `install_layout` (whether the layer contributes a `PATH` entry at all), and
+  `defaults` (the `module load` lines in `/etc/profile.d/strata-defaults.sh`).
+  Two encoding differences that assemble the same environment now share an
+  identity: an omitted `install_layout` equals an explicit `versioned`, and a
+  package set whose entries are `nil` equals one whose entries are `[]` (#117).
+
+  **What changes per consumer.** Enumerated from
+  `grep -rn 'EnvironmentID()' --include='*.go' . | grep -v _test.go`, which finds
+  eight call sites, plus the human procedure the identity exists for — citing an
+  environment in a paper:
+  - **No stored identity changes, because there are none.** No shipped code
+    assigns `Base.AMISHA256` — `grep -rn 'AMISHA256\s*[:=]' --include='*.go' . |
+    grep -v _test.go` finds only a format string, a copy into
+    `ProvenanceRecord`, and the hash input itself — so `IsFrozen()` is false for
+    every lockfile the resolver produces and `EnvironmentID()` returns `""` for
+    all of them (#64). Every consumer below sees `""` today and continues to.
+    This is why the widening lands now: it invalidates nothing, and that stops
+    being true the moment #64 is fixed.
+  - `internal/registry/s3client.go:617` and `localclient.go:374` key stored
+    lockfiles on `locks/<id>.yaml`. Unchanged in practice, per the above; a
+    lockfile that *is* frozen gets a different key than it would have before.
+  - `cmd/strata-agent/ec2_signaler.go:84` tags instances with
+    `strata:environment-id`. Same.
+  - `internal/export/oci.go:404` sets `org.opencontainers.image.revision`, and
+    `internal/zenodo/zenodo.go:105,211` puts the identity in DOI metadata. Same.
+  - `cmd/strata/update.go:117-119` and `cmd/strata/diff.go:41-43` compare two
+    lockfiles' identities to decide whether an update is a no-op. These are the
+    two sites that get *more* accurate: an update that changed only a layer's
+    version, or a profile rename, previously compared equal and reported no
+    change.
+  - **Anyone who has recorded an `EnvironmentID` outside the repository** — in a
+    paper, a ticket, a lab notebook — has recorded either `""` or a value from a
+    hand-built lockfile. The latter will not match a recomputation.
+
+  The membership rule is documented in `docs/environment-identity.md` and enforced
+  rather than described: `spec/environment_id_scope_test.go` compares seven route
+  tables against their struct definitions by reflection in both directions, so a
+  new field on any of them fails until it is classified; mutates each of the 57
+  classified fields to assert the identity moves if and only if the table says it
+  is content; and requires a table for every struct reached through a field the
+  tables call content, which is what stops the enumeration ending one level above
+  a new field. Counts from
+  `go test ./spec/ -run TestEnvironmentIDRoutes -count=1 -v | grep -c -- '--- PASS'`
+  which reports 67 — 57 mutation rows, 7 struct comparisons, 3 top-level tests.
+  `spec/declared_provenance_test.go` enforces the one exclusion that rests
+  entirely on an absence — that nothing in-tree reads `STRATA_REKOR_ENTRY` back
+  (#120) — by enumerating every mention of the name and failing on any that is
+  not a known write site.
+
+- **Two `sort.Slice` calls on layer stacks are now `sort.SliceStable`**
+  (`internal/overlay/mount_linux.go:140`, `internal/export/oci.go:49`). Two layers
+  may share a `MountOrder`, and the tie decides which one's files win in the
+  merged view. With an unstable sort the winner came from `sort.Slice`'s
+  internals, while `EnvironmentID` hashes the layers in lockfile order — so the
+  assembled environment and its identity could disagree about the same lockfile.
+  Both now break ties the same way, by the order the layers appear in the
+  lockfile.
+
+  **This changes nothing for any lockfile shipped code produces.** All three
+  producers assign distinct values — `internal/resolver/stages.go:411` and
+  `internal/build/buildenv.go:76,105` assign `i + 1`, `internal/scan/profile_gen.go:54`
+  assigns `i` — and an unstable sort on distinct keys is already deterministic.
+  It matters for hand-written and externally produced lockfiles. What a tie
+  *ought* to mean is still undefined by the specification (#95); this change only
+  removes the disagreement between two sorts.
+
 - **A `PROPERTIES.md` Basis cell covering several execution routes now reports the
   weakest of them, not the strongest** (#135). §3 defined the column as *the strongest
   basis claimed* — a max over the evidence. For a proposition quantifying over every

--- a/docs/environment-identity.md
+++ b/docs/environment-identity.md
@@ -1,0 +1,129 @@
+# Environment identity
+
+`LockFile.EnvironmentID()` returns the SHA256 of a canonical encoding of a
+lockfile's content. It is used as a registry storage key, an EC2 instance tag, an
+OCI image label and DOI metadata, so what it does and does not commit to decides
+whether those uses are sound.
+
+This document is the reasoning behind `envHashInput` in `spec/lockfile_hash.go`.
+The field list itself is not repeated here — a second copy is a second thing to
+keep current, and the copy that used to live in `spec/lockfile.go` drifted twice.
+What is here is the rule for deciding membership, the residual the identity does
+*not* cover, and the gaps that are known and open.
+
+## Four rules
+
+**1. Content, or a named route out.** A lockfile field is hashed unless it takes
+one of four routes, each a checkable obligation rather than a judgement:
+
+| Route | Means | Fails when |
+|---|---|---|
+| `inert` | No consumer outside `spec` reads it | A consumer appears |
+| `digest-mediated` | Its influence is bounded by a check against a hashed field | The check is removed, or was never implemented |
+| `abort-only` | It can stop assembly but never change it | A code path degrades instead of refusing |
+| `declared-provenance` | Exported under a name the identity's claim excludes, with no in-tree reader | Something reads the name back |
+
+Two labels in the route tables are not additional routes and should not be read
+as extending this list. `order-expressing` (`ResolvedLayer.MountOrder`) is rule 2
+below: the ordering the field defines *is* hashed and only its literal value is
+dropped. `manifest-metadata` is the `digest-mediated`-or-`inert` argument applied
+to `LayerManifest` as a class — every field of it either describes the squashfs
+artifact pinned by `SHA256`, which is hashed, or is consumed at resolve time
+before the lockfile exists. The five fields the assembler reads out of the
+lockfile's own copy of the manifest — `ID`, `Name`, `Version`, `InstallLayout`,
+`SHA256` — are excepted from that class and hashed.
+
+A field with *no* route is the defect this list exists to catch. Three tests
+enforce it, all in `spec/environment_id_scope_test.go`:
+`TestEnvironmentIDRoutes_CoverEveryField` compares the route tables against the
+struct definitions by reflection in both directions;
+`TestEnvironmentIDRoutes_MatchBehaviour` mutates each field and asserts the
+identity moves if and only if the table says the field is content; and
+`TestEnvironmentIDRoutes_ContentStructsHaveTables` requires a table for every
+struct reached through a field the tables call content, since the first test can
+only compare a struct that already has one.
+
+A field classified as taking a route out needs no table for its own type: the
+route covers the whole subtree beneath it, which is what makes `inert` a claim
+worth checking rather than a claim about one field.
+
+The `declared-provenance` route has its own enforcement, because it is the one
+route that rests entirely on an absence: `TestDeclaredProvenance_NoInTreeReader`
+in `spec/declared_provenance_test.go` enumerates every in-tree mention of
+`STRATA_REKOR_ENTRY` and `strata.lockfile.rekor_entry` and fails on any mention
+that is not a known write site.
+
+**2. Hash the meaning, not the encoding.** Two lockfiles that assemble the same
+environment must not differ in identity because of how they were written down.
+Two consequences are implemented:
+
+| Encoding difference | Treated as | Where |
+|---|---|---|
+| `install_layout:` omitted vs. `versioned` | Same identity | `canonicalInstallLayout`, `spec/lockfile_hash.go` |
+| A package set's entries `nil` vs. `[]` | Same identity | `omitempty` on `packageSetHashInput.Packages` |
+| Mount orders `1,2` vs. `10,20` | Same identity | Layers are sorted by `MountOrder`; the value is not hashed |
+| Order of two package sets | **Different** identity | One install command runs per entry, in order |
+
+The last row is not an exception to rule 2 — it is rule 2 applied correctly.
+`internal/agent/package_installer.go:37` iterates the sets and `:99` and `:113`
+run one `pip`/`conda` command per entry, so a later entry can change what an
+earlier one installed. Sorting either dimension would give two different install
+sequences one identity.
+
+**3. Equal identities mean identical instructions, not identical state.** This is
+the residual, and it is the reason the stronger claim — same ID, same environment
+— is recorded REFUTED in `PROPERTIES.md` as X2.
+
+| Instruction | Deterministic? | Consequence of equal IDs |
+|---|---|---|
+| Base AMI digest, layer digests | Yes | Identical bytes |
+| Layer set and mount sequence | Yes | Identical stack |
+| Exported environment (`env:`, profile name) | Yes | Identical variables |
+| Packages with a recorded digest | Yes | Identical bytes |
+| Packages without a digest | No | Same request, whatever upstream now resolves it to |
+| `on_ready:` commands | No | Same commands, no claim about their effect |
+| A mutable EBS upper | No | Same declaration, unknown contents |
+
+For the bottom three, the identity commits to the instruction and not to its
+outcome. A reader who needs the stronger claim needs a lockfile that avoids them,
+which is what `strata freeze` is for.
+
+**4. The undefined case is not a value.** An unfrozen lockfile has no identity,
+and `EnvironmentID()` returns `""` to say so. `""` is not an identifier: it must
+not be published, tagged, or used as a storage key. This is currently violated —
+see below.
+
+## Known gaps, all open
+
+These are stated rather than fixed, because each is tracked separately and
+because a document that quietly omits them reads as a claim they do not exist.
+
+| Gap | Effect | Issue |
+|---|---|---|
+| No shipped code assigns `Base.AMISHA256` | `IsFrozen()` is false for every lockfile the resolver produces, so `EnvironmentID()` returns `""` for all of them | #64 |
+| The lockfile's copy of a layer's `name`, `version` and `install_layout` sits outside the signed envelope | An attacker with registry write can change them; hashing them makes the change *visible* in the identity, not *refused* | #146 |
+| `""` reaches a storage key and an instance tag | Two of the three publishing paths have no frozen gate. `pkg/strata.UploadLockfile` (`pkg/strata/strata.go:125`) is the only caller of `PutLockfile`, so an unfrozen lockfile is stored at `locks/.yaml` — one key shared by every such lockfile. `cmd/strata-agent/ec2_signaler.go:84` tags every instance with `strata:environment-id` unconditionally. The DOI path *is* gated: `strata publish` refuses an unfrozen lockfile before reaching Zenodo (`cmd/strata/publish.go:30`, `:73`) | #124 |
+| Which layer wins under a tied `MountOrder` is undefined | The identity follows the mounter's tie-break — lockfile order, via a stable sort — but the specification does not say what a tie *means*, so a resolver could emit ties that assemble unpredictably | #95 |
+| `on_ready:` has no in-tree executor | Hashed as an instruction under rule 3; if one is added, the outcome becomes part of the environment and rule 3's residual shrinks | #69 |
+| Package digests are recorded but not enforced at install time | Two lockfiles differing only in a recorded digest install identical bytes, so the digest is hashed as an instruction rather than a guarantee | #98 |
+
+## Changing what is hashed
+
+Widening the hash changes every identity it touches, so the cost depends
+entirely on how many identities are stored. Today that number is zero: because
+no shipped code populates `Base.AMISHA256` (#64), every lockfile the resolver can
+produce returns `""`, and there is nothing whose identity a widening could
+invalidate. That is a property of the present, not of the design — it stops being
+true the moment #64 is fixed, and the cost of widening rises from nothing to a
+migration.
+
+Any change to membership must:
+
+1. add or move the field's row in the route tables in
+   `spec/environment_id_scope_test.go`, with the evidence for its route;
+2. state the reason in `spec/lockfile_hash.go` next to the field, not here;
+3. update `PROPERTIES.md` where a proposition's evidence cites the old
+   membership.
+
+The tests enforce (1) mechanically. Nothing enforces (2) or (3), which is why
+they are written down.

--- a/internal/export/oci.go
+++ b/internal/export/oci.go
@@ -41,9 +41,12 @@ func Export(ctx context.Context, lf *spec.LockFile, layerPaths []overlay.LayerPa
 	}
 
 	// Sort layerPaths by MountOrder ascending (bottom of stack first).
+	// Stable, for the same reason as the mounter: tied MountOrders keep
+	// lockfile order, so the exported image stacks its layers the way the
+	// mounted environment does.
 	sorted := make([]overlay.LayerPath, len(layerPaths))
 	copy(sorted, layerPaths)
-	sort.Slice(sorted, func(i, j int) bool {
+	sort.SliceStable(sorted, func(i, j int) bool {
 		return sorted[i].MountOrder < sorted[j].MountOrder
 	})
 

--- a/internal/overlay/mount_linux.go
+++ b/internal/overlay/mount_linux.go
@@ -129,9 +129,15 @@ func MountWithConfig(layers []LayerPath, cfg Config) (*Overlay, error) {
 	}
 
 	// Sort ascending by MountOrder so we mount bottom-of-stack first.
+	// The sort is stable because two layers may share a MountOrder, and the
+	// stack order decides which of them wins in the merged view. A stable sort
+	// makes the tie-break the order the layers appear in the lockfile, which is
+	// the order spec.EnvironmentID hashes — an unstable sort would leave both
+	// the assembled environment and its identity resting on sort.Slice's
+	// internals, and they could disagree.
 	sorted := make([]LayerPath, len(layers))
 	copy(sorted, layers)
-	sort.Slice(sorted, func(i, j int) bool {
+	sort.SliceStable(sorted, func(i, j int) bool {
 		return sorted[i].MountOrder < sorted[j].MountOrder
 	})
 

--- a/spec/declared_provenance_test.go
+++ b/spec/declared_provenance_test.go
@@ -1,0 +1,407 @@
+package spec
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// This file enforces the "declared provenance" route out of envHashInput
+// (spec/lockfile_hash.go). LockFile.RekorEntry is exported into the assembled
+// environment and is deliberately not hashed, on the argument that it is a
+// statement *about* the environment rather than part of it. That argument holds
+// only while nothing in-tree reads the exported value back: a program that
+// branched on $STRATA_REKOR_ENTRY would make the field content, and the identity
+// would be under-determined for exactly as long as nobody noticed.
+//
+// The obligation was originally written as a comment. A comment asserting an
+// absence is a check waiting to be written, so it is written here.
+//
+// # What is checked, and which check is the fence
+//
+// Two detectors, in decreasing order of strength:
+//
+//  1. Enumeration. Every mention of an exported name in a scanned file must
+//     appear in allowedProvenanceMentions, with the expected count, and every
+//     entry in that list must be observed. A new mention anywhere fails,
+//     whatever it does — including forms detector 2 cannot spell, such as
+//     indexing a map built from os.Environ(), a read split across lines, or a
+//     local wrapper named getenv. This is the fence.
+//  2. Read-function proximity. A mention on a line that also names an
+//     environment read (os.Getenv, os.LookupEnv, os.Environ, syscall.Getenv,
+//     syscall.Environ) fails with a specific message, and a shell expansion
+//     ($NAME or ${NAME}) fails likewise. This adds nothing detector 1 misses
+//     inside scanned files; it exists so the failure names the defect instead of
+//     reporting an unexplained count.
+//
+// # Scope, stated rather than left to the reader
+//
+// Scanned: non-test .go files, and .sh/.bash files. Out of scope, by name:
+//
+//   - _test.go files — internal/overlay/overlay_test.go:76 asserts the export is
+//     present, which is a test of the writer, not a program reading the value.
+//     This file is itself a test and names the variables throughout.
+//   - .md files — docs/userspace.md:103 publishes the variable as part of the
+//     userspace contract and PROPERTIES.md cites it as evidence. Prose cannot
+//     read an environment variable.
+//   - .yml/.yaml — CI workflows do not assemble a Strata environment, so a
+//     mention there could not make the field content.
+//   - the YAML key rekor_entry (spec/lockfile.go:27) — that is the lockfile's
+//     own serialisation, not a name invented for export. Reading it back means
+//     reading the lockfile, which is the scope question #121 tracks, not this
+//     one.
+//
+// The names checked are the two the value is exported under, which is *not* the
+// same as the set of sites that export RekorEntry: internal/fold/eject.go
+// exports STRATA_PROFILE and does not export the Rekor entry at all.
+
+// declaredProvenanceNames are the names LockFile.RekorEntry's value is published
+// under. Both are strings invented for export, so any in-tree occurrence of one
+// is either a write site or a consumer.
+func declaredProvenanceNames() []string {
+	return []string{
+		// Written to /etc/profile.d/strata.sh, /etc/strata/environment, and the
+		// child process environment.
+		"STRATA_REKOR_ENTRY",
+		// The OCI image label written by internal/export/oci.go.
+		"strata.lockfile.rekor_entry",
+	}
+}
+
+// allowedProvenanceMentions maps each exported name to the scanned files that
+// may mention it, and how many lines in each may do so. The counts are
+// deliberately exact in both directions: an extra mention fails as a possible
+// reader, and a missing one fails as either a moved export site or a broken
+// scanner. A one-directional list would report "no readers found" when the walk
+// reached nothing at all.
+func allowedProvenanceMentions() map[string]map[string]int {
+	return map[string]map[string]int{
+		"STRATA_REKOR_ENTRY": {
+			// :143 export line in /etc/profile.d/strata.sh, :198 line in
+			// /etc/strata/environment. Both writes.
+			"internal/overlay/overlay.go": 2,
+			// :372 sets it in the child process environment. A write.
+			"cmd/strata/run.go": 1,
+			// The route's documentation, which names this test.
+			"spec/lockfile_hash.go": 1,
+		},
+		"strata.lockfile.rekor_entry": {
+			// :407 sets the OCI label. A write.
+			"internal/export/oci.go": 1,
+		},
+	}
+}
+
+// envReadPattern matches the ways in-tree Go reads the process environment.
+// Built per call because this package declares no globals.
+func envReadPattern() *regexp.Regexp {
+	return regexp.MustCompile(`\b(os\.Getenv|os\.LookupEnv|os\.Environ|syscall\.Getenv|syscall\.Environ)\b`)
+}
+
+// provenanceMention is one line of one file that names an exported name.
+type provenanceMention struct {
+	Path string
+	Line int
+	Text string
+	// Read records that the same line also names an environment read.
+	Read bool
+}
+
+// scanMentions returns one entry per line of content that contains name.
+// Counting by line, not by occurrence, is what allowedProvenanceMentions
+// records; two occurrences on one line would count as one and fail the exact
+// count, which is the safe direction.
+func scanMentions(path, content, name string, readPattern *regexp.Regexp) []provenanceMention {
+	var out []provenanceMention
+	for i, line := range strings.Split(content, "\n") {
+		if !strings.Contains(line, name) {
+			continue
+		}
+		out = append(out, provenanceMention{
+			Path: path,
+			Line: i + 1,
+			Text: strings.TrimSpace(line),
+			Read: readPattern.MatchString(line),
+		})
+	}
+	return out
+}
+
+// scanShellExpansions returns the lines of content that expand name as a shell
+// variable, in either the bare or braced form.
+func scanShellExpansions(path, content, name string) []provenanceMention {
+	pattern := regexp.MustCompile(`\$\{?` + regexp.QuoteMeta(name) + `\b`)
+	var out []provenanceMention
+	for i, line := range strings.Split(content, "\n") {
+		if !pattern.MatchString(line) {
+			continue
+		}
+		out = append(out, provenanceMention{Path: path, Line: i + 1, Text: strings.TrimSpace(line), Read: true})
+	}
+	return out
+}
+
+// moduleRoot walks up from the test's working directory to the directory
+// holding go.mod, and confirms it is this module. Without the confirmation a
+// stray go.mod above the checkout would silently redirect the whole scan.
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		modPath := filepath.Join(dir, "go.mod")
+		if data, err := os.ReadFile(modPath); err == nil {
+			if !strings.Contains(string(data), "module github.com/scttfrdmn/strata\n") {
+				t.Fatalf("%s is not this module's go.mod; the scan would cover the wrong tree", modPath)
+			}
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("no go.mod found above the test working directory")
+		}
+		dir = parent
+	}
+}
+
+// collectFiles reads every file under root whose repo-relative path satisfies
+// want, keyed by that relative path.
+func collectFiles(t *testing.T, root string, want func(rel string) bool) map[string]string {
+	t.Helper()
+
+	out := make(map[string]string)
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "vendor", "node_modules", "bin":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !want(filepath.ToSlash(rel)) {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		out[filepath.ToSlash(rel)] = string(data)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+	return out
+}
+
+func isGoNonTest(rel string) bool {
+	return strings.HasSuffix(rel, ".go") && !strings.HasSuffix(rel, "_test.go")
+}
+
+func isShellScript(rel string) bool {
+	return strings.HasSuffix(rel, ".sh") || strings.HasSuffix(rel, ".bash")
+}
+
+func TestDeclaredProvenance_NoInTreeReader(t *testing.T) {
+	root := moduleRoot(t)
+	readPattern := envReadPattern()
+
+	goFiles := collectFiles(t, root, isGoNonTest)
+	shellFiles := collectFiles(t, root, isShellScript)
+
+	// Non-vacuity, before any result is read. A scan that reached no files
+	// reports the same clean zero as a scan that found no readers.
+	if len(goFiles) == 0 {
+		t.Fatalf("scanned 0 non-test .go files under %s; the walk found nothing, so a "+
+			"zero-readers result below would mean nothing", root)
+	}
+	if len(shellFiles) == 0 {
+		t.Fatalf("scanned 0 shell scripts under %s; the shell detector below would be "+
+			"reading an empty domain", root)
+	}
+	t.Logf("scanned %d non-test .go files and %d shell scripts under %s",
+		len(goFiles), len(shellFiles), root)
+
+	allowed := allowedProvenanceMentions()
+
+	for _, name := range declaredProvenanceNames() {
+		observed := make(map[string]int)
+
+		for _, files := range []map[string]string{goFiles, shellFiles} {
+			for rel, content := range files {
+				for _, m := range scanMentions(rel, content, name, readPattern) {
+					observed[rel]++
+					if m.Read {
+						t.Errorf("%s:%d reads the exported provenance name %q:\n"+
+							"    %s\n"+
+							"  The declared-provenance route in spec/lockfile_hash.go rests on "+
+							"nothing in-tree reading this value back. With a reader, the field is "+
+							"content and must be hashed into envHashInput (#120).",
+							m.Path, m.Line, name, m.Text)
+					}
+				}
+			}
+		}
+
+		for rel, content := range shellFiles {
+			for _, m := range scanShellExpansions(rel, content, name) {
+				t.Errorf("%s:%d expands $%s in a shell script:\n"+
+					"    %s\n"+
+					"  Same consequence as a Go read: the field becomes content (#120).",
+					m.Path, m.Line, name, m.Text)
+			}
+		}
+
+		want := allowed[name]
+		for rel, count := range observed {
+			switch wantCount, ok := want[rel]; {
+			case !ok:
+				t.Errorf("%s mentions %q on %d line(s) and is not in "+
+					"allowedProvenanceMentions.\n"+
+					"  Every mention of an exported provenance name is either a write site or a "+
+					"consumer. If it is a write, add it to the list with its purpose. If it "+
+					"reads the value, the declared-provenance route no longer applies and the "+
+					"field must move into envHashInput (#120).", rel, name, count)
+			case count != wantCount:
+				t.Errorf("%s mentions %q on %d line(s), expected %d.\n"+
+					"  A new line naming this value is a possible consumer. Classify it, then "+
+					"update the count.", rel, name, count, wantCount)
+			}
+		}
+		for rel, wantCount := range want {
+			if observed[rel] == 0 {
+				t.Errorf("expected %d mention(s) of %q in %s and found none.\n"+
+					"  Either the export site moved — update allowedProvenanceMentions — or "+
+					"this scan is broken, in which case every zero it reported above is "+
+					"meaningless.", wantCount, name, rel)
+			}
+		}
+	}
+}
+
+// TestDeclaredProvenanceDetectorsFire is the positive control for both
+// detectors. Without it, TestDeclaredProvenance_NoInTreeReader passing is
+// consistent with a scanner that cannot recognise a reader at all: a repository
+// with no readers and a broken matcher produce identical output.
+//
+// Each detector class gets its own case, and the last two cases carry two
+// offenders differing in kind, because a check that returns a collection can
+// pass a single-offender fixture by stopping at the first one.
+func TestDeclaredProvenanceDetectorsFire(t *testing.T) {
+	readPattern := envReadPattern()
+	const name = "STRATA_REKOR_ENTRY"
+
+	goCases := []struct {
+		label     string
+		content   string
+		wantLines int
+		wantReads int
+	}{
+		{
+			label:     "os.Getenv",
+			content:   "package p\n\nfunc f() string { return os.Getenv(\"STRATA_REKOR_ENTRY\") }\n",
+			wantLines: 1,
+			wantReads: 1,
+		},
+		{
+			label:     "os.LookupEnv",
+			content:   "package p\n\nfunc f() (string, bool) { return os.LookupEnv(\"STRATA_REKOR_ENTRY\") }\n",
+			wantLines: 1,
+			wantReads: 1,
+		},
+		{
+			label:     "syscall.Getenv",
+			content:   "package p\n\nfunc f() (string, bool) { return syscall.Getenv(\"STRATA_REKOR_ENTRY\") }\n",
+			wantLines: 1,
+			wantReads: 1,
+		},
+		{
+			label: "map index built from os.Environ — enumeration only",
+			// The mention line names no read function, so detector 2 stays
+			// silent and detector 1 is the only thing standing between this and
+			// a silent pass. That is the case this fixture exists to pin.
+			content:   "package p\n\nfunc f(env map[string]string) string {\n\treturn env[\"STRATA_REKOR_ENTRY\"]\n}\n",
+			wantLines: 1,
+			wantReads: 0,
+		},
+		{
+			label: "two offenders differing in kind",
+			content: "package p\n\nfunc f() string {\n" +
+				"\tif v := os.Getenv(\"STRATA_REKOR_ENTRY\"); v != \"\" {\n" +
+				"\t\treturn v\n\t}\n" +
+				"\treturn lookup[\"STRATA_REKOR_ENTRY\"]\n}\n",
+			wantLines: 2,
+			wantReads: 1,
+		},
+	}
+
+	for _, tc := range goCases {
+		t.Run("go/"+tc.label, func(t *testing.T) {
+			got := scanMentions("fixture.go", tc.content, name, readPattern)
+			if len(got) != tc.wantLines {
+				t.Fatalf("scanMentions found %d mention(s), want %d: %+v", len(got), tc.wantLines, got)
+			}
+			reads := 0
+			for _, m := range got {
+				if m.Read {
+					reads++
+				}
+			}
+			if reads != tc.wantReads {
+				t.Errorf("scanMentions flagged %d read(s), want %d: %+v", reads, tc.wantReads, got)
+			}
+		})
+	}
+
+	shellCases := []struct {
+		label     string
+		content   string
+		wantLines int
+	}{
+		{
+			label:     "braced expansion",
+			content:   "#!/bin/sh\necho \"${STRATA_REKOR_ENTRY}\"\n",
+			wantLines: 1,
+		},
+		{
+			label:     "bare expansion",
+			content:   "#!/bin/sh\ntest -n \"$STRATA_REKOR_ENTRY\" && exit 1\n",
+			wantLines: 1,
+		},
+		{
+			label:     "two offenders differing in kind",
+			content:   "#!/bin/sh\necho \"${STRATA_REKOR_ENTRY}\"\nif [ -n \"$STRATA_REKOR_ENTRY\" ]; then :; fi\n",
+			wantLines: 2,
+		},
+		{
+			label: "a write is not an expansion",
+			// The write form must not be reported, or every export site would
+			// fail the shell detector and the check would be 100% false
+			// positives on the population it runs against.
+			content:   "#!/bin/sh\nexport STRATA_REKOR_ENTRY=abc\n",
+			wantLines: 0,
+		},
+	}
+
+	for _, tc := range shellCases {
+		t.Run("shell/"+tc.label, func(t *testing.T) {
+			got := scanShellExpansions("fixture.sh", tc.content, name)
+			if len(got) != tc.wantLines {
+				t.Fatalf("scanShellExpansions found %d expansion(s), want %d: %+v",
+					len(got), tc.wantLines, got)
+			}
+		})
+	}
+}

--- a/spec/environment_id_scope_test.go
+++ b/spec/environment_id_scope_test.go
@@ -1,0 +1,880 @@
+package spec
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+// This file is the machine-checked form of the membership rule stated in
+// spec/lockfile_hash.go: a LockFile field is hashed into EnvironmentID unless it
+// takes one of four named routes out.
+//
+// It exists because the rule's previous form — a prose comment plus a field list
+// — drifted twice, and because the drift was invisible in both directions. Two
+// hashed fields had no consumer at all; ten fields the assembler reads were not
+// hashed. Neither is detectable by reading either list alone: the comment was
+// self-consistent, and every test in the tree passed. What makes a route
+// checkable is stating the field set and the expected behaviour together, so
+// that a new field has to be classified before the package compiles green.
+//
+// # What the three tests do
+//
+//  1. TestEnvironmentIDRoutes_CoverEveryField compares the route tables below
+//     against the struct definitions by reflection, in both directions. A field
+//     added to any table's struct fails until it is given a route; a route naming
+//     a field that no longer exists fails too, which is the direction a stale
+//     list rots in.
+//  2. TestEnvironmentIDRoutes_MatchBehaviour mutates each field on a frozen
+//     fixture and asserts the identity moved if and only if the table says the
+//     field is content. This is what makes the table a claim about the code
+//     rather than a description of itself.
+//  3. TestEnvironmentIDRoutes_ContentStructsHaveTables checks that the set of
+//     tables is closed under "reached through a content field", because (1) can
+//     only compare a struct that has a table. Two content fields had element
+//     types with no table at all until it was written.
+//
+// # The LayerManifest class route, and the hole in it
+//
+// LayerManifest has thirty-odd fields and enumerating a bespoke argument for
+// each would be thirty unverified claims. They share one: the manifest describes
+// a squashfs artifact whose bytes are pinned by SHA256, which is hashed. Each
+// field therefore either describes those bytes — and so cannot vary
+// independently of the digest without the manifest being false — or is consumed
+// at resolve time, before the lockfile exists, and so cannot change what an
+// existing lockfile assembles.
+//
+// The exceptions are the fields the assembler reads out of the lockfile's own
+// copy of the manifest while assembling, which are content and are hashed:
+// ID, Name, Version, InstallLayout, SHA256.
+//
+// The class argument rests on the manifest's copy inside the lockfile being
+// *correct*, and nothing enforces that: the lockfile's metadata sits outside the
+// signed envelope, so an attacker with registry write can edit Name, Version or
+// InstallLayout without breaking a signature. Hashing them makes the edit
+// visible in the identity; it does not make it refused. That gap is #146 and is
+// not closed here.
+
+// scopeFixture is a frozen lockfile with every field the route tables reach set
+// to a distinguishable non-zero value. Two calls return independent values —
+// no shared maps or slice backing arrays — so a test can mutate one and compare
+// against the other without a clone step that could alias.
+func scopeFixture() *LockFile {
+	return &LockFile{
+		ProfileName:   "genomics",
+		ProfileSHA256: "1111111111",
+		ResolvedAt:    time.Unix(1700000000, 0).UTC(),
+		StrataVersion: "v0.22.0",
+		RekorEntry:    "rekor-lockfile-1",
+		Bundle:        "bundle-lockfile-1",
+		Base: ResolvedBase{
+			DeclaredOS: "al2023",
+			AMIID:      "ami-0abc",
+			AMISHA256:  "2222222222",
+			Capabilities: BaseCapabilities{
+				Arch: "x86_64",
+			},
+		},
+		Layers: []ResolvedLayer{
+			{
+				LayerManifest: LayerManifest{
+					ID:              "python-3.11.9-x86_64",
+					Name:            "python",
+					Version:         "3.11.9",
+					Source:          "s3://strata-layers/python.sqfs",
+					SHA256:          "3333333333",
+					Size:            4096,
+					ContentManifest: map[string]string{"/bin/python3": "4444444444"},
+					RekorEntry:      "rekor-layer-python",
+					Bundle:          "bundle-layer-python",
+					SignedBy:        "strata-builder",
+					CosignVersion:   "v3.0.5",
+					Provides:        []Capability{{Name: "python", Version: "3.11"}},
+					Requires:        []Requirement{{Name: "glibc", MinVersion: "2.34"}},
+					Arch:            "x86_64",
+					ABI:             "linux-gnu-2.34",
+					BuiltAt:         time.Unix(1690000000, 0).UTC(),
+					UserSelectable:  true,
+					InstallLayout:   "versioned",
+					HasModulefile:   true,
+					RecipeSHA256:    "5555555555",
+					BuildEnvLockID:  "6666666666",
+					BootstrapBuild:  false,
+					CaptureSource:   "",
+					OriginalPrefix:  "",
+					Normalized:      false,
+				},
+				MountOrder:  1,
+				SatisfiedBy: "python@3.11",
+			},
+			{
+				LayerManifest: LayerManifest{
+					ID:            "samtools-1.21-x86_64",
+					Name:          "samtools",
+					Version:       "1.21",
+					Source:        "s3://strata-layers/samtools.sqfs",
+					SHA256:        "7777777777",
+					InstallLayout: "versioned",
+				},
+				MountOrder:  2,
+				SatisfiedBy: "samtools@1.21",
+			},
+		},
+		Env:      map[string]string{"OMP_NUM_THREADS": "8", "MPLBACKEND": "Agg"},
+		OnReady:  []string{"echo one", "echo two"},
+		Defaults: []SoftwareRef{{Name: "python", Version: "3.11.9"}, {Name: "samtools"}},
+		Packages: []ResolvedPackageSet{
+			{Manager: "pip", Packages: []ResolvedPackageEntry{
+				{Name: "numpy", Version: "2.1.0", SHA256: "8888888888"},
+				{Name: "scipy", Version: "1.14.0", SHA256: "9999999999"},
+			}},
+			{Manager: "conda", Env: "bio", Packages: []ResolvedPackageEntry{
+				{Name: "bwa", Version: "0.7.18"},
+			}},
+		},
+		RequiresHost: []HostRequirement{{Key: "nvidia_driver", Value: ">=550"}},
+	}
+}
+
+// fieldRoute is one field's classification. hashed=true means the field is
+// content: the identity must move when it moves. hashed=false names the route it
+// takes out, and the identity must not move.
+type fieldRoute struct {
+	// name is the Go field name, checked against the struct by reflection.
+	name string
+	// hashed is the expected behaviour, asserted by mutation.
+	hashed bool
+	// route is content, one of the four routes out named in
+	// spec/lockfile_hash.go (inert, digest-mediated, abort-only,
+	// declared-provenance), or one of three labels that are not additional
+	// routes: order-expressing is rule 2 — the ordering is hashed and only the
+	// literal value is dropped; manifest-metadata is the digest-mediated-or-inert
+	// argument applied to LayerManifest as a class; nested defers to another
+	// table. docs/environment-identity.md states the same reconciliation, because
+	// a route set stated in three places is a route set that drifts in three
+	// places.
+	route string
+	// why is the evidence. For an unhashed field it is what makes the route
+	// hold; a route without one is an assertion, which is what this file
+	// replaced.
+	why string
+	// mutate overrides the generic reflection mutator. Needed where a generic
+	// mutation would change the answer for the wrong reason — appending a
+	// zero-valued layer, for instance, makes the lockfile unfrozen, and an
+	// unfrozen lockfile has no identity at all.
+	mutate func(l *LockFile)
+	// nested marks a struct field enumerated by its own table.
+	nested bool
+}
+
+// lockFileRoutes classifies every field of LockFile.
+func lockFileRoutes() []fieldRoute {
+	return []fieldRoute{
+		{name: "ProfileName", hashed: true, route: "content",
+			why: "exported as $STRATA_PROFILE into /etc/profile.d/strata.sh, " +
+				"/etc/strata/environment and the child process environment (#120)"},
+		{name: "ProfileSHA256", hashed: false, route: "inert",
+			why: "no consumer outside spec — grep '\\.ProfileSHA256' finds only " +
+				"ProvenanceRecord and the resolver that sets it"},
+		{name: "ResolvedAt", hashed: false, route: "inert",
+			why: "a timestamp reported in provenance; no assembler reads it"},
+		{name: "StrataVersion", hashed: false, route: "inert",
+			why: "records which resolver produced the lockfile; nothing at assembly " +
+				"time branches on it"},
+		{name: "RekorEntry", hashed: false, route: "declared-provenance",
+			why: "exported as STRATA_REKOR_ENTRY, which no in-tree code reads back — " +
+				"enforced by TestDeclaredProvenance_NoInTreeReader, not asserted here"},
+		{name: "Bundle", hashed: false, route: "inert",
+			why: "the lockfile's own cosign bundle path; no assembler reads it"},
+		{name: "Base", hashed: false, route: "nested", nested: true,
+			why: "enumerated by resolvedBaseRoutes"},
+		{name: "Layers", hashed: true, route: "content",
+			why: "the layer set and its mount sequence are the environment",
+			mutate: func(l *LockFile) {
+				// A frozen layer, so the mutation tests membership rather than
+				// IsFrozen: appending a layer with an empty SHA256 makes the
+				// whole lockfile unfrozen and the identity empty, which would
+				// register as "changed" without saying anything about Layers.
+				l.Layers = append(l.Layers, ResolvedLayer{
+					LayerManifest: LayerManifest{
+						ID: "r-4.4.3-x86_64", Name: "R", Version: "4.4.3",
+						SHA256: "aaaaaaaaaa", InstallLayout: "versioned",
+					},
+					MountOrder: 3,
+				})
+			}},
+		{name: "Env", hashed: true, route: "content",
+			why: "written into /etc/profile.d/strata.sh and /etc/strata/environment " +
+				"(internal/overlay/overlay.go:145-150, :200-202)"},
+		{name: "OnReady", hashed: true, route: "content",
+			why: "declared as commands to run after assembly. Hashed although no " +
+				"in-tree executor exists (#69): the field is an instruction, and rule 3 " +
+				"binds the identity to instructions rather than to their outcomes"},
+		{name: "Defaults", hashed: true, route: "content",
+			why: "internal/overlay/overlay.go:171-176 writes 'module load <name>/<version>' " +
+				"lines into /etc/profile.d/strata-defaults.sh (#118)"},
+		{name: "Packages", hashed: true, route: "content",
+			why: "internal/agent/package_installer.go:37 installs each set, :99 and :113 " +
+				"run one pip/conda command per entry"},
+		{name: "MutableLayer", hashed: false, route: "inert",
+			why: "latent: grep 'MutableLayer' outside spec and tests finds no consumer, " +
+				"so the persistent-upper workflow it declares is not implemented. A " +
+				"lockfile carrying one cannot be published (HasMutableLayer gates it), " +
+				"and if an agent ever mounts the upper this route fails and the field " +
+				"becomes content"},
+		{name: "RequiresHost", hashed: false, route: "inert",
+			why: "\"Advisory only in v0.21.0\" by specification — spec/lockfile.go:57-60"},
+	}
+}
+
+// resolvedBaseRoutes classifies every field of ResolvedBase.
+func resolvedBaseRoutes() []fieldRoute {
+	return []fieldRoute{
+		{name: "DeclaredOS", hashed: false, route: "inert",
+			why: "the profile's OS string, used at resolve time to pick the AMI; " +
+				"no assembler reads it",
+			mutate: func(l *LockFile) { l.Base.DeclaredOS += "-probe" }},
+		{name: "AMIID", hashed: false, route: "digest-mediated — unenforced",
+			why: "the base image is content, and AMISHA256 is the digest of it. AMIID is " +
+				"the locator. Hashing the locator instead would give the same filesystem " +
+				"copied to a second region two identities. The mediation this route names " +
+				"is not implemented: nothing compares the booted AMI against AMISHA256, " +
+				"and AMISHA256 is never populated by shipped code (#64). This is the one " +
+				"row in these tables whose route is a promise rather than a check, and it " +
+				"is stated here so it is visible rather than absent",
+			mutate: func(l *LockFile) { l.Base.AMIID += "-probe" }},
+		{name: "AMISHA256", hashed: true, route: "content",
+			why:    "the digest of the base filesystem every layer is stacked on",
+			mutate: func(l *LockFile) { l.Base.AMISHA256 += "aa" }},
+		{name: "Capabilities", hashed: false, route: "inert",
+			why: "the probe record the resolver validated layer requirements against; " +
+				"consumed at resolve time, before the lockfile exists",
+			mutate: func(l *LockFile) { l.Base.Capabilities.Arch += "-probe" }},
+	}
+}
+
+// resolvedLayerRoutes classifies ResolvedLayer's own fields — those not part of
+// the embedded LayerManifest.
+func resolvedLayerRoutes() []fieldRoute {
+	return []fieldRoute{
+		{name: "LayerManifest", hashed: false, route: "nested", nested: true,
+			why: "enumerated by layerManifestRoutes"},
+		{name: "MountOrder", hashed: false, route: "order-expressing",
+			why: "the ordering it expresses is hashed — computeEnvironmentID sorts the " +
+				"layers by it before hashing — while the literal value is not. Mount " +
+				"orders 1,2 and 10,20 mount the same layers in the same sequence, so " +
+				"they must not differ in identity. Asserted directly by " +
+				"TestEnvironmentID_MountOrderValuesAreNotHashed",
+			mutate: func(l *LockFile) {
+				// Scale rather than permute: 1,2 becomes 10,20, which preserves
+				// the sequence. Adding a constant would too, but scaling also
+				// rules out an implementation that hashed differences.
+				for i := range l.Layers {
+					l.Layers[i].MountOrder *= 10
+				}
+			}},
+		{name: "SatisfiedBy", hashed: false, route: "inert",
+			why:    "records which profile ref this layer satisfied; read by no assembler",
+			mutate: func(l *LockFile) { l.Layers[0].SatisfiedBy += "-probe" }},
+		{name: "FromFormation", hashed: false, route: "inert",
+			why:    "records the formation a layer was expanded from; read by no assembler",
+			mutate: func(l *LockFile) { l.Layers[0].FromFormation += "-probe" }},
+	}
+}
+
+// layerManifestRoutes classifies every field of LayerManifest. All but five take
+// the manifest-metadata class route argued for in this file's header comment;
+// the five the assembler reads out of the lockfile's copy are content.
+func layerManifestRoutes() []fieldRoute {
+	const class = "manifest-metadata"
+	const classWhy = "describes the squashfs artifact pinned by SHA256, or is consumed " +
+		"at resolve time before the lockfile exists — see this file's header for the " +
+		"class argument and the hole in it (#146)"
+
+	content := func(name, why string) fieldRoute {
+		return fieldRoute{name: name, hashed: true, route: "content", why: why,
+			mutate: layerFieldMutator(name)}
+	}
+	metadata := func(name string) fieldRoute {
+		return fieldRoute{name: name, hashed: false, route: class, why: classWhy,
+			mutate: layerFieldMutator(name)}
+	}
+
+	return []fieldRoute{
+		content("ID", "internal/overlay/mount_linux.go:147 makes the layer's mount point "+
+			"/strata/layers/<id>"),
+		content("Name", "internal/overlay/overlay.go:112 builds $STRATA_ENV/<name>/<version>/bin "+
+			"into PATH (#122)"),
+		content("Version", "same PATH construction as Name (#122)"),
+		content("SHA256", "the digest of the mounted filesystem — the layer's content"),
+		content("InstallLayout", "decides whether the layer contributes a versioned PATH "+
+			"entry at all: every consumer compares it against \"flat\" "+
+			"(internal/overlay/overlay.go:109,116; cmd/strata/run.go:336,342; "+
+			"internal/fold/eject.go:220,225; internal/export/oci.go:371,378)"),
+
+		{name: "Source", hashed: false, route: "digest-mediated",
+			why: "the fetch locator. What it returns is verified against SHA256 before " +
+				"use — cmd/strata/run.go:436, :481; internal/agent/agent.go:244 — so a " +
+				"different Source either yields the same bytes or aborts",
+			mutate: layerFieldMutator("Source")},
+		{name: "RekorEntry", hashed: false, route: "abort-only",
+			why: "internal/agent/agent.go:367 verifies the fetched layer against it and " +
+				"refuses on mismatch; it can stop assembly, never change it",
+			mutate: layerFieldMutator("RekorEntry")},
+		{name: "Bundle", hashed: false, route: "abort-only",
+			why:    "same verification path as RekorEntry",
+			mutate: layerFieldMutator("Bundle")},
+
+		metadata("Size"),
+		metadata("ContentManifest"),
+		metadata("SignedBy"),
+		metadata("CosignVersion"),
+		metadata("Provides"),
+		metadata("Requires"),
+		metadata("Arch"),
+		metadata("ABI"),
+		metadata("BuiltAt"),
+		metadata("UserSelectable"),
+		metadata("HasModulefile"),
+		metadata("RecipeSHA256"),
+		metadata("BuildEnvLockID"),
+		metadata("BuiltWith"),
+		metadata("BootstrapBuild"),
+		metadata("BootstrapCompiler"),
+		metadata("CaptureSource"),
+		metadata("FoldedFrom"),
+		metadata("OriginalPrefix"),
+		metadata("Normalized"),
+	}
+}
+
+// packageSetRoutes classifies every field of ResolvedPackageSet. The struct has
+// a table because LockFile.Packages is content: a content field's own fields are
+// unclassified until they are enumerated, which is the hole
+// TestEnvironmentIDRoutes_ContentStructsHaveTables closes.
+func packageSetRoutes() []fieldRoute {
+	return []fieldRoute{
+		{name: "Manager", hashed: true, route: "content",
+			why: "internal/agent/package_installer.go:39-45 switches on it to pick pip, " +
+				"conda or CRAN — the same package names installed by a different manager " +
+				"are different software",
+			mutate: packageSetFieldMutator("Manager")},
+		{name: "Env", hashed: true, route: "content",
+			why: "internal/agent/package_installer.go:109-111 passes it as conda's -n, so " +
+				"it decides which environment the packages land in",
+			mutate: packageSetFieldMutator("Env")},
+		{name: "Packages", hashed: true, route: "content",
+			why:    "the entries installed; enumerated by packageEntryRoutes",
+			mutate: packageSetFieldMutator("Packages")},
+	}
+}
+
+// packageEntryRoutes classifies every field of ResolvedPackageEntry.
+func packageEntryRoutes() []fieldRoute {
+	return []fieldRoute{
+		{name: "Name", hashed: true, route: "content",
+			why:    "internal/agent/package_installer.go:100 builds the pip argument from it",
+			mutate: packageEntryFieldMutator("Name")},
+		{name: "Version", hashed: true, route: "content",
+			why:    "pinned into the same argument (package_installer.go:100, :114-117)",
+			mutate: packageEntryFieldMutator("Version")},
+		{name: "SHA256", hashed: true, route: "content",
+			why: "recorded but not checked at install time (#98), so it is hashed as an " +
+				"instruction under rule 3 rather than as a guarantee — the same shape as " +
+				"OnReady. It is not inert: it is written into the lockfile as part of the " +
+				"request, and if the installer ever enforces it the field becomes a " +
+				"guarantee without this row needing to change",
+			mutate: packageEntryFieldMutator("SHA256")},
+	}
+}
+
+// softwareRefRoutes classifies every field of SoftwareRef as it appears in
+// LockFile.Defaults. The same struct also appears in a Profile, where Formation
+// is read; a route here is a claim about the lockfile's copy only.
+func softwareRefRoutes() []fieldRoute {
+	return []fieldRoute{
+		{name: "Name", hashed: true, route: "content",
+			why: "internal/overlay/overlay.go:171-176 writes 'module load <name>/<version>' " +
+				"from it (#118)",
+			mutate: softwareRefFieldMutator("Name")},
+		{name: "Version", hashed: true, route: "content",
+			why:    "the other half of the same module load line",
+			mutate: softwareRefFieldMutator("Version")},
+		{name: "Formation", hashed: false, route: "inert",
+			why: "every reader of this field takes it from a Profile at resolve time, " +
+				"before a lockfile exists — internal/resolver/stages.go:52 and " +
+				"spec/profile.go:156,163,267. Nothing reads it from LockFile.Defaults: " +
+				"overlay.go:171-176 is the only lockfile consumer and reads Name and " +
+				"Version. A lockfile default that is a formation ref therefore has an " +
+				"empty Name, and overlay writes a bare 'module load ' line — a defect in " +
+				"that writer, not evidence that this field is content",
+			mutate: softwareRefFieldMutator("Formation")},
+	}
+}
+
+// layerFieldMutator returns a mutator that applies the generic reflection
+// mutation to one field of the first layer's manifest.
+func layerFieldMutator(field string) func(l *LockFile) {
+	return func(l *LockFile) {
+		mutateValue(reflect.ValueOf(&l.Layers[0].LayerManifest).Elem().FieldByName(field))
+	}
+}
+
+// packageSetFieldMutator mutates one field of the first package set.
+func packageSetFieldMutator(field string) func(l *LockFile) {
+	return func(l *LockFile) {
+		mutateValue(reflect.ValueOf(&l.Packages[0]).Elem().FieldByName(field))
+	}
+}
+
+// packageEntryFieldMutator mutates one field of the first entry of the first
+// package set.
+func packageEntryFieldMutator(field string) func(l *LockFile) {
+	return func(l *LockFile) {
+		mutateValue(reflect.ValueOf(&l.Packages[0].Packages[0]).Elem().FieldByName(field))
+	}
+}
+
+// softwareRefFieldMutator mutates one field of the first lockfile default.
+func softwareRefFieldMutator(field string) func(l *LockFile) {
+	return func(l *LockFile) {
+		mutateValue(reflect.ValueOf(&l.Defaults[0]).Elem().FieldByName(field))
+	}
+}
+
+// mutateValue replaces v with a value that differs from it, for the kinds the
+// spec structs use. It returns false when it has no rule for the kind — the
+// caller fails rather than skipping, because a field nothing can mutate is a
+// field nothing checks.
+func mutateValue(v reflect.Value) bool {
+	if !v.IsValid() || !v.CanSet() {
+		return false
+	}
+	switch v.Kind() {
+	case reflect.String:
+		v.SetString(v.String() + "-probe")
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v.SetInt(v.Int() + 1)
+	case reflect.Bool:
+		v.SetBool(!v.Bool())
+	case reflect.Slice:
+		v.Set(reflect.Append(v, reflect.Zero(v.Type().Elem())))
+	case reflect.Map:
+		if v.Type().Key().Kind() != reflect.String {
+			return false
+		}
+		if v.IsNil() {
+			v.Set(reflect.MakeMap(v.Type()))
+		}
+		v.SetMapIndex(reflect.ValueOf("strata-probe"), reflect.Zero(v.Type().Elem()))
+	case reflect.Pointer:
+		if v.IsNil() {
+			v.Set(reflect.New(v.Type().Elem()))
+		} else {
+			v.Set(reflect.Zero(v.Type()))
+		}
+	case reflect.Struct:
+		if t, ok := v.Interface().(time.Time); ok {
+			v.Set(reflect.ValueOf(t.Add(time.Hour)))
+			return true
+		}
+		return false
+	default:
+		return false
+	}
+	return true
+}
+
+// routeTable pairs a route list with the struct it classifies.
+func routeTables() []struct {
+	label  string
+	typ    reflect.Type
+	routes []fieldRoute
+} {
+	return []struct {
+		label  string
+		typ    reflect.Type
+		routes []fieldRoute
+	}{
+		{"LockFile", reflect.TypeOf(LockFile{}), lockFileRoutes()},
+		{"ResolvedBase", reflect.TypeOf(ResolvedBase{}), resolvedBaseRoutes()},
+		{"ResolvedLayer", reflect.TypeOf(ResolvedLayer{}), resolvedLayerRoutes()},
+		{"LayerManifest", reflect.TypeOf(LayerManifest{}), layerManifestRoutes()},
+		{"ResolvedPackageSet", reflect.TypeOf(ResolvedPackageSet{}), packageSetRoutes()},
+		{"ResolvedPackageEntry", reflect.TypeOf(ResolvedPackageEntry{}), packageEntryRoutes()},
+		{"SoftwareRef", reflect.TypeOf(SoftwareRef{}), softwareRefRoutes()},
+	}
+}
+
+// structTypeOf unwraps slices, arrays, pointers and map values down to a struct
+// type, and reports whether it found one. time.Time is excluded: it is a struct
+// whose fields are unexported implementation detail, not a spec type whose
+// membership anyone can classify.
+func structTypeOf(t reflect.Type) (reflect.Type, bool) {
+	for {
+		switch t.Kind() {
+		case reflect.Slice, reflect.Array, reflect.Pointer, reflect.Map:
+			t = t.Elem()
+		case reflect.Struct:
+			if t == reflect.TypeOf(time.Time{}) {
+				return nil, false
+			}
+			return t, true
+		default:
+			return nil, false
+		}
+	}
+}
+
+// TestEnvironmentIDRoutes_ContentStructsHaveTables checks the tables reach as far
+// as the identity does.
+//
+// TestEnvironmentIDRoutes_CoverEveryField compares each table against its own
+// struct, so it says nothing about a struct that has no table at all. That is not
+// a hypothetical: LockFile.Packages and LockFile.Defaults were classified content
+// and their element types went unenumerated, so a field added to
+// ResolvedPackageEntry or SoftwareRef would have been dropped from the identity
+// with every test in this file still green.
+//
+// The rule is: a struct type needs a table when it is reached through a field the
+// tables call content, or through a field explicitly marked nested. A field
+// classified as taking a route out needs no table, because the route covers the
+// whole subtree beneath it — that is what makes "inert" a claim worth checking
+// rather than a claim about one field.
+func TestEnvironmentIDRoutes_ContentStructsHaveTables(t *testing.T) {
+	tables := routeTables()
+
+	covered := make(map[reflect.Type]string, len(tables))
+	for _, table := range tables {
+		covered[table.typ] = table.label
+	}
+
+	required := 0
+	for _, table := range tables {
+		for _, r := range table.routes {
+			field, ok := table.typ.FieldByName(r.name)
+			if !ok {
+				// CoverEveryField reports this; nothing to unwrap here.
+				continue
+			}
+			if !r.hashed && !r.nested {
+				continue
+			}
+			typ, isStruct := structTypeOf(field.Type)
+			if !isStruct {
+				continue
+			}
+			required++
+			if _, ok := covered[typ]; !ok {
+				t.Errorf("%s.%s is %s and reaches %s, which has no route table.\n"+
+					"  Add one and register it in routeTables. Until then every field of %s "+
+					"is unclassified, and a new one joins or leaves the identity with no test "+
+					"noticing.",
+					table.label, r.name,
+					map[bool]string{true: "content", false: "marked nested"}[r.hashed],
+					typ.Name(), typ.Name())
+			}
+		}
+	}
+
+	// Non-vacuity: if no row reached a struct at all, the loop above proved
+	// nothing and would keep passing after the unwrap broke.
+	if required == 0 {
+		t.Fatal("no content or nested row reached a struct type; structTypeOf is not " +
+			"unwrapping, so this test cannot fail")
+	}
+	t.Logf("%d content/nested field(s) reach a struct type; %d table(s) registered",
+		required, len(tables))
+}
+
+func TestEnvironmentIDRoutes_CoverEveryField(t *testing.T) {
+	for _, table := range routeTables() {
+		t.Run(table.label, func(t *testing.T) {
+			if table.typ.NumField() == 0 {
+				t.Fatalf("%s has no fields; reflection found nothing to compare against",
+					table.label)
+			}
+
+			declared := make(map[string]bool, table.typ.NumField())
+			for i := 0; i < table.typ.NumField(); i++ {
+				declared[table.typ.Field(i).Name] = true
+			}
+
+			classified := make(map[string]bool, len(table.routes))
+			for _, r := range table.routes {
+				if classified[r.name] {
+					t.Errorf("%s.%s is classified twice", table.label, r.name)
+				}
+				classified[r.name] = true
+				if r.route == "" || r.why == "" {
+					t.Errorf("%s.%s has an empty route or reason; a route without "+
+						"evidence is the assertion this table replaced", table.label, r.name)
+				}
+				if !declared[r.name] {
+					t.Errorf("%s.%s is classified here but no longer exists on the struct.\n"+
+						"  A renamed or deleted field leaves a route that reads as coverage "+
+						"and checks nothing.", table.label, r.name)
+				}
+			}
+
+			for name := range declared {
+				if !classified[name] {
+					t.Errorf("%s.%s has no route.\n"+
+						"  Every field is hashed into EnvironmentID unless it takes one of the "+
+						"named routes out (spec/lockfile_hash.go). Add it to the table with the "+
+						"evidence for its route — an unclassified field is how the previous "+
+						"field list drifted.", table.label, name)
+				}
+			}
+		})
+	}
+}
+
+func TestEnvironmentIDRoutes_MatchBehaviour(t *testing.T) {
+	baseline := scopeFixture().EnvironmentID()
+	if baseline == "" {
+		t.Fatal("the fixture is not frozen, so every comparison below would be \"\" == \"\"")
+	}
+
+	for _, table := range routeTables() {
+		for _, r := range table.routes {
+			if r.nested {
+				continue
+			}
+			t.Run(table.label+"/"+r.name, func(t *testing.T) {
+				before := scopeFixture()
+				mutated := scopeFixture()
+
+				if r.mutate != nil {
+					r.mutate(mutated)
+				} else if !mutateValue(reflect.ValueOf(mutated).Elem().FieldByName(r.name)) {
+					t.Fatalf("no generic mutator for %s.%s (kind %s); give the route an "+
+						"explicit mutate func — a field that cannot be varied is a field "+
+						"this test does not check",
+						table.label, r.name, reflect.ValueOf(mutated).Elem().FieldByName(r.name).Kind())
+				}
+
+				// Non-vacuity: an identical pair compares equal, which reads as
+				// "the field is not hashed" for every unhashed row in the table.
+				if reflect.DeepEqual(before, mutated) {
+					t.Fatalf("the mutation for %s.%s left the lockfile unchanged, so this "+
+						"row asserts nothing", table.label, r.name)
+				}
+
+				got := mutated.EnvironmentID()
+				if got == "" {
+					t.Fatalf("the mutation for %s.%s made the lockfile unfrozen; the empty "+
+						"identity is not a value and this row would pass for the wrong reason",
+						table.label, r.name)
+				}
+
+				switch changed := got != baseline; {
+				case r.hashed && !changed:
+					t.Errorf("%s.%s is classified content and the identity did not move.\n"+
+						"  why: %s\n"+
+						"  Either the field is missing from envHashInput, or the reason above "+
+						"is wrong. Both are defects; the first is the one that has happened "+
+						"before.", table.label, r.name, r.why)
+				case !r.hashed && changed:
+					t.Errorf("%s.%s takes the %q route and the identity moved anyway.\n"+
+						"  route holds because: %s\n"+
+						"  A field outside the identity that changes it is a spurious "+
+						"distinction: two lockfiles that assemble the same environment now "+
+						"have different identities (R7).", table.label, r.name, r.route, r.why)
+				}
+			})
+		}
+	}
+}
+
+// TestEnvironmentID_MountOrderValuesAreNotHashed states the order-expressing
+// route directly rather than through the table, because the property is about
+// two mount orders being equivalent rather than about one field's presence.
+func TestEnvironmentID_MountOrderValuesAreNotHashed(t *testing.T) {
+	dense := scopeFixture()
+	sparse := scopeFixture()
+	for i := range sparse.Layers {
+		sparse.Layers[i].MountOrder = (i + 1) * 100
+	}
+
+	if got, want := sparse.EnvironmentID(), dense.EnvironmentID(); got != want {
+		t.Errorf("mount orders 1,2 and 100,200 gave different identities: %s != %s\n"+
+			"  Both mount the same layers in the same sequence, so they assemble the same "+
+			"environment. Hashing the literal MountOrder manufactures a distinction (R7).",
+			got, want)
+	}
+}
+
+// TestEnvironmentID_LayerSequenceIsContent is the other half: the sequence the
+// sort produces is content even though the numbers are not.
+func TestEnvironmentID_LayerSequenceIsContent(t *testing.T) {
+	forward := scopeFixture()
+	reversed := scopeFixture()
+	reversed.Layers[0].MountOrder, reversed.Layers[1].MountOrder =
+		reversed.Layers[1].MountOrder, reversed.Layers[0].MountOrder
+
+	if forward.EnvironmentID() == reversed.EnvironmentID() {
+		t.Error("swapping two layers' mount orders left the identity unchanged.\n" +
+			"  The stack order decides which layer's files win in the merged view and " +
+			"which version lands first on PATH, so the sequence is content.")
+	}
+}
+
+// TestEnvironmentID_TiedMountOrderKeepsLockfileOrder pins the reason
+// computeEnvironmentID and internal/overlay/mount_linux.go both use a *stable*
+// sort. Under a tied MountOrder the mounter's tie-break is the order the layers
+// appear in the lockfile, so that order is content; an unstable sort would leave
+// the identity resting on sort.Slice's internals, where the two could disagree.
+//
+// Which layer *should* win under a tie is underdetermined by the specification —
+// that is #95, and it is a validation question rather than something this
+// function can fix. This test asserts only that the identity follows the same
+// tie-break the mounter uses.
+func TestEnvironmentID_TiedMountOrderKeepsLockfileOrder(t *testing.T) {
+	tied := func() *LockFile {
+		l := scopeFixture()
+		for i := range l.Layers {
+			l.Layers[i].MountOrder = 1
+		}
+		return l
+	}
+
+	asWritten := tied()
+	swapped := tied()
+	swapped.Layers[0], swapped.Layers[1] = swapped.Layers[1], swapped.Layers[0]
+
+	if asWritten.EnvironmentID() == swapped.EnvironmentID() {
+		t.Error("with tied mount orders, swapping the two layers in the lockfile left " +
+			"the identity unchanged.\n" +
+			"  internal/overlay/mount_linux.go:140 breaks the tie by slice order, so the " +
+			"two lockfiles mount a different stack and must not share an identity.")
+	}
+
+	// Repeat to catch the failure mode a single comparison cannot see: an
+	// unstable sort can return either order for the same input, so one equal
+	// comparison is consistent with a stable sort and one unequal comparison is
+	// consistent with an unstable one that happened to reorder.
+	first := asWritten.EnvironmentID()
+	for i := 0; i < 32; i++ {
+		if got := tied().EnvironmentID(); got != first {
+			t.Fatalf("the identity of a lockfile with tied mount orders is not stable: "+
+				"iteration %d gave %s, first call gave %s.\n"+
+				"  computeEnvironmentID must use a stable sort.", i, got, first)
+		}
+	}
+}
+
+// TestEnvironmentID_EmptyInstallLayoutEqualsVersioned pins the canonicalisation.
+// spec/layer.go declares "versioned" as the default and the empty string means
+// exactly that, so two lockfiles differing only in whether the key was written
+// out assemble the same environment.
+func TestEnvironmentID_EmptyInstallLayoutEqualsVersioned(t *testing.T) {
+	omitted := scopeFixture()
+	written := scopeFixture()
+	for i := range omitted.Layers {
+		omitted.Layers[i].InstallLayout = ""
+		written.Layers[i].InstallLayout = "versioned"
+	}
+
+	if got, want := omitted.EnvironmentID(), written.EnvironmentID(); got != want {
+		t.Errorf("an omitted install_layout and an explicit \"versioned\" gave different "+
+			"identities: %s != %s\n"+
+			"  Every consumer compares this field against \"flat\", so the two assemble "+
+			"the same environment (R7).", got, want)
+	}
+}
+
+// TestEnvironmentID_NilAndEmptyInnerPackagesAgree is #117, fixed by the
+// omitempty on packageSetHashInput.Packages. A package set with no entries
+// installs nothing whether the slice is nil or empty.
+//
+// It replaces the control that was supposed to detect this fix and could not:
+// TestR7Exclusion_NilVersusEmptyInnerPackages mutated the whole Packages field
+// rather than varying nil against empty, so it asserted the identity changes
+// when two entries are replaced by none — true before and after the fix, and
+// silent about either.
+func TestEnvironmentID_NilAndEmptyInnerPackagesAgree(t *testing.T) {
+	withNil := scopeFixture()
+	withEmpty := scopeFixture()
+
+	// An entry-free set, which is the only case the distinction can arise in:
+	// dropping entries from a set that has them changes what is installed.
+	withNil.Packages = append(withNil.Packages,
+		ResolvedPackageSet{Manager: "cran", Packages: nil})
+	withEmpty.Packages = append(withEmpty.Packages,
+		ResolvedPackageSet{Manager: "cran", Packages: []ResolvedPackageEntry{}})
+
+	if got, want := withNil.EnvironmentID(), withEmpty.EnvironmentID(); got != want {
+		t.Errorf("a package set with nil entries and one with empty entries gave "+
+			"different identities: %s != %s\n"+
+			"  Both install nothing (#117).", got, want)
+	}
+
+	// And the distinction that must survive: a set with entries is not the same
+	// as a set without them. Without this, the assertion above is satisfied by a
+	// hash that ignores package entries entirely.
+	populated := scopeFixture()
+	populated.Packages = append(populated.Packages,
+		ResolvedPackageSet{Manager: "cran", Packages: []ResolvedPackageEntry{
+			{Name: "ggplot2", Version: "3.5.1"},
+		}})
+	if populated.EnvironmentID() == withEmpty.EnvironmentID() {
+		t.Error("a package set with an entry and one with no entries share an identity; " +
+			"the entries are not reaching the hash at all")
+	}
+}
+
+// TestEnvironmentID_PackageOrderIsContent records why neither dimension of
+// Packages is sorted before hashing. internal/agent/package_installer.go:37
+// iterates the sets and :99, :113 run one pip/conda command per entry, so a
+// later entry can change what an earlier one installed — pip resolves each
+// command against the environment the previous one left behind.
+//
+// #95 prescribes sorting both dimensions to make the identity
+// order-insensitive. That prescription is refuted by the consumer above: it
+// would give two different install sequences one identity. The refutation is
+// recorded on #95; this test pins the behaviour the refutation implies so that
+// the fix cannot be applied without the assertion failing.
+func TestEnvironmentID_PackageOrderIsContent(t *testing.T) {
+	asWritten := scopeFixture()
+
+	setsSwapped := scopeFixture()
+	setsSwapped.Packages[0], setsSwapped.Packages[1] =
+		setsSwapped.Packages[1], setsSwapped.Packages[0]
+	if asWritten.EnvironmentID() == setsSwapped.EnvironmentID() {
+		t.Error("swapping two package sets left the identity unchanged; the sets are " +
+			"installed in order, so the two lockfiles can produce different environments")
+	}
+
+	entriesSwapped := scopeFixture()
+	e := entriesSwapped.Packages[0].Packages
+	e[0], e[1] = e[1], e[0]
+	if asWritten.EnvironmentID() == entriesSwapped.EnvironmentID() {
+		t.Error("swapping two entries within a package set left the identity unchanged; " +
+			"one pip command runs per entry, in order")
+	}
+}
+
+// TestEnvironmentID_UnfrozenHasNoIdentity is rule 4 of the decision: the
+// undefined case is not a value. It is stated here because every other test in
+// this file compares two identities, and a comparison of two empty strings
+// succeeds without exercising anything.
+func TestEnvironmentID_UnfrozenHasNoIdentity(t *testing.T) {
+	unfrozen := scopeFixture()
+	unfrozen.Layers[0].SHA256 = ""
+
+	if unfrozen.IsFrozen() {
+		t.Fatal("clearing a layer digest left the lockfile frozen; the fixture or " +
+			"IsFrozen has changed and this test no longer reaches its subject")
+	}
+	if got := unfrozen.EnvironmentID(); got != "" {
+		t.Errorf("an unfrozen lockfile returned an identity %q; only frozen lockfiles "+
+			"have one", got)
+	}
+
+	noBase := scopeFixture()
+	noBase.Base.AMISHA256 = ""
+	if got := noBase.EnvironmentID(); got != "" {
+		t.Errorf("a lockfile with no base digest returned an identity %q", got)
+	}
+}

--- a/spec/lockfile.go
+++ b/spec/lockfile.go
@@ -130,15 +130,29 @@ func (l *LockFile) HasMutableLayer() bool {
 	return l.MutableLayer != nil
 }
 
-// EnvironmentID returns a stable identifier for this environment.
-// It is the SHA256 of the canonical content: base AMI SHA256, layer SHA256s
-// in mount order, env vars, and on-ready commands. Fields that are populated
-// after resolution (RekorEntry, Bundle, ResolvedAt, StrataVersion) are
-// excluded so that signing an already-resolved lockfile does not change its ID.
+// EnvironmentID returns a stable identifier for this environment. It is the
+// SHA256 of a canonical encoding of the lockfile's content; envHashInput in
+// lockfile_hash.go is the definition of what that covers, and the rule for
+// what may sit outside it is stated there. Do not maintain a second copy of
+// the field list here — the one that used to be here drifted twice.
 //
-// Two lockfiles with the same EnvironmentID describe identical environments.
+// What the identifier commits to:
+//
+//	Two lockfiles with the same EnvironmentID were assembled from identical
+//	instructions. Where those instructions are deterministic — the base image,
+//	the layer set and its mount sequence, the exported environment,
+//	digest-pinned packages — identical instructions produce identical content.
+//	Where they are not — on_ready commands, packages without a digest, a
+//	mutable upper — the identity commits to the instruction and not to its
+//	outcome.
+//
+// The second sentence is why this is not "the same ID means the same
+// environment": that stronger claim is recorded REFUTED in PROPERTIES.md (X2)
+// and the residual is enumerated in docs/environment-identity.md.
+//
 // Only frozen lockfiles (all SHA256s present) produce a stable ID; a lockfile
-// without content hashes returns an empty string.
+// without content hashes returns an empty string, which is not an identity and
+// must not be published, tagged or used as a key (#124).
 func (l *LockFile) EnvironmentID() string {
 	return computeEnvironmentID(l)
 }

--- a/spec/lockfile_hash.go
+++ b/spec/lockfile_hash.go
@@ -8,47 +8,146 @@ import (
 )
 
 // envHashInput is the canonical content struct hashed to produce EnvironmentID.
-// Only fields that define environment content are included. Attestation fields
-// (RekorEntry, Bundle), timing fields (ResolvedAt), and identity fields
-// (ProfileName, StrataVersion) are excluded — they do not affect what runs.
-// MutableLayer is also excluded — it is metadata about the build process,
-// not the environment content itself (the upper is not content-addressed).
+//
+// Membership is not a field-by-field judgement. A LockFile field appears here
+// unless it takes one of four routes out, each of which is a checkable
+// obligation rather than an assertion:
+//
+//   - inert — no consumer outside spec reads it (Base.DeclaredOS,
+//     ProfileSHA256, MutableLayer, RequiresHost, SatisfiedBy, FromFormation).
+//   - digest-mediated — its influence is bounded by a check against a field
+//     that is hashed (Layers[].Source is fetched and then verified against
+//     Layers[].SHA256: cmd/strata/run.go:436, :481; internal/agent/agent.go:244).
+//   - abort-only — it can cause assembly to fail but never to differ
+//     (Layers[].Bundle, Layers[].RekorEntry: internal/agent/agent.go:367
+//     verifies the fetched file and refuses on mismatch).
+//   - declared provenance — exported under a name that EnvironmentID's claim
+//     excludes by name, with no in-tree reader (LockFile.RekorEntry, exported
+//     as STRATA_REKOR_ENTRY; the absence of a reader is enforced by
+//     TestDeclaredProvenance_NoInTreeReader, not asserted here).
+//
+// Everything else is content and is hashed. Adding a LockFile field without
+// recording which route it takes is the defect this list exists to prevent.
+// The reasoning is docs/environment-identity.md.
 type envHashInput struct {
-	BaseAMISHA256 string               `json:"base_ami_sha256"`
-	LayerSHA256s  []string             `json:"layer_sha256s"`
-	Env           map[string]string    `json:"env,omitempty"`
-	OnReady       []string             `json:"on_ready,omitempty"`
-	Packages      []ResolvedPackageSet `json:"packages,omitempty"`
+	BaseAMISHA256 string                `json:"base_ami_sha256"`
+	ProfileName   string                `json:"profile_name"`
+	Layers        []layerHashInput      `json:"layers,omitempty"`
+	Env           map[string]string     `json:"env,omitempty"`
+	Defaults      []moduleHashInput     `json:"defaults,omitempty"`
+	OnReady       []string              `json:"on_ready,omitempty"`
+	Packages      []packageSetHashInput `json:"packages,omitempty"`
+}
+
+// layerHashInput is one layer's contribution to the identity.
+//
+// MountOrder is deliberately absent. The layers slice is sorted by it, so the
+// ordering it expresses is captured while its literal value is not: two
+// lockfiles whose mount orders are 1,2 and 10,20 mount the same layers in the
+// same sequence and assemble the same environment, so they must not differ in
+// identity. Hashing the number would manufacture a distinction.
+type layerHashInput struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Version       string `json:"version"`
+	InstallLayout string `json:"install_layout"`
+	SHA256        string `json:"sha256"`
+}
+
+// moduleHashInput is one entry of LockFile.Defaults. Only Name and Version are
+// hashed because they are the only fields any consumer reads: overlay writes
+// "module load <name>/<version>" lines from them
+// (internal/overlay/overlay.go:171-176). Order is preserved — module load
+// sequencing is meaningful.
+type moduleHashInput struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
+}
+
+// packageSetHashInput and packageEntryHashInput mirror ResolvedPackageSet and
+// ResolvedPackageEntry with one difference: the inner Packages slice carries
+// omitempty, so a set with no entries hashes identically whether the slice is
+// nil or empty. A set with no entries installs nothing either way (#117).
+//
+// Order is preserved, in both dimensions, because it is consumed in order:
+// internal/agent/package_installer.go:37 iterates the sets and :99, :113 run
+// one pip/conda command per entry, so a later entry can change what an earlier
+// one installed. Sorting either dimension would give two different
+// environments one identity.
+type packageSetHashInput struct {
+	Manager  PackageManager          `json:"manager"`
+	Env      string                  `json:"env,omitempty"`
+	Packages []packageEntryHashInput `json:"packages,omitempty"`
+}
+
+type packageEntryHashInput struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	SHA256  string `json:"sha256,omitempty"`
 }
 
 // computeEnvironmentID returns a hex SHA256 of the lockfile's canonical
 // content, or an empty string if the lockfile is not frozen (missing SHA256s).
 //
-// Layers are sorted by MountOrder before hashing to ensure determinism
-// regardless of the order they appear in the lockfile YAML.
+// Layers are sorted by MountOrder with a stable sort, which is the same order
+// the mounter uses (internal/overlay/mount_linux.go:134) — including for tied
+// MountOrders, where both fall back to the order the layers appear in the
+// lockfile. That fallback is why the sort must be stable: an unstable sort
+// leaves the identity of a lockfile with tied mount orders dependent on an
+// implementation detail of sort.Slice. Ties are underdetermined in a further
+// sense that this function cannot fix — see #95.
 func computeEnvironmentID(l *LockFile) string {
 	if !l.IsFrozen() {
 		return ""
 	}
 
-	// Sort a copy of layers by MountOrder so hashing is order-independent.
+	// Sort a copy of layers by MountOrder so the identity follows the mount
+	// sequence rather than the order the layers were written down.
 	layers := make([]ResolvedLayer, len(l.Layers))
 	copy(layers, l.Layers)
-	sort.Slice(layers, func(i, j int) bool {
+	sort.SliceStable(layers, func(i, j int) bool {
 		return layers[i].MountOrder < layers[j].MountOrder
 	})
 
-	sha256s := make([]string, len(layers))
+	hashLayers := make([]layerHashInput, len(layers))
 	for i, layer := range layers {
-		sha256s[i] = layer.SHA256
+		hashLayers[i] = layerHashInput{
+			ID:            layer.ID,
+			Name:          layer.Name,
+			Version:       layer.Version,
+			InstallLayout: canonicalInstallLayout(layer.InstallLayout),
+			SHA256:        layer.SHA256,
+		}
+	}
+
+	defaults := make([]moduleHashInput, len(l.Defaults))
+	for i, ref := range l.Defaults {
+		defaults[i] = moduleHashInput{Name: ref.Name, Version: ref.Version}
+	}
+
+	packages := make([]packageSetHashInput, len(l.Packages))
+	for i, ps := range l.Packages {
+		entries := make([]packageEntryHashInput, len(ps.Packages))
+		for j, e := range ps.Packages {
+			// A conversion rather than a field-by-field literal, deliberately: it
+			// is legal only while the two structs have identical fields, so a new
+			// field on ResolvedPackageEntry breaks the build here instead of being
+			// silently dropped from the identity. If such a field is genuinely
+			// outside the identity, this becomes a literal again and the field gets
+			// a row in packageEntryRoutes with its route.
+			entries[j] = packageEntryHashInput(e)
+		}
+		packages[i] = packageSetHashInput{Manager: ps.Manager, Env: ps.Env, Packages: entries}
 	}
 
 	input := envHashInput{
 		BaseAMISHA256: l.Base.AMISHA256,
-		LayerSHA256s:  sha256s,
+		ProfileName:   l.ProfileName,
+		Layers:        hashLayers,
 		Env:           l.Env,
+		Defaults:      defaults,
 		OnReady:       l.OnReady,
-		Packages:      l.Packages,
+		Packages:      packages,
 	}
 
 	// json.Marshal on a struct with string/map/slice fields is deterministic
@@ -61,4 +160,23 @@ func computeEnvironmentID(l *LockFile) string {
 
 	sum := sha256.Sum256(data)
 	return hex.EncodeToString(sum[:])
+}
+
+// canonicalInstallLayout maps the empty layout to its documented meaning.
+// spec/layer.go declares "versioned" as the default and the empty string means
+// exactly that, so two lockfiles differing only in whether the key was written
+// out assemble the same environment and must share an identity.
+//
+// The mapping stops there deliberately. Every consumer compares this field for
+// equality against "flat" (internal/overlay/overlay.go:109,116;
+// cmd/strata/run.go:336,342; internal/fold/eject.go:220,225;
+// internal/export/oci.go:368,375), so today any non-"flat" spelling behaves
+// like "versioned" and could be folded in too. That equivalence rests on an
+// absence — no consumer testing for "versioned" positively — which nothing
+// checks, whereas the empty case rests on the spec.
+func canonicalInstallLayout(layout string) string {
+	if layout == "" {
+		return "versioned"
+	}
+	return layout
 }


### PR DESCRIPTION
Closes #145. Resolves #117, #118, #120, #121, #122, #123.

## What this changes

`LockFile.EnvironmentID()` now hashes the fields the assembler reads. Six open
issues each described the identity as too *narrow* — a sound subset missing a
field. It was not a subset. Cross-tabulating what the hash covered against what
the assembler reads found it **misaligned in both directions**:

| | Read by an assembler | Not read |
|---|---|---|
| **Hashed before** | 3 | 2 (`on_ready` #69, package `sha256` #98) |
| **Not hashed before** | 10 | the rest |

That is why this is one decision rather than six patches: no patch to any single
issue would have surfaced the two hashed-but-unread fields, and each of the six
would have added its own field on its own reasoning.

Newly hashed, with the consumer that makes each one content:

| Field | Consumer | Issue |
|---|---|---|
| `profile` | `$STRATA_PROFILE` in every login shell (`internal/overlay/overlay.go:143`, `:198`) | #120 |
| layer `id` | the mount point `/strata/layers/<id>` (`internal/overlay/mount_linux.go:147`) | #122 |
| layer `name`, `version` | the `$STRATA_ENV/<name>/<version>/bin` entry on `PATH` (`internal/overlay/overlay.go:112`) | #122 |
| layer `install_layout` | whether the layer contributes a `PATH` entry at all | #123 |
| `defaults` | the `module load` lines in `/etc/profile.d/strata-defaults.sh` (`internal/overlay/overlay.go:171-176`) | #118 |

Two encoding differences that assemble the same environment now share an
identity: an omitted `install_layout` equals an explicit `versioned`, and a
package set whose entries are `nil` equals one whose entries are `[]` (#117).

The two hashed-but-unread fields stay hashed, under rule 3 below: the identity
commits to the *instruction*, not to its outcome.

`sort.Slice` becomes `sort.SliceStable` in the mounter (`internal/overlay/mount_linux.go:140`)
and the OCI exporter (`internal/export/oci.go:49`), so a lockfile with tied
`MountOrder`s assembles in the order its identity was computed from. **No shipped
producer emits ties** — `internal/resolver/stages.go:411` and
`internal/build/buildenv.go:76,105` assign `i+1`, `internal/scan/profile_gen.go:54`
assigns `i` — so this is unobservable through the CLI today and matters only for
hand-written and externally produced lockfiles.

## The rule, and why it is a test and not a comment

The previous membership rule was a prose comment plus a field list. It drifted
twice, invisibly in both directions, with every test in the tree green. So the
rule is stated in `docs/environment-identity.md` and enforced in
`spec/environment_id_scope_test.go`: a field is hashed unless it takes one of four
named routes out — `inert`, `digest-mediated`, `abort-only`, `declared-provenance`
— each a checkable obligation with a stated failure condition.

Three tests, all new:

| Test | What it makes impossible |
|---|---|
| `TestEnvironmentIDRoutes_CoverEveryField` | a new field on any classified struct going unclassified (reflection, both directions) |
| `TestEnvironmentIDRoutes_MatchBehaviour` | a route that describes itself rather than the code — mutates each field, asserts the identity moves iff the table says content |
| `TestEnvironmentIDRoutes_ContentStructsHaveTables` | the enumeration stopping one level above a new field |

The third exists because of a hole the first two had: `CoverEveryField` can only
compare a struct that has a table, and `LockFile.Packages` and `LockFile.Defaults`
were classified content with their element types unenumerated. A field added to
`ResolvedPackageEntry` or `SoftwareRef` would have been dropped from the identity
with everything green. Three tables were added (`ResolvedPackageSet`,
`ResolvedPackageEntry`, `SoftwareRef`) and the closure rule is now checked.

`spec/lockfile_hash.go` also converts rather than copies field-by-field —
`packageEntryHashInput(e)` — which is legal only while the two structs have
identical fields, so the same omission breaks the build at that line too.

`spec/declared_provenance_test.go` enforces the one route that rests entirely on
an absence. `declared-provenance` holds for `RekorEntry` only while nothing
in-tree reads `STRATA_REKOR_ENTRY` back; a program that branched on it would make
the field content and the identity under-determined for as long as nobody
noticed. The test enumerates every mention of `STRATA_REKOR_ENTRY` and
`strata.lockfile.rekor_entry` in non-test `.go` and `.sh` files and fails on any
that is not a known write site. The enumeration is the fence, not the
`os.Getenv` regex: the allow-list also catches reader forms a regex cannot spell
(a map index off `os.Environ()`, a read split across lines, a local wrapper).
Counts are exact in both directions, so a walk that reaches nothing fails instead
of reporting clean.

## Measurements

All commands run at `69f789d`.

| Claim | Command | Result |
|---|---|---|
| suite green with race | `go test -race ./...` | rc=0, 20 `ok` lines |
| route tables live | `go test ./spec/ -run TestEnvironmentIDRoutes -count=1 -v \| grep -c -- '--- PASS'` | `67` (57 mutation rows, 7 struct comparisons, 3 top-level) |
| the provenance scan reaches the tree | `go test ./spec/ -run TestDeclaredProvenance_NoInTreeReader -count=1 -v \| grep scanned` | `scanned 95 non-test .go files and 33 shell scripts` |
| vet | `go vet ./...` | rc=0 |
| format | `gofmt -l .` | no output |
| lint | `golangci-lint run ./...` | `0 issues.` |

**The lint run was local `golangci-lint 2.13.0`; CI pins `v2.11.3` (`.github/workflows/ci.yml:90`).**
A clean local run is not a clean CI run — the finding sets differ between
versions. The CI result is the one that counts and is linked below.

Both instruments were mutation-probed against the real tree, not only against
their fixtures, because a fixture control proves the matcher fires and says
nothing about whether the walk composes with it. Each probe asserted the patch
applied and the mutant still **built** before its exit status was read — a build
failure exits 1 exactly as a caught defect does — and restored from a `trap`:

| Probe | Expected | Observed |
|---|---|---|
| drop the `ResolvedPackageEntry` table | closure test fails | `ResolvedPackageSet.Packages is content and reaches ResolvedPackageEntry, which has no route table` |
| make `structTypeOf` never find a struct | non-vacuity guard fires | `no content or nested row reached a struct type; structTypeOf is not unwrapping` |
| claim `SoftwareRef.Formation` is content | that row fails | `SoftwareRef.Formation is classified content and the identity did not move` |
| remove `StrataVersion` from the hash input (earlier window) | its row fails | row failed after the patch was confirmed applied and building |

## One cleanup this PR cannot make

`spec/environment_id_r7_exclusions_test.go:133` still contains
`TestR7Exclusion_NilVersusEmptyInnerPackages`, which asserts #117 **still
reproduces**, and `spec/environment_id_r7_fuzz_test.go:39` still lists #117 among
the fuzz target's excluded distinctions. #117 is fixed here, so that control
should now be failing and telling someone to delete it. It passes.

It passes because it is mis-constructed: it replaces the whole `Packages` field —
two sets, three entries — with `[]ResolvedPackageSet{{Manager: "pip", Packages: nil}}`,
so the identity moves because the package *contents* changed. It never builds a
nil/empty pair, which is the distinction #117 is about. Verified:

```
$ go test ./spec/ -run 'TestR7Exclusion_NilVersusEmptyInnerPackages|TestEnvironmentID_NilAndEmptyInnerPackagesAgree' -count=1 -v
--- PASS: TestR7Exclusion_NilVersusEmptyInnerPackages (0.00s)
--- PASS: TestEnvironmentID_NilAndEmptyInnerPackagesAgree (0.00s)
```

The first should fail and does not; the second is the correctly constructed
replacement, in `spec/environment_id_scope_test.go`.

I did not edit it. A session guard refuses edits to any test file inherited from
`main`, and its purpose is exactly this situation — a tightening must not be made
to pass by editing what it collides with — so "my reason is good" is not
something the guard can check at edit time. The deletion is filed as a follow-up
and named precisely there.

## A note, not a check

A lockfile `defaults:` entry that is a formation ref has an empty `Name`, and
`internal/overlay/overlay.go:171-176` writes a bare `module load ` line for it.
That is a defect in the writer, not evidence that `SoftwareRef.Formation` is
content, so it does not change the route table. It is recorded in that row's
reason. No issue opened for it — I am deliberately not converting one review pass
into a queue of new filings, and a note that does not fire is being labelled as
one rather than presented as covered.

## Not closed here

| Left open | Why |
|---|---|
| #146 | the lockfile's copy of a layer's `name`/`version`/`install_layout` sits outside the signed envelope. Hashing them makes an edit **visible** in the identity, not **refused**. Filed as the consequence of #122's fix, per the ruling on it |
| #64 | no shipped code assigns `Base.AMISHA256`, so `IsFrozen()` is false for every resolver-produced lockfile and `EnvironmentID()` returns `""` for all of them |
| #124 | `""` still reaches a storage key (`pkg/strata/strata.go:125` → `locks/.yaml`) and an instance tag (`cmd/strata-agent/ec2_signaler.go:84`). The DOI path *is* gated (`cmd/strata/publish.go:30`, `:73`) |
| #95 | what a tied `MountOrder` *means* is still undefined; this PR only makes the tie-break consistent between the mounter, the exporter and the identity |
| R7 / X2 statement repairs in `PROPERTIES.md` | a repair to a proposition's *statement* travels alone |

## Why the widening lands now rather than later

Widening the hash invalidates every stored identity it touches, so the cost is
the number of stored identities. Today that is zero: nothing assigns
`Base.AMISHA256`, so every lockfile the resolver produces returns `""`.

```
$ grep -rn 'AMISHA256\s*[:=]' --include='*.go' . | grep -v _test.go
```

finds a format string, a copy into `ProvenanceRecord`, and the hash input — no
assignment. **This is a now-or-never.** The moment #64 is fixed, the cost of
changing membership rises from nothing to a migration.

Per-consumer impact is enumerated in the `CHANGELOG.md` entry, including the
human procedure — citing an environment identity in a paper — since the two
`EnvironmentID()` comparison sites (`cmd/strata/update.go:117-119`,
`cmd/strata/diff.go:41-43`) are the ones that get *more* accurate: an update that
changed only a layer's version previously compared equal and reported no change.
