### PR TITLE
test: retire three R7 controls that cannot fail, and stop a fourth prescribing the defect (#148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -338,6 +338,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   timeout. Completes the two work items left unchecked in #36.
 
 ### Changed
+- **Three test controls that could not detect the fixes they guarded are removed,
+  and one that detects its fix correctly no longer prescribes the defect** (#148).
+  No behaviour change: no non-test file is touched, and `go test ./spec/
+  ./internal/agent/ -count=1` returns 0 before and after every commit on the
+  branch. Nothing was red and nothing becomes green — what changes is that four
+  assertions stop claiming coverage they never supplied.
+
+  `spec/environment_id_r7_exclusions_test.go` held four controls asserting that a
+  named defect *still reproduces*, so that fixing the defect would fail the test
+  and force the exclusion list to be updated. #148 probed all 46 assertions of
+  that shape in the repo by applying each fix locally; three of these four could
+  not do the job:
+  - **#117's** control mutated the whole `Packages` field rather than varying
+    `nil` against empty, so it passed both before and after #147 fixed the
+    defect. Deleted;
+    `TestEnvironmentID_NilAndEmptyInnerPackagesAgree` is the assertion that the
+    fix holds.
+  - **#69's** and **#98's** controls read `EnvironmentID()`, but those fixes land
+    in an on-ready executor and in an installer's argv respectively — nothing a
+    lockfile identity can observe. Both would have stayed green through their own
+    repair. Deleted rather than rewritten, because a control against a different
+    observable is a new control wearing the old one's name. The observable each
+    one should watch is now recorded on
+    [#69](https://github.com/scttfrdmn/strata/issues/69) and
+    [#98](https://github.com/scttfrdmn/strata/issues/98) instead.
+
+  **#95's two controls are kept.** They fire correctly and they are also the only
+  control that the R7 fuzz target's clone-and-compare machinery works at all. What
+  was wrong was their failure message: it said the defect "appears to be FIXED"
+  and told the reader to widen R7 over package order — the prescription #95 itself
+  records as refuted, since one install command runs per package entry and two
+  orders are two install sequences. A red there now reads as a regression in
+  `envHashInput`, names the test that should be failing beside it, and says not to
+  delete the control.
+
+  Also corrected: the comments on `knownOpenCells` in
+  `internal/agent/boot_matrix_test.go`, which claimed the constant was a tripwire
+  against the code. Both sides of that check derive from the same expectation
+  table, so it catches an edit to the table, not a fix to the defect; the real
+  tripwire fires once per affected cell and is now named. The constant and the
+  check are unchanged.
+
+  **What changes per consumer:** nothing. `gh pr diff 152 --name-only` lists only
+  `*_test.go`, `PROPERTIES.md` and this file, so no build, no binary and no
+  on-disk artifact differs. The audience for this entry is whoever next
+  fixes #69, #95, #98 or #93(a) and would otherwise read a green suite as evidence
+  their fix was detected.
+
 - **`EnvironmentID` now covers the fields the assembler actually reads** (#145,
   closing #117, #118, #120, #121, #122, #123). The six issues above each
   described the identity as too *narrow* — a sound subset missing a field. It was

--- a/PROPERTIES.md
+++ b/PROPERTIES.md
@@ -1883,6 +1883,10 @@ states the standard it violated and puts a cadence on finding the next.
     would be precisely the overclaim §2.1 exists to catch. The exclusion is recorded
     in the document and in the code, not silently avoided.
 
+    **Amended 2026-08-22 (#148, item 81):** three of those four classes no longer have a
+    control in that file, and one of them is no longer a class — #117 was fixed by #147. The
+    count in this paragraph is the count as it stood on 2026-08-21.
+
 58. **The exclusion list cannot outlive the defects it describes.**
     `spec/environment_id_r7_exclusions_test.go` holds one control per exclusion,
     each asserting the spurious distinction **still reproduces**. Those tests fail when
@@ -1898,6 +1902,11 @@ states the standard it violated and puts a cadence on finding the next.
     the fuzz target would pass on every input and read exactly as it does now — and
     these five tests would fail. A generator with no such control cannot distinguish
     holding from being unable to see.
+
+    **Amended 2026-08-22 (#148, item 81):** *one control per exclusion* and *these five tests*
+    were both true when written and are neither now. Two controls remain, both #95, and the
+    machinery-control argument in the paragraph above rests on those two — which is why they were
+    kept rather than deleted with the others.
 
 59. **Two counterexamples filed, and they run in opposite directions.**
     **#117** (R7): a package set's inner `Packages` slice hashes differently when
@@ -2536,3 +2545,83 @@ states the standard it violated and puts a cadence on finding the next.
     what it points at, which is why #105's *"make test names mandatory alongside line
     numbers"* is the part that buys the detection — recorded on #105 rather than filed
     again here. (2026-08-22, #135.)
+
+### 2026-08-22 — three controls that could not fail, and one that failed with the wrong instruction
+
+81. **The exclusion list's guard against rot was itself unguarded.** §58 claimed the file holds one
+    control per exclusion, each failing when its defect is fixed. #148 probed all 46 assertions of
+    that shape in the repo by applying each fix locally and reading the verdict, and four could not
+    do the job — three of them in this file. The classes, and the treatment each got:
+
+    | Class | Instance | Failure mode | Treatment |
+    |---|---|---|---|
+    | A | `TestR7Exclusion_NilVersusEmptyInnerPackages` (#117) | mutated the whole `Packages` field, not nil against empty — true before *and* after #147 | deleted; `TestEnvironmentID_NilAndEmptyInnerPackagesAgree` is the assertion the fix holds |
+    | B | `TestR7Exclusion_MutateOnReady` (#69), `TestR7Exclusion_MutatePackageDigest` (#98) | read `EnvironmentID()`; the fixes land in an executor and an installer argv | deleted, not repaired — the observable each needs is named on its issue |
+    | C | `assertStillSpurious`'s message (#95 ×2) | goes red correctly, then instructs the reader to apply #95's *refuted* prescription | message repaired; controls kept |
+    | D | `knownOpenCells` comment (`internal/agent/boot_matrix_test.go:87`) | claimed a tripwire role; both sides of the check derive from `wantFor()` | comment repaired, constant untouched |
+
+    **Class B is the finding this document has to absorb, because it is not a repairable control.**
+    A mutation of a lockfile's identity cannot observe a fix that lands in an installer's argv. There
+    is no better mutation; writing one means a different control against a different observable,
+    which is a new control wearing the old one's name. So the treatment is deletion plus a **named
+    absence** on the issue — and the rule that follows is that *a control aimed at an instrument that
+    cannot observe its subject reads as coverage and supplies none*, which no green run can tell you.
+
+    **Class C is the sharper one, and it is not machine-detectable.** *Does it go red* is answerable
+    by a probe; *does the red say the right thing* is not. Both #95 controls fail correctly and then
+    say *"appears to be FIXED … move this transformation into liveTransforms()"* — widening R7 over
+    package order, which `TestEnvironmentID_PackageOrderIsContent` refutes and #95 records as
+    refuted. A control that fails correctly and prescribes wrongly is worse than one that never
+    fires, because it converts a real signal into a wrong action. The review rule adopted from it:
+    **when a control goes red, read what it tells the reader to do.**
+
+    **Class D is R6's error, alive inside the document that retired R6.** The comment claimed the
+    constant was the tripwire against the code. Check (5) compares `fired[reasonNoVerifier]` against
+    `const knownOpenCells = 20`, and `fired` is built from `c.want` — so **both sides derive from
+    `wantFor()`**, the expectation table. It is a consistency check between two representations of
+    one claim, refutable only by the two disagreeing, which is exactly the ground on which R6 was
+    withdrawn rather than narrowed (item 54) and the ground rule 11 was adopted on (item 79). Fixing
+    #93(a) leaves both sides at 20 and check (5) green. The real tripwire is the `knownOpen` branch
+    in `runCell` — `Run` refuses where the cell says it boots — and it fires **twenty times**, once
+    per cell, each failure carrying the instruction to lower the constant. The treatment is the
+    comment, because the constant and the check are both correct for what they actually do: they
+    bound the *table*. What is worth recording is the date. This shape was named in items 54 and 79
+    on 2026-08-21, and the table carrying it was added the **same day**:
+
+    ```sh
+    git log --diff-filter=A --format='%h %ad %s' --date=short -- internal/agent/boot_matrix_test.go
+    # a76ef34 2026-08-21 test(agent): enumerate the boot verification decision surface (112 cells)
+    ```
+
+    Knowing the pattern did not prevent it, and no green run could have said so. What found it was
+    asking, of a check that passes, *where does each side of the comparison come from* — which is
+    rule 11's question pointed at an instrument instead of at a register row.
+
+    Two consequences beyond the repairs. The `why` strings these two controls pass are documented as
+    *the specification-level reason the environment is unchanged*, and they assert something the
+    suite contradicts — so **the R7 half of #95's register row rests on a premise
+    `TestEnvironmentID_PackageOrderIsContent` denies**, and a transformation whose premise fails
+    belongs in the opposite-reason list beside `Defaults` (#118) rather than among R7's
+    counterexamples. That is a refutation-register change and travels alone; raised on #95. And
+    #117's fix left three artifacts describing it as live — this register's #117 R7 row, §59's *"two
+    counterexamples filed"*, and a transformation that is now neither excluded nor in the live set —
+    filed as #150.
+
+    **Two stale citations were created and corrected inside this change**, which is item 80's class
+    arriving one item later: `runCell (:513-517)` was already wrong at `origin/main` before the
+    branch existed, and `environment_id_scope_test.go:838` was correct when one commit wrote it and
+    one line off after the next commit added a line above the function. Both are the *valid wrong
+    line* form an existence check reads as green. Both replacements name the symbol they point at —
+    #105's prescription — which is what makes them checkable rather than merely correct today.
+
+    Neither the sweep nor this change fixes a defect. Both are apparatus, and the apparatus/defect
+    purpose counter does not advance: 46 assertions probed, 3 controls deleted, 10 comment or string
+    sites corrected across 4 files — one of them the failure message that prescribed the defect — 0
+    lines of shipped code touched, 0 issues closed. The two counts a reader can re-derive on `main`:
+
+    ```sh
+    grep -c 'assertStillSpurious(t,' spec/environment_id_r7_exclusions_test.go   # 2, was 5
+    grep -c '^func Test' spec/environment_id_r7_exclusions_test.go                # 3, was 6
+    ```
+
+    (2026-08-22, #148.)

--- a/internal/agent/boot_matrix_test.go
+++ b/internal/agent/boot_matrix_test.go
@@ -86,8 +86,15 @@ var ladderOutcomes = []bootOutcome{
 
 // knownOpenCells is the number of cells that reach the mount with no authenticity
 // verification because Verifier or BundleFetcher is nil (#93(a)). It is asserted
-// as a literal so the size of the hole is a number in the suite: closing #93(a)
-// changes this line, and nothing can shrink it silently.
+// as a literal so the size of the hole is a number in the suite, and so the
+// expectation table cannot shrink it silently: check (5) below compares it against
+// wantFor()'s own output, which means it catches an edit to the *table*.
+//
+// It is not the tripwire against the code, and #148 measured that: fixing #93(a)
+// leaves this number at 20 and check (5) green, because both sides are derived from
+// wantFor(). What goes red is the knownOpen branch in runCell (:526-530), once per
+// cell — Run refuses where the cell says it does not — and that failure carries the
+// instruction to lower this constant. Twenty cells fail, not one.
 const knownOpenCells = 20
 
 // --- dimension 1: the verifier's disposition -------------------------------
@@ -429,8 +436,9 @@ func TestBootMatrix_Shape(t *testing.T) {
 		seen[c.name] = true
 	}
 
-	// (5) The size of the open hole, as a literal. Closing #93(a) changes this
-	// number, so it cannot shrink without a diff.
+	// (5) The size of the open hole, as a literal, checked against the expectation
+	// table it is a claim about. Both sides come from wantFor(), so this catches the
+	// table being edited and not the code being fixed — see knownOpenCells.
 	open := fired[reasonNoVerifier]
 	if open != knownOpenCells {
 		t.Errorf("%d cells are #93(a) fail-open, knownOpenCells says %d — "+

--- a/spec/environment_id_r7_exclusions_test.go
+++ b/spec/environment_id_r7_exclusions_test.go
@@ -3,33 +3,64 @@ package spec
 import "testing"
 
 // The R7-refuting exclusions named in environment_id_r7_fuzz_test.go's stated
-// domain — same environment, different identity — each asserted to still
-// reproduce.
+// domain, each asserted to still distinguish two lockfiles.
 //
-// The stated domain has a second kind of exclusion which is NOT controlled here,
-// and the gap is structural rather than an oversight: the opposite-reason
-// exclusions (Defaults #118, ProfileName and RekorEntry #120, the layer
-// manifest's Name/Version/InstallLayout #122) are cases where the environment
-// differs and the identity does not. Witnessing one means calling
-// overlay.ConfigureEnvironment and comparing the assembled roots, and
-// internal/overlay imports spec, so a control for them cannot live in this
-// package. It has to live in internal/overlay; #120 and #122 carry that as a
-// task. Until it does, this file controls the four R7-refuting exclusions and
-// every opposite-reason exclusion rests on its issue alone.
+// Two controls remain, both #95, and the list of what is *not* controlled here is
+// longer than the list of what is. That is deliberate. #148 probed every assertion
+// in this repo that a defect still reproduces by applying the fix locally and
+// watching the assertion go red, and three of the controls that used to live in
+// this file could not fail:
 //
-// These tests fail when a defect is FIXED. That is the intent. An exclusion list
-// is a claim about the present, and the way such a list rots is that someone
-// repairs the code and the list keeps quietly narrowing the property for years
-// afterwards. Here the list cannot outlive the defects: fix #95 and
-// TestR7Exclusion_ReorderPackageSets fails, which is the instruction to delete
-// the exclusion and move the transformation into liveTransforms().
+//   - #117 (nil versus empty inner Packages) was fixed by #147, and its control was
+//     mis-constructed: it replaced two entries with none rather than varying nil
+//     against empty, so it asserted something true before and after the fix.
+//     Deleted. TestEnvironmentID_NilAndEmptyInnerPackagesAgree in
+//     environment_id_scope_test.go is the assertion that the fix holds.
+//   - #98 (the installer ignores a package entry's recorded sha256) and #69
+//     (on_ready is hashed and executed by nothing) had controls that read
+//     EnvironmentID(). Neither fix goes anywhere near it: #98's is an installer
+//     argv carrying --require-hashes and --hash=sha256:, #69's is an executor that
+//     runs the commands. No mutation of a lockfile's identity can observe either,
+//     so there is no better mutation to write — the instrument cannot see the
+//     subject. Both are deleted and the observable each should watch is recorded on
+//     its own issue. A named absence is better than a control that reads as
+//     coverage.
 //
-// They are also the control for the fuzz target's machinery, which is why they
-// use the same clone-and-compare path rather than a private one. If clone()
+// The stated domain has a second kind of exclusion which is NOT controlled here
+// either, and that gap is structural rather than an oversight: the opposite-reason
+// exclusions (Defaults #118, ProfileName and RekorEntry #120, the layer manifest's
+// Name/Version/InstallLayout #122) are cases where the environment differs and the
+// identity does not. Witnessing one means calling overlay.ConfigureEnvironment and
+// comparing the assembled roots, and internal/overlay imports spec, so a control
+// for them cannot live in this package. It has to live in internal/overlay; #120
+// and #122 carry that as a task.
+//
+// An exclusion list is a claim about the present, and the way such a list rots is
+// that someone repairs the code and the list keeps quietly narrowing the property
+// for years afterwards. What follows from that, for the two controls left, is not
+// what it was when there were four.
+//
+// A failure here does NOT mean #95 has been fixed and the transformation should
+// move into liveTransforms(). #95 prescribes sorting both dimensions of Packages,
+// and that prescription is refuted on the issue by the consumer:
+// internal/agent/package_installer.go:37 iterates the sets and :99, :113 run one
+// install command per entry, so a later entry can change what an earlier one
+// installed. TestEnvironmentID_PackageOrderIsContent
+// (environment_id_scope_test.go:839) pins the behaviour that refutation implies,
+// and it asserts the same distinction from the other side, so the two fail
+// together. A red here is a regression in envHashInput, or someone applying the
+// refuted prescription — never an instruction to widen R7 over package order.
+// assertStillSpurious's message says so, because #148 found two controls that go
+// red while telling the reader to implement the defect, and these were them.
+//
+// These two are also the control for the fuzz target's machinery, which is why
+// they use the same clone-and-compare path rather than a private one. If clone()
 // returned an alias, or EnvironmentID() returned a constant, or the comparison
 // were inverted, FuzzR7NoSpuriousDistinctions would pass on everything and look
-// exactly as it does now. These tests are what makes that distinguishable:
-// a harness that cannot see a changed identity fails here.
+// exactly as it does now. These tests are what makes that distinguishable: a
+// harness that cannot see a changed identity fails here. Two callers are enough
+// for that role, and it is why these two survive the deletions above — a control
+// is not retired for being redundant to its stated purpose.
 
 // r7Fixture is a frozen lockfile with one layer and one package set, built
 // explicitly rather than drawn from a stream so each control below is readable

--- a/spec/environment_id_r7_exclusions_test.go
+++ b/spec/environment_id_r7_exclusions_test.go
@@ -55,9 +55,16 @@ func r7Fixture() *LockFile {
 	}
 }
 
-// assertStillSpurious asserts that mutate changes the EnvironmentID even though
-// the assembled environment is unchanged — i.e. that the named R7 counterexample
-// still reproduces.
+// assertStillSpurious asserts that mutate changes the EnvironmentID across a
+// transformation the named issue claims preserves the assembled environment.
+//
+// The name is from when this file held four controls, each asserting a live R7
+// counterexample that would expire when its defect was fixed. Both remaining
+// callers are #95, whose environment-preserving premise the repo contradicts
+// elsewhere (see the file comment), so what these assertions buy is a regression
+// pin plus the fuzz target's machinery control — not an exclusion waiting to
+// expire. The failure message reflects that; whether #95's pair are R7
+// counterexamples at all is recorded on #95.
 func assertStillSpurious(t *testing.T, issue, why string, mutate func(l *LockFile)) {
 	t.Helper()
 
@@ -80,22 +87,33 @@ func assertStillSpurious(t *testing.T, issue, why string, mutate func(l *LockFil
 
 	after := mutated.EnvironmentID()
 	if after == before {
-		t.Errorf("%s appears to be FIXED: the identity no longer distinguishes these "+
-			"lockfiles.\n"+
-			"  the environment was unchanged because: %s\n"+
-			"  This test failing is the instruction to act, not a regression:\n"+
-			"    1. move this transformation into liveTransforms() in "+
-			"environment_id_r7_fuzz_test.go\n"+
-			"    2. delete this control and its entry from that file's stated domain\n"+
-			"    3. update the R7 row and %s's register row in PROPERTIES.md\n"+
-			"  id: %s", issue, why, issue, before)
+		t.Errorf("%s: the identity no longer distinguishes these two lockfiles.\n"+
+			"  the transformation, and what the issue claims about it: %s\n"+
+			"  This is a REGRESSION. It is NOT an instruction to move the "+
+			"transformation into liveTransforms():\n"+
+			"    - package order is content. internal/agent/package_installer.go:37 "+
+			"iterates the sets; :99 and :113 run one install command per entry, so a "+
+			"later entry can change what an earlier one installed.\n"+
+			"    - TestEnvironmentID_PackageOrderIsContent "+
+			"(environment_id_scope_test.go:839) pins that behaviour and should be "+
+			"failing beside this test. If it is passing, this test is the wrong one.\n"+
+			"    - #95 prescribes sorting both dimensions of Packages. That "+
+			"prescription is refuted on the issue for the reason above: it would give "+
+			"two different install sequences one identity.\n"+
+			"  Repair envHashInput, or revert the sort. Do not widen R7 over package "+
+			"order, and do not delete this control — it is also what proves the fuzz "+
+			"target can see a changed identity at all.\n"+
+			"  id: %s", issue, why, before)
 	}
 }
 
 func TestR7Exclusion_ReorderPackageSets(t *testing.T) {
 	assertStillSpurious(t, "#95",
-		"the order two package sets are listed in does not change which packages are "+
-			"installed; every version is exactly pinned",
+		"#95 claims the order two package sets are listed in does not change which "+
+			"packages are installed, since every version is exactly pinned. That claim "+
+			"is contradicted by internal/agent/package_installer.go:37,99,113 and the "+
+			"contradiction is recorded on the issue; what is asserted here is only that "+
+			"the identity distinguishes the two orders",
 		func(l *LockFile) {
 			l.Packages[0], l.Packages[1] = l.Packages[1], l.Packages[0]
 		})
@@ -103,8 +121,11 @@ func TestR7Exclusion_ReorderPackageSets(t *testing.T) {
 
 func TestR7Exclusion_ReorderPackageEntries(t *testing.T) {
 	assertStillSpurious(t, "#95",
-		"a package set is a set; listing numpy before scipy installs the same two "+
-			"exactly-pinned packages as the reverse",
+		"#95 claims a package set is a set, so listing numpy before scipy installs the "+
+			"same two exactly-pinned packages as the reverse. One pip command runs per "+
+			"entry, in order (internal/agent/package_installer.go:99), so the claim does "+
+			"not hold; what is asserted here is only that the identity distinguishes the "+
+			"two orders",
 		func(l *LockFile) {
 			p := l.Packages[0].Packages
 			p[0], p[1] = p[1], p[0]

--- a/spec/environment_id_r7_exclusions_test.go
+++ b/spec/environment_id_r7_exclusions_test.go
@@ -111,35 +111,6 @@ func TestR7Exclusion_ReorderPackageEntries(t *testing.T) {
 		})
 }
 
-func TestR7Exclusion_MutateOnReady(t *testing.T) {
-	assertStillSpurious(t, "#69",
-		"on_ready is hashed into the identity and executed by nothing — declared "+
-			"spec/lockfile.go:39-40, copied internal/resolver/stages.go:434, no executor "+
-			"in non-test code — so changing it cannot change what is assembled",
-		func(l *LockFile) {
-			l.OnReady = []string{"echo something entirely different"}
-		})
-}
-
-func TestR7Exclusion_MutatePackageDigest(t *testing.T) {
-	assertStillSpurious(t, "#98",
-		"the installer resolves name@version from upstream and ignores the recorded "+
-			"sha256, so two lockfiles differing only in that digest install identical bytes",
-		func(l *LockFile) {
-			l.Packages[0].Packages[0].SHA256 = "ffffffff"
-		})
-}
-
-func TestR7Exclusion_NilVersusEmptyInnerPackages(t *testing.T) {
-	assertStillSpurious(t, "#117",
-		"a package set with no entries installs nothing whether the slice is nil or "+
-			"empty; ResolvedPackageSet.Packages carries json:\"packages\" without "+
-			"omitempty (spec/packages.go:49), so one marshals as null and the other as []",
-		func(l *LockFile) {
-			l.Packages = []ResolvedPackageSet{{Manager: "pip", Packages: nil}}
-		})
-}
-
 // TestR7ExclusionNilEmptyIsNotAboutTheOuterSlice separates the defect from a
 // neighbour it would otherwise be conflated with. The outer Packages field does
 // carry omitempty, so nil and empty are both omitted there and the identity is

--- a/spec/environment_id_r7_fuzz_test.go
+++ b/spec/environment_id_r7_fuzz_test.go
@@ -29,20 +29,32 @@ import (
 //
 // # Stated domain, and why each exclusion is named rather than avoided
 //
-// Four transformations preserve the assembled environment and still change the
-// identity. They are R7 counterexamples, all filed, and they are excluded from
-// the live set here because a target that fails on every input searches nothing:
+// Three transformations change the identity while the reason they are said to
+// preserve the assembled environment stands on record. They are excluded from the
+// live set here because a target that fails on every input searches nothing:
 //
 //   - reordering package sets or their entries — #95
 //   - mutating on_ready, which is hashed and executed nowhere — #69
 //   - mutating a package entry's sha256, which the installer ignores — #98
-//   - a nil versus empty inner Packages slice — #117
 //
-// Each exclusion has a control in environment_id_r7_exclusions_test.go that
-// asserts the distinction is *still* there. When one is fixed the control fails,
-// which is the signal to delete the exclusion and move the transformation into
-// the live set below. The exclusion list cannot silently outlive the defects it
-// describes.
+// A fourth, a nil versus empty inner Packages slice (#117), was fixed by #147 and
+// is no longer a counterexample. It is not in the live set either: adding it widens
+// the property this target asserts and needs a seed that reaches an entry-free
+// package set, so it travels on its own change (#150). Until then it is neither
+// excluded nor live, and saying so is what this paragraph is for.
+//
+// #95's two transformations have controls in environment_id_r7_exclusions_test.go
+// asserting the distinction is still there. #69's and #98's do not, and the absence
+// is named rather than left to be found: #148 measured that a control reading
+// EnvironmentID() cannot observe either fix — #69's lands in an executor, #98's in
+// an installer's argv — so those controls were deleted and the observable each one
+// needs is recorded on its issue.
+//
+// Whether #95's pair are R7 counterexamples at all is an open question recorded on
+// the issue: TestEnvironmentID_PackageOrderIsContent holds that package order *is*
+// content, and a transformation whose environment-preserving premise fails is not
+// R7's business. Either way they stay out of the live set; what would change is
+// which list they belong in, and what PROPERTIES.md's R7 row may claim.
 //
 // Excluded for the opposite reason — these change the environment, so R7's
 // premise does not hold and they are not R7's business:
@@ -175,8 +187,10 @@ func buildLockFile(s *r7Stream) *LockFile {
 	nSets := s.intn(3)
 	for i := 0; i < nSets; i++ {
 		set := ResolvedPackageSet{Manager: PackageManager(s.str()), Env: s.str()}
-		// Non-nil so the nil-versus-empty distinction (#117) is reached only by
-		// the transformation that means to reach it, not incidentally here.
+		// Non-nil so the nil-versus-empty distinction is reached only by a
+		// transformation that means to reach it, not incidentally here. #147 fixed
+		// that distinction (#117); this stays non-nil because the transformation
+		// varying it is not in the live set yet — see the stated domain above.
 		set.Packages = []ResolvedPackageEntry{}
 		nEntries := s.intn(4)
 		for j := 0; j < nEntries; j++ {

--- a/spec/environment_id_scope_test.go
+++ b/spec/environment_id_scope_test.go
@@ -792,7 +792,8 @@ func TestEnvironmentID_EmptyInstallLayoutEqualsVersioned(t *testing.T) {
 // TestR7Exclusion_NilVersusEmptyInnerPackages mutated the whole Packages field
 // rather than varying nil against empty, so it asserted the identity changes
 // when two entries are replaced by none — true before and after the fix, and
-// silent about either.
+// silent about either. That control was deleted by #148, which measured the
+// failure rather than reasoning about it: with #147's fix applied it still passed.
 func TestEnvironmentID_NilAndEmptyInnerPackagesAgree(t *testing.T) {
 	withNil := scopeFixture()
 	withEmpty := scopeFixture()


### PR DESCRIPTION
Executes the instruction approved on #148 (`issuecomment-5383178123`, approved with one drop and
three conditions). Four classes of failed control, three treatments, four commits.

**Nothing was red. Nothing becomes green. Four assertions stop claiming coverage they never
supplied.** That is the whole of the change, and the per-commit table below is the evidence.

## What each commit does

| # | Commit | Contents | What a reviewer checks |
|---|---|---|---|
| 1 | `d2b3886` | the three deletions (A: #117, B: #69, #98) | 29 lines removed, nothing else in the diff |
| 2 | `c58870c` | class C: the failure message, the doc comment, two `why` strings | every changed line inside a comment or a string literal |
| 3 | `f51b4a5` | class D's two comments; the file header; the fuzz stated domain and generator comment; the scope-test reference | comments only |
| 4 | `47ae161` | §57/§58 amendments, item 81, the `CHANGELOG` entry | claims match commits 1–3; every number has its command |

## Condition 2 — baselines reconciled per commit

Pre-registered on #148 **before** any edit: `59 → 56`, `5 call sites → 2`, `rc=0` throughout. Measured
by checking out each commit and running the suite against that tree, not by carrying forward
as-I-went numbers — commit 2's tree changed after its first measurement, so the earlier numbers were
not the shipped ones.

```
$ for sha in c6c02b4 d2b3886 c58870c f51b4a5 47ae161; do git checkout -q $sha; \
    go test ./spec/ ./internal/agent/ -count=1 >/tmp/pc.txt 2>&1; echo "rc=$?"; ...; done
```

| SHA | `go test` rc | top-level `func Test` in `spec` | `assertStillSpurious` call sites | `gofmt -l` |
|---|---|---|---|---|
| `c6c02b4` (`origin/main`) | **0** | **59** | **5** | 0 |
| `d2b3886` | **0** | **56** | **2** | 0 |
| `c58870c` | **0** | **56** | **2** | 0 |
| `f51b4a5` | **0** | **56** | **2** | 0 |
| `47ae161` (tip) | **0** | **56** | **2** | 0 |

Every measured value equals its prediction, so nothing halted. Green before, green after: a deletion
that had changed the suite's result would have meant the control did something after all, and the
instruction was to stop and report rather than adjust.

Re-derivable in the reader's state after merge:

```
grep -c 'assertStillSpurious(t,' spec/environment_id_r7_exclusions_test.go   # 2, was 5
grep -c '^func Test' spec/environment_id_r7_exclusions_test.go               # 3, was 6
```

Whole tree, at the tip: `go test ./... -count=1 -race` **rc=0**, `gofmt -l .` **0 files**,
`go vet ./...` **rc=0**, `golangci-lint run ./spec/... ./internal/agent/...` **0 issues** (local
**2.13.0**, CI pins **v2.11.3** at `.github/workflows/ci.yml:90` — the versions differ, so read the
local run as indicative and the CI job as binding).

## Condition 1 — the class-C audit, run rather than asserted

Editing a control's failure message is where *make it say something more convenient* lives, and a
reworded message is a plausible line change a reviewer skims. So the property is measured. Every
changed line of commit 2, classified by a script that strips Go string literals (honouring `\"`) and
line comments and reports what is left:

| Bucket | Lines |
|---|---|
| comment | 13 |
| string-literal continuation | 36 |
| mixed (a literal plus code) | 4 |
| **neither** | **0** |
| total | 53 (+37 / −16) |

The 4 mixed lines are two `-`/`+` pairs, and **only one is a code change**:

```
-		t.Errorf("%s appears to be FIXED: the identity no longer distinguishes these "+
      code outside the literal: 't.Errorf(+'
+		t.Errorf("%s: the identity no longer distinguishes these two lockfiles.\n"+
      code outside the literal: 't.Errorf(+'          <- byte-identical either side
-			"  id: %s", issue, why, issue, before)
      code outside the literal: ', issue, why, issue, before)'
+			"  id: %s", issue, why, before)
      code outside the literal: ', issue, why, before)'   <- one argument dropped
```

The dropped argument is forced: the new message interpolates the issue number once instead of twice.
It is also the only part of this commit a machine checks — `go vet ./spec/` (rc=0) validates printf
arity statically, which matters because the branch containing this message never executes while the
defect is open.

**I predicted "one changed line" before running the classifier and the classifier said four.** The
prediction was wrong about lines and right about semantics; the number reported is the measured one,
commit 2's message was amended to match it, and the discrepancy is stated here rather than quietly
corrected — that is the point of running the check instead of claiming the property.

Commit 3 was classified the same way: **130 changed lines, 130 comment, 0 anything else.**

The full `git diff --unified=0 c58870c^..c58870c` is in commit 2's own diff on this PR; the classifier
input was that exact output.

## The two class-B named absences, reproduced

A named absence only beats a misleading control if the naming is findable from the deletion, so both
land in this PR:

**#98** — [`issuecomment-5383133414`](https://github.com/scttfrdmn/strata/issues/98#issuecomment-5383133414).
The observable is the installer's argv, not a lockfile identity:

```
$ grep -c 'SHA256' internal/agent/package_installer.go
0
$ grep -rn 'require-hashes\|hash=sha256' --include='*.go' . | grep -v _test.go | wc -l
0
```

Note the second command needs `grep -v _test.go`: commit 3's new file-header comment contains the
string `--require-hashes` while describing its absence, so the unfiltered grep now hits its own
description. Writing about an absent token makes the absence check match the writing.

**#69** — [`issuecomment-5383135917`](https://github.com/scttfrdmn/strata/issues/69#issuecomment-5383135917).
`on_ready` is declared, hashed and copied, and executed nowhere:

```
$ grep -rn 'OnReady' --include='*.go' . | grep -v _test.go
spec/lockfile.go:39:	// OnReady are commands to run after overlay assembly.
spec/lockfile.go:40:	OnReady []string `yaml:"on_ready,omitempty" json:"on_ready,omitempty"`
spec/profile.go:47:	// OnReady is a list of commands run after the overlay is assembled,
spec/profile.go:49:	OnReady []string `yaml:"on_ready,omitempty" json:"on_ready,omitempty"`
spec/lockfile_hash.go:38:	OnReady       []string              `json:"on_ready,omitempty"`
spec/lockfile_hash.go:149:		OnReady:       l.OnReady,
internal/resolver/stages.go:434:		OnReady:      profile.OnReady,
```

Seven sites, no executor. A mutation of `EnvironmentID()` cannot observe a fix that adds one, which
is why the control was deleted rather than rewritten: a control against a different observable is a
new control wearing the old one's name.

## Findings produced while executing, not while reviewing

**1. #95 is a misclassification, not a message defect** —
[`issuecomment-5383137772`](https://github.com/scttfrdmn/strata/issues/95#issuecomment-5383137772).
The `why` strings are documented as *the specification-level reason the environment is unchanged*,
and both asserted something `TestEnvironmentID_PackageOrderIsContent` denies. A transformation whose
environment-preserving premise fails is not an R7 counterexample at all — it belongs in the
opposite-reason list beside `Defaults` (#118). That is a refutation-register change and travels
alone; it is **not** in this PR.

**2. Class D is the R6 shape, inside the tool built by the people who had just named it.** Recorded
as item 81 rather than treated as a comment typo. `a76ef34`, which added the table, is dated
**2026-08-21** — the same day items 54 and 79 named that exact pattern.

**3. Two stale `path:line` citations, created and corrected inside this change.** Both are the *valid
wrong line* form, which an existence check reads as green:

- `runCell (:513-517)` in the pre-registered instruction was **already wrong at `origin/main`** — that
  `Fatalf` is at `:519` there — so the approved text carried a stale citation of its own. Corrected
  to the measured `:526-530` after this branch's `+8` lines of comment.
- `environment_id_scope_test.go:838` was correct when commit 2 wrote it and one line off after
  commit 3 added a line above the function. Fixed **in commit 2**, so the class-C message stays
  auditable in the single commit that owns it; the cost is that the number is right at the tip and one
  off in that commit read alone. Intermediate states are not merge candidates.

Every `file:line` citation this branch adds is now resolved against the tree by script (3 carrying a
filename); the bare ones (`:99`, `:113`, `:526-530`) were checked by hand and are shown above. Both
replacements name the symbol they point at, which is #105's prescription and what makes them
checkable rather than merely correct today.

**4. `grep -c '^\tassertStillSpurious(t,'`, in the first draft of item 81, is grep-dependent.** BSD
grep reads `\t` as a tab; GNU grep reads it as a literal `t` and returns 0. A published command must
work in the reader's shell, so it was replaced with an anchor-free form that gives 2 under either.

## Scope: one thing dropped, one thing not done

The move of `TestR7ExclusionNilEmptyIsNotAboutTheOuterSlice` was **dropped** on instruction — a move
of an inherited test file riding along because a guard happens to be down is scope creep under a
bypass. Filed as **#151**, to land in a session where the constraint holds and the move justifies
itself on its own.

Consequence, stated rather than left to be found: `spec/environment_id_r7_exclusions_test.go` still
contains a test named `TestR7Exclusion…` that is not one of the two exclusions its header now
describes.

## Guard disclosure

The `no-inherited-tests` `PreToolUse` guard was **off**, not relaxed, for this session, by the repo
owner, on the written instruction above. Nothing was allowlisted, so the enforcement for this branch
is the branch-wide diff plus the pre-registered counts plus the classification above:

```
$ git diff --name-status origin/main...HEAD -- '*_test.go' | awk '$1 != "A"'
M	internal/agent/boot_matrix_test.go
M	spec/environment_id_r7_exclusions_test.go
M	spec/environment_id_r7_fuzz_test.go
M	spec/environment_id_scope_test.go
```

Four modified inherited test files, all four on the named path list, nothing outside it. `git diff
--stat origin/main...HEAD` adds only `PROPERTIES.md` and `CHANGELOG.md`: **no non-test file is
touched, so no build, binary or on-disk artifact differs.**

The mechanism used was a rename of `.claude/settings.json`, which wires **two** hooks — so the
unrelated `pipefail-guard` was off as collateral for the session, held by hand instead. The file is
restored byte-identically (`sha256 018b24bf…`) before the session ends and re-probed in four
directions in the session after, with the fetch time, per condition 3.

Refs #148. Closes nothing: 46 assertions probed, 3 controls deleted, 10 comment or string sites
corrected, **0 lines of shipped code touched, 0 issues closed.** The apparatus/defect purpose counter
does not advance, and the next change on this branch's heels should be a defect fix.

---

**Amended after opening:** commit 4 is `47ae161`, not the `e37878a` this body first named. The
`CHANGELOG` cited `git diff --stat origin/main...HEAD` for its file list, which returns nothing once
this merges — a published command's *range* is as perishable as its output. Replaced with `gh pr diff
152 --name-only`, verified against this PR. The force-push then staled three SHAs in the table above,
which is the fourth instance in this change of a citation going wrong while staying well-formed. Suite
re-run after the amend: `go test ./spec/ ./internal/agent/ -count=1` **rc=0**.
