### PR TITLE
fix: provider selection no longer depends on layer order (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -356,9 +356,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `BaseCapabilities.HasCapability` had the same first-match shape and no shipped
   caller; it is fixed rather than left as a trap for the first one.
 
-  **Which resolutions change**, and the shapes are reachable today even though no
-  shipped formation is one of them — `ls cmd/strata/formations/*.yaml | wc -l`
-  gives 6 and none contains two providers of one capability name:
+  **Which resolutions change under the new rule — highest satisfying version,
+  ties broken by lowest layer ID** — and the shapes are reachable today even
+  though no shipped formation is one of them —
+  `ls cmd/strata/formations/*.yaml | wc -l` gives 6 and none contains two
+  providers of one capability name:
   - **A profile naming two versions of the same software** now resolves where it
     could previously fail, and may mount in a different order. Eight recipes ship
     more than one version —
@@ -377,9 +379,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     Zenodo deposition id. Unaffected profiles — every one with at most one
     provider per capability name, which is all six shipped formations — keep the
     id they had.
-  - **No change to the mounter, the overlay stack semantics, or the lockfile
-    schema.** Only which layer is chosen as a requirement's provider, and
-    therefore the sequence stage 8 numbers.
+  - **`strata diff` does not report a mount-order change**, so the tool a user
+    reaches for to answer "what changed between these two lockfiles" cannot
+    answer it for the change this entry describes. `diffLayers` keys both
+    lockfiles by layer name and compares `Version` and `SHA256` only
+    (`cmd/strata/diff.go:152-182`); `MountOrder` is in neither the key nor the
+    comparison, so a re-resolve whose only effect is a reordering is reported as
+    a set of unchanged layers. This is a pre-existing limitation of `diff` (#154)
+    that this fix makes reachable, not a behaviour introduced here. Measured
+    against a resolver-produced lockfile and a copy with its two `mount_order`
+    values swapped and nothing else altered:
+    - **unfrozen**, which is what `strata resolve` emits — `ami_sha256` is empty,
+      so `EnvironmentID()` returns `""` for both sides
+      (`spec/lockfile_hash.go:100-102`) and the id comparison is skipped:
+      **exit 0, `No differences found.`**
+    - **frozen**: **exit 1**, an `EnvironmentID: 45ef2726… → c6489460…` line
+      followed by `Layers (2 unchanged)` — the identity changed, every layer is
+      reported unchanged, and no field is named as the cause.
+
+    ```sh
+    go build -o /tmp/strata ./cmd/strata
+    go run ./internal/testregistry/mkregistry /tmp/fx
+    STRATA_REGISTRY_URL=file:///tmp/fx/registry \
+      /tmp/strata resolve /tmp/fx/profiles/offline-minimal.yaml -o /tmp/a.yaml
+    sed 's/mount_order: 1/mount_order: 9/; s/mount_order: 2/mount_order: 1/; s/mount_order: 9/mount_order: 2/' \
+      /tmp/a.yaml > /tmp/b.yaml
+    diff /tmp/a.yaml /tmp/b.yaml          # exactly the two mount_order lines
+    /tmp/strata diff /tmp/a.yaml /tmp/b.yaml; echo "exit $?"   # unfrozen
+    for f in a b; do sed "s/ami_sha256: \"\"/ami_sha256: $(printf 'a%.0s' $(seq 64))/" \
+      /tmp/$f.yaml > /tmp/f$f.yaml; done
+    /tmp/strata diff /tmp/fa.yaml /tmp/fb.yaml; echo "exit $?"  # frozen
+    ```
+  - **No change to the mounter, the overlay stack semantics, the lockfile schema,
+    or the set of layers in a lockfile.** Stage 6 orders the layers it is given;
+    it does not choose which ones are present, so an affected profile resolves to
+    the same layers with different `mount_order` values. What that reordering
+    then means is unchanged but not nothing: `lowerdir` is assembled highest
+    `MountOrder` first (`internal/overlay/mount_fuse_linux.go:40-48`), so which
+    layer's copy of a shared path is the visible one follows mount order, and
+    `internal/export/oci.go:47-78` emits OCI diff layers in ascending
+    `MountOrder`, so an affected profile's exported image lists its layers in a
+    different sequence.
 
 ### Changed
 - **Three test controls that could not detect the fixes they guarded are removed,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -336,6 +336,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `newClientForURL`. A `file://` registry also no longer reaches for SSM when
   probing the base OS, which would have traded the missing lockfile for an IMDS
   timeout. Completes the two work items left unchecked in #36.
+- **Two layers providing the same capability no longer make resolution depend on
+  the order they were listed** (#67). The defect was one disagreement showing up
+  in two stages, which is why one commit fixes both — separated, the first fix
+  doubles the exposure of the second.
+
+  `spec.BaseCapabilities.SatisfiesRequirement` decided on the *first* entry whose
+  name matched, so a set containing `python@3.9` before `python@3.13` was reported
+  as failing `python >= 3.10` even though a satisfying provider was present, and
+  stage 4 rejected a satisfiable profile. `stage6TopoSort` assigned
+  `capProviderIdx[cap.Name] = i` with no version check at all, so the *last*
+  provider of a name won the dependency edge — stage 4 could validate a
+  requirement against one provider while stage 6 wired the consumer to a
+  different, non-satisfying one, which puts a layer ahead of the layer it needs in
+  the OverlayFS stack. Both rules are now one predicate, `spec.Capability.Satisfies`,
+  so they cannot drift apart again; the edge is chosen by highest satisfying
+  version with ties broken by lowest layer ID, which makes it a function of the
+  capabilities rather than of the order a profile author typed.
+  `BaseCapabilities.HasCapability` had the same first-match shape and no shipped
+  caller; it is fixed rather than left as a trap for the first one.
+
+  **Which resolutions change**, and the shapes are reachable today even though no
+  shipped formation is one of them — `ls cmd/strata/formations/*.yaml | wc -l`
+  gives 6 and none contains two providers of one capability name:
+  - **A profile naming two versions of the same software** now resolves where it
+    could previously fail, and may mount in a different order. Eight recipes ship
+    more than one version —
+    `ls -d cmd/strata/recipes/*/*/*/ | awk -F/ '{print $5}' | sort | uniq -d`
+    lists `cuda gcc hdf5 julia nodejs openblas python R` — and stage 5 permits
+    them to coexist, both having the default versioned layout.
+  - **A profile naming two different packages that provide one capability**, the
+    same. `grep -l 'name: htslib' cmd/strata/recipes/*/*/*/meta.yaml` names the
+    one such pair in the shipped catalogue, `bcftools` and `samtools`.
+  - **`environment_id` changes for any lockfile whose mount order changes.** The
+    identity hashes layers in mount sequence (`spec/lockfile_hash.go:99-110`), so
+    a re-resolve of an affected profile produces a different id — which is the
+    published lockfile's storage key (`locks/<id>.yaml` in both
+    `internal/registry/s3client.go:617` and `localclient.go:374`), the
+    `strata:environment-id` instance tag, the OCI `image.revision` label and the
+    Zenodo deposition id. Unaffected profiles — every one with at most one
+    provider per capability name, which is all six shipped formations — keep the
+    id they had.
+  - **No change to the mounter, the overlay stack semantics, or the lockfile
+    schema.** Only which layer is chosen as a requirement's provider, and
+    therefore the sequence stage 8 numbers.
 
 ### Changed
 - **Three test controls that could not detect the fixes they guarded are removed,

--- a/internal/resolver/provider_matrix_test.go
+++ b/internal/resolver/provider_matrix_test.go
@@ -4,23 +4,35 @@ package resolver
 // completeness), both of which stood SOUND with a Basis of `none` — asserted by
 // the document and executed by nothing.
 //
-// Both are refuted by issue #67, whose two halves live in different stages:
+// Both were refuted by issue #67, whose two halves lived in different stages:
 //
-//	stage 4 (R5) `spec.BaseCapabilities.SatisfiesRequirement` walks Provides and
-//	  decides on the FIRST entry whose name matches, so a satisfiable profile is
-//	  rejected when a non-satisfying provider of the same capability name is
+//	stage 4 (R5) `spec.BaseCapabilities.SatisfiesRequirement` walked Provides and
+//	  decided on the FIRST entry whose name matched, so a satisfiable profile was
+//	  rejected when a non-satisfying provider of the same capability name was
 //	  merged in first.
-//	stage 6 (R4) `stage6TopoSort` builds `capProviderIdx[cap.Name] = i` in a
-//	  nested loop with no guard, so the LAST provider of a capability wins the
+//	stage 6 (R4) `stage6TopoSort` built `capProviderIdx[cap.Name] = i` in a
+//	  nested loop with no guard, so the LAST provider of a capability won the
 //	  dependency edge irrespective of version.
 //
+// Both are fixed as of #67, and the counts below are now zero. That changes what
+// this file is for without changing a line of its structure: it was a
+// reproduction, and it is now a regression barrier. The distinction matters when
+// reading a failure — a nonzero count here no longer means "the defect is where
+// we said it was", it means the defect is back.
+//
 // These tests enumerate a declared, finite domain of the shipping resolver
-// rather than sampling it, so what they establish is the exact boundary of the
-// defect: which cells violate and which hold. That makes the refutation
-// reproducible, which is what #67's register row needs in order to be
-// dischargeable at all — and it makes the tests fail in BOTH directions. A
-// regression widens the violating set; a fix empties it. Either way the stated
-// counts stop matching and someone has to look.
+// rather than sampling it, so what they establish is the exact boundary: which
+// cells violate and which hold. That is what made the refutation reproducible,
+// which is what #67's register row needed in order to be dischargeable at all —
+// and it makes the tests fail in BOTH directions. A regression makes a count
+// nonzero; a change in the enumeration makes the cardinality mismatch. Either
+// way the stated numbers stop matching and someone has to look.
+//
+// One assertion is deliberately NOT a count: stage 4's verdict is now asserted
+// to be the same for both provider orders of the same pair. A count of known
+// defects has to be maintained by hand and says nothing once it reaches zero,
+// whereas order-independence is the property the fix actually established and it
+// stays falsifiable forever.
 //
 // The version oracle here is deliberately NOT the implementation's semverGTE and
 // semverLT. Expectations computed with the code under test would hold by
@@ -113,23 +125,57 @@ func consumer(req spec.Requirement) resolvedLayer {
 //
 // The converse is asserted too, and it is what stops R5 being "fixed" by never
 // rejecting anything: when NO provider satisfies, stage 4 must reject.
+//
+// Since the fix, the load-bearing assertion is neither of those counts but
+// order-independence: the same pair of providers must produce the same verdict in
+// either slice order. A count of known defects stops discriminating once it is
+// zero — every implementation that rejects nothing scores zero too — whereas the
+// order comparison has no such fixed point.
 func TestStage4ProviderCompleteness(t *testing.T) {
 	// Cardinality is stated rather than derived from the same slices the loops
 	// iterate: computing it from len(versions)*len(versions)*len(reqs)*2 would
 	// let a dropped dimension value shrink both sides and pass.
 	const wantCells = 72
-	// #67's stage-4 half. This is a count of KNOWN DEFECTS: it must go to zero
-	// when #67 is fixed, and this test must then be updated on purpose.
-	const wantViolations = 12
+	// #67's stage-4 half, fixed: SatisfiesRequirement now scans every provider
+	// instead of deciding on the first name match. This was 12 — the cells where a
+	// satisfiable set was rejected because the first provider of the name did not
+	// satisfy — and it is a count of KNOWN DEFECTS, so zero is the post-fix value
+	// and any nonzero is a regression.
+	const wantViolations = 0
+	// Non-vacuity bound for the order-independence assertion, which compares two
+	// verdicts and therefore asserts nothing about a pair whose providers agree.
+	// A pair discriminates only when exactly one of the two satisfies: 4 for each
+	// of the three constrained requirements (satisfying set size s of 3 gives
+	// 2*s*(3-s) discordant ordered pairs, so 4, 4, 4) and 0 for the unconstrained
+	// one, where all three satisfy. That is the same 12 wantViolations used to
+	// hold, and not by coincidence — a discordant pair has exactly one order whose
+	// first provider fails, which is exactly what produced one violating cell. The
+	// arithmetic is why the assertion can REPLACE the count rather than sit
+	// alongside it.
+	const wantDiscriminating = 12
 
 	versions := matrixVersions()
 	reqs := matrixRequirements()
 	base := &spec.BaseCapabilities{} // Provides nothing, so the layer path decides.
 
-	cells, violations, satisfiableCells := 0, 0, 0
+	cells, violations, satisfiableCells, discriminating := 0, 0, 0, 0
 	for _, vA := range versions {
 		for _, vB := range versions {
 			for _, req := range reqs {
+				// Stage 4's verdict must not depend on which of the two
+				// providers comes first in the slice. This is the property the
+				// stage-4 half actually broke, and it is asserted instead of
+				// merely counted because it survives the fix: a count of known
+				// defects says nothing once it reaches zero, whereas this stays
+				// falsifiable forever. On the first-match implementation the two
+				// orders disagree in exactly the 12 cells wantViolations used to
+				// hold, so this assertion subsumes that count rather than
+				// duplicating it.
+				accepted := make(map[bool]bool, 2)
+				if satisfiesOracle(t, vA, req) != satisfiesOracle(t, vB, req) {
+					discriminating++
+				}
+
 				for _, aFirst := range []bool{true, false} {
 					cells++
 
@@ -146,6 +192,7 @@ func TestStage4ProviderCompleteness(t *testing.T) {
 						satisfiableCells++
 					}
 					err := (&Resolver{}).stage4ValidateGraph(base, layers)
+					accepted[aFirst] = err == nil
 					name := req.String() + " providers=" + firstVersion + " then " +
 						map[bool]string{true: vB, false: vA}[aFirst]
 
@@ -159,18 +206,19 @@ func TestStage4ProviderCompleteness(t *testing.T) {
 						// looks at order.
 						if satisfiesOracle(t, firstVersion, req) {
 							t.Errorf("%s: stage 4 rejected a satisfiable set whose FIRST provider satisfies (%v); "+
-								"R5 is violated by a mechanism other than #67's first-match", name, err)
+								"R5 is violated by a mechanism other than the old first-match", name, err)
 						}
 					case !satisfiable && err == nil:
 						t.Errorf("%s: no provider satisfies the constraint and stage 4 accepted; "+
 							"totality is broken, or R5 was 'fixed' by never rejecting", name)
-					case satisfiable && err == nil:
-						// R5 holds here, and it must be for the right reason.
-						if !satisfiesOracle(t, firstVersion, req) {
-							t.Errorf("%s: stage 4 accepted although the first provider does not satisfy; "+
-								"#67's stage-4 half no longer reproduces — update wantViolations", name)
-						}
 					}
+				}
+
+				if accepted[true] != accepted[false] {
+					t.Errorf("%s providers={%s,%s}: stage 4 accepts with one provider first and "+
+						"rejects with the other (a-first accepted=%v, b-first accepted=%v); "+
+						"the verdict depends on slice order",
+						req.String(), vA, vB, accepted[true], accepted[false])
 				}
 			}
 		}
@@ -180,15 +228,26 @@ func TestStage4ProviderCompleteness(t *testing.T) {
 		t.Errorf("enumerated %d cells, want %d", cells, wantCells)
 	}
 	if violations != wantViolations {
-		t.Errorf("R5 violated in %d cells, want %d (#67's stage-4 half). "+
-			"Fewer means the defect is being fixed and this test needs updating on purpose; "+
-			"more means a regression", violations, wantViolations)
+		t.Errorf("R5 violated in %d cells, want %d. #67's stage-4 half is fixed, so nonzero "+
+			"here is a regression: a satisfiable requirement is being rejected. Do not restate "+
+			"this constant to match — SatisfiesRequirement must scan every provider",
+			violations, wantViolations)
 	}
 	// Non-vacuity: an oracle that called nothing satisfiable would make every
 	// R5 assertion above unreachable while the table still passed.
 	if satisfiableCells == 0 || satisfiableCells == cells {
 		t.Errorf("%d of %d cells are satisfiable; a table with no mix of both cannot "+
 			"exercise R5 and its converse", satisfiableCells, cells)
+	}
+	// Non-vacuity for the order-independence assertion specifically. Stated as an
+	// exact count rather than >0 because both directions are informative: fewer
+	// discriminating pairs means the version domain or the constraint domain lost
+	// the asymmetry the assertion needs, and more means the domain grew and the
+	// arithmetic in the constant's derivation no longer describes it.
+	if discriminating != wantDiscriminating {
+		t.Errorf("%d of %d (vA,vB,req) combinations have exactly one satisfying provider, want %d; "+
+			"only those can falsify order-independence, so a change here changes what that "+
+			"assertion covers", discriminating, len(versions)*len(versions)*len(reqs), wantDiscriminating)
 	}
 }
 
@@ -233,13 +292,24 @@ func permutations(items []string) [][]string {
 //
 //	stage 5 must not reject the two same-name providers (it does not: both have
 //	  the default InstallLayout, so canCoexist exempts them), and
-//	stage 4 must accept, which it only does when the first mpi provider in slice
-//	  order satisfies — so #67's stage-4 half MASKS its stage-6 half in half the
-//	  permutations, and the reachable count is stated below.
+//	stage 4 must accept, which before the fix it only did when the first mpi
+//	  provider in slice order satisfied — so the stage-4 half MASKED the stage-6
+//	  half in half the permutations. Fixing stage 4 unmasks them, which is why the
+//	  reachable count below went from 12 to 24 in the same change that took
+//	  violations to zero. The two halves were coupled through this number, and
+//	  that coupling is the reason they had to be fixed together: closing stage 4
+//	  alone would have doubled the exposure of stage 6.
 func TestStage6ProviderSoundness(t *testing.T) {
-	const wantCells = 24     // 4! input orders.
-	const wantReachable = 12 // Those stage 4 accepts: mpi-3 before mpi-1.
-	const wantViolations = 3 // #67's stage-6 half, at min-index tie-breaking.
+	const wantCells = 24 // 4! input orders.
+	// Every order now reaches stage 6, because stage 4 no longer rejects on the
+	// basis of which provider comes first. This was 12 — the orders with mpi-3
+	// ahead of mpi-1 — and the change from 12 to 24 is the masking being removed,
+	// not the domain growing.
+	const wantReachable = 24
+	// #67's stage-6 half, fixed: the edge is chosen by highest satisfying version
+	// (ties by lowest layer ID) instead of by whichever provider happened to be
+	// assigned last. This was 3.
+	const wantViolations = 0
 
 	build := func(name string) resolvedLayer {
 		switch name {
@@ -280,8 +350,15 @@ func TestStage6ProviderSoundness(t *testing.T) {
 
 		r := &Resolver{}
 		if err := r.stage4ValidateGraph(base, layers); err != nil {
-			// Masked by #67's other half. Recorded, not asserted clean: the
-			// rejection is itself an R5 violation, enumerated by the test above.
+			// Before #67 this was the masking path and was recorded rather than
+			// asserted clean, the rejection being an R5 violation enumerated by
+			// the test above. It is now a fault in its own right: mpi-3 satisfies
+			// mpi>=2.0.0 in every one of these orders, so a rejection here means
+			// stage 4 has regressed to deciding on slice order. Asserted per-order
+			// as well as counted below, because "12 reached stage 6, want 24" does
+			// not say WHICH orders stopped or why.
+			t.Errorf("%s: stage 4 rejected a set in which mpi-3 satisfies mpi>=2.0.0 (%v); "+
+				"the stage-4 half has regressed and is masking this table again", label, err)
 			continue
 		}
 		reachable++
@@ -314,9 +391,12 @@ func TestStage6ProviderSoundness(t *testing.T) {
 			// The harm, spelled out so the failure is legible without the
 			// issue: the consumer requires mpi>=2.0.0, mpi-3 is the only
 			// provider satisfying that, and the consumer mounts first.
+			t.Errorf("%s: consumer (requires mpi>=2.0.0) sorts at %d, before its only satisfying "+
+				"provider mpi-3 at %d; the dependency edge points at the wrong layer",
+				label, pos["consumer"], pos["mpi-3"])
 			if pos["mpi-1"] >= pos["consumer"] {
-				t.Errorf("%s: consumer sorts before mpi-3 and NOT after mpi-1 either; "+
-					"R4 is violated by a mechanism other than #67's last-wins index", label)
+				t.Errorf("%s: and NOT after mpi-1 either; R4 is violated by a mechanism other "+
+					"than the old last-wins index", label)
 			}
 		}
 	}
@@ -325,17 +405,135 @@ func TestStage6ProviderSoundness(t *testing.T) {
 		t.Errorf("enumerated %d input orders, want %d", cells, wantCells)
 	}
 	if reachable != wantReachable {
-		t.Errorf("%d cells reached stage 6, want %d; #67's stage-4 half masks the rest, "+
-			"so a change here means one of the two halves moved", reachable, wantReachable)
+		t.Errorf("%d cells reached stage 6, want %d; every input order must reach it now that "+
+			"stage 4 is order-independent, so fewer means the stage-4 half regressed and is "+
+			"masking this table", reachable, wantReachable)
 	}
 	if violations != wantViolations {
-		t.Errorf("R4 violated in %d of %d reachable cells, want %d (#67's stage-6 half). "+
-			"Zero means the defect is fixed and this test needs updating on purpose",
-			violations, reachable, wantViolations)
+		t.Errorf("R4 violated in %d of %d reachable cells, want %d. #67's stage-6 half is fixed, "+
+			"so nonzero here is a regression: the edge is being drawn to a provider that does not "+
+			"satisfy. Do not restate this constant to match", violations, reachable, wantViolations)
 	}
 	// Non-vacuity, stated separately from the count above: a table where nothing
 	// reached stage 6 would report zero violations and look like a clean pass.
 	if reachable == 0 {
 		t.Error("no cell reached stage 6; every R4 assertion above was unreachable")
+	}
+}
+
+// TestStage6SelectsHighestSatisfyingProvider pins the selection rule, which R4
+// does not constrain and which #67's fix therefore had to choose.
+//
+// R4 only requires the edge to point at SOME satisfying provider. When two
+// providers both satisfy, that leaves the choice open, and the two candidates are
+// not equivalent: "first satisfying in slice order" is a function of the order the
+// profile author listed the layers, while "highest satisfying version" is a
+// function of the capabilities alone. Since the edge determines mount order and
+// mount order goes into the lockfile, the first rule would make the lockfile
+// depend on an author-visible ordering — the same class of defect as #67 itself.
+// So the rule is highest version, ties broken by lowest layer ID, and this test
+// is what holds it in place.
+//
+// TestStage6ProviderSoundness cannot do that job: there, mpi-1 does not satisfy
+// mpi>=2.0.0, so every rule that picks a satisfying provider picks mpi-3 and the
+// two candidate rules are indistinguishable. Here BOTH providers satisfy, and
+// that premise is asserted rather than assumed.
+//
+//	yy-provider  provides yy
+//	mpi-3        provides mpi@3.0.0, requires yy   <- highest; blocked behind yy
+//	mpi-2        provides mpi@2.0.0                <- also satisfies mpi>=2.0.0
+//	consumer     requires mpi>=2.0.0
+//
+// mpi-3 is blocked behind yy-provider for the same reason as in the soundness
+// table, and the reason is worth restating because without it this test passes
+// under both rules: with no prerequisite, the consumer is the only layer with any
+// in-degree, so Kahn's algorithm emits it last whichever provider owns the edge
+// and the wrong choice is invisible. The block gives the wrong edge a way to
+// release the consumer early.
+func TestStage6SelectsHighestSatisfyingProvider(t *testing.T) {
+	const wantCells = 24 // 4! input orders.
+
+	req := spec.Requirement{Name: capName, MinVersion: "2.0.0"}
+	if !satisfiesOracle(t, "2.0.0", req) || !satisfiesOracle(t, "3.0.0", req) {
+		t.Fatalf("both providers must satisfy %s, or this table cannot distinguish "+
+			"highest-version selection from first-in-slice selection", req)
+	}
+
+	build := func(name string) resolvedLayer {
+		switch name {
+		case "yy-provider":
+			return resolvedLayer{manifest: &spec.LayerManifest{
+				ID: name, Name: name, Version: "1.0.0",
+				Provides: []spec.Capability{{Name: "yy", Version: "1.0.0"}},
+			}}
+		case "mpi-3":
+			l := provider(name, "3.0.0")
+			l.manifest.Requires = []spec.Requirement{{Name: "yy"}}
+			return l
+		case "mpi-2":
+			return provider(name, "2.0.0")
+		case "consumer":
+			return consumer(req)
+		default:
+			t.Fatalf("no fixture for %q", name)
+			return resolvedLayer{}
+		}
+	}
+
+	base := &spec.BaseCapabilities{}
+	cells := 0
+	for _, order := range permutations([]string{"yy-provider", "mpi-3", "mpi-2", "consumer"}) {
+		cells++
+		layers := make([]resolvedLayer, 0, len(order))
+		for _, name := range order {
+			layers = append(layers, build(name))
+		}
+		label := ""
+		for i, name := range order {
+			if i > 0 {
+				label += " "
+			}
+			label += name
+		}
+
+		r := &Resolver{}
+		// Both premises asserted per-order, because either one failing would make
+		// the assertion below unreachable for that order while the loop still ran
+		// to completion and the test still passed.
+		if err := r.stage4ValidateGraph(base, layers); err != nil {
+			t.Errorf("%s: stage 4 rejected a set where both mpi providers satisfy (%v)", label, err)
+			continue
+		}
+		if err := r.stage5DetectConflicts(layers); err != nil {
+			t.Fatalf("%s: stage 5 rejected two coexisting mpi providers (%v); the selection "+
+				"rule's domain is unreachable and this table would be vacuous", label, err)
+		}
+
+		ordered, err := r.stage6TopoSort(layers)
+		if err != nil {
+			t.Fatalf("%s: stage 6 failed: %v", label, err)
+		}
+		pos := make(map[string]int, len(ordered))
+		for i, rl := range ordered {
+			pos[rl.manifest.ID] = i
+		}
+		if len(pos) != len(layers) {
+			t.Fatalf("%s: stage 6 output names %d distinct layers, want %d", label, len(pos), len(layers))
+		}
+
+		// The observable consequence of selecting mpi-3: the consumer inherits
+		// mpi-3's own prerequisite and cannot mount before it. Under a
+		// first-satisfying rule the edge points at mpi-2 in the orders where mpi-2
+		// precedes mpi-3, and the consumer is released as soon as mpi-2 is emitted
+		// — ahead of mpi-3 in some of them.
+		if pos["consumer"] < pos["mpi-3"] {
+			t.Errorf("%s: consumer sorts at %d, before mpi-3 at %d; the edge was drawn to "+
+				"mpi-2 (also satisfying, lower version), so selection is following slice "+
+				"order rather than version", label, pos["consumer"], pos["mpi-3"])
+		}
+	}
+
+	if cells != wantCells {
+		t.Errorf("enumerated %d input orders, want %d", cells, wantCells)
 	}
 }

--- a/internal/resolver/stages.go
+++ b/internal/resolver/stages.go
@@ -251,6 +251,52 @@ func (r *Resolver) stage5DetectConflicts(layers []resolvedLayer) error {
 	return nil
 }
 
+// selectProvider returns the index of the layer, among cands, whose capability
+// best satisfies req. The bool reports whether any candidate satisfies it at all
+// — false means no dependency edge is drawn, which is correct when the
+// requirement is met by the base image instead.
+//
+// Selection is by highest satisfying version, ties broken by lowest layer ID.
+// Both parts are deliberate, and the alternative is worth naming because it
+// looks simpler: picking the FIRST satisfying candidate would also close #67 as
+// stated, since the stated property is only that the consumer sorts after a
+// provider that satisfies it. It was rejected because cands is in layer slice
+// order, which comes from the order the profile author listed the layers. That
+// would leave the dependency edge — and therefore mount order, and therefore the
+// lockfile — a function of an author-visible ordering rather than of content,
+// which is the same order-dependence class as the defect being fixed. Highest
+// version is a function of the capabilities alone, and the ID tie-break makes it
+// total, so two profiles naming the same layers in different orders resolve
+// identically.
+//
+// Highest is also the defensible semantic on its own: given two providers that
+// both satisfy a constraint, the newer is the one a user asking for ">= X"
+// expects to be wired to.
+func selectProvider(layers []resolvedLayer, cands []int, req spec.Requirement) (int, bool) {
+	best, bestVersion := -1, ""
+	for _, idx := range cands {
+		for _, cap := range layers[idx].manifest.Provides {
+			if !cap.Satisfies(req) {
+				continue
+			}
+			if best >= 0 {
+				cmp := spec.CompareVersions(cap.Version, bestVersion)
+				if cmp < 0 {
+					continue
+				}
+				if cmp == 0 && layers[idx].manifest.ID >= layers[best].manifest.ID {
+					continue
+				}
+			}
+			best, bestVersion = idx, cap.Version
+		}
+	}
+	if best < 0 {
+		return 0, false
+	}
+	return best, true
+}
+
 // stage6TopoSort performs a topological sort of layers based on their
 // capability dependency edges using Kahn's algorithm. The returned slice
 // is in dependency order (dependencies before dependents). MountOrder
@@ -261,12 +307,19 @@ func (r *Resolver) stage6TopoSort(layers []resolvedLayer) ([]resolvedLayer, erro
 		return layers, nil
 	}
 
-	// Map capability name → layer index for resolving which layer satisfies
-	// a requirement (used to build dependency edges).
-	capProviderIdx := make(map[string]int, n*4)
+	// Map capability name → every layer index providing it, for resolving which
+	// layer satisfies a requirement (used to build dependency edges).
+	//
+	// Every provider is kept. The previous form was a map[string]int assigned
+	// inside this loop, so the LAST provider of a name won the edge with no
+	// version check at all — #67's stage-6 half. Stage 4 would validate the
+	// requirement against a satisfying provider and stage 6 would wire the
+	// dependency to a different, non-satisfying one, which puts the consumer
+	// ahead of the layer it needs in mount order.
+	capProviders := make(map[string][]int, n*4)
 	for i, rl := range layers {
 		for _, cap := range rl.manifest.Provides {
-			capProviderIdx[cap.Name] = i
+			capProviders[cap.Name] = append(capProviders[cap.Name], i)
 		}
 	}
 
@@ -278,7 +331,7 @@ func (r *Resolver) stage6TopoSort(layers []resolvedLayer) ([]resolvedLayer, erro
 	for i, rl := range layers {
 		seen := make(map[int]bool)
 		for _, req := range rl.manifest.Requires {
-			j, ok := capProviderIdx[req.Name]
+			j, ok := selectProvider(layers, capProviders[req.Name], req)
 			if !ok || j == i || seen[j] {
 				continue // satisfied by base, self-dep, or already counted
 			}

--- a/spec/layer.go
+++ b/spec/layer.go
@@ -173,31 +173,58 @@ type BaseCapabilities struct {
 	Provides []Capability `yaml:"provides" json:"provides"`
 }
 
+// Satisfies reports whether c satisfies r: the names match and c's version is
+// within r's bounds. MinVersion is inclusive, MaxVersion exclusive, and an empty
+// bound is unbounded in that direction.
+//
+// This is the single definition of capability satisfaction. It exists because
+// #67 was two stages disagreeing about it: stage 4 compared versions and stage 6
+// did not, so a profile could be validated against one provider and wired to
+// another. Three call sites walked a Provides slice with their own inline
+// version logic; they now share this one, which is what stops the two rules
+// drifting apart again rather than merely realigning them once.
+func (c Capability) Satisfies(r Requirement) bool {
+	if c.Name != r.Name {
+		return false
+	}
+	if r.MinVersion != "" && !semverGTE(c.Version, r.MinVersion) {
+		return false
+	}
+	if r.MaxVersion != "" && !semverLT(c.Version, r.MaxVersion) {
+		return false
+	}
+	return true
+}
+
+// CompareVersions compares two dotted version strings numerically, returning
+// -1, 0 or 1 analogous to strings.Compare. Exported so callers outside this
+// package can rank providers by version without reimplementing the comparison
+// — internal/resolver needs it to pick among several satisfying providers, and a
+// second implementation there would be a second chance to disagree.
+func CompareVersions(a, b string) int { return compareVersions(a, b) }
+
 // HasCapability reports whether the base provides the named capability
 // at or above the specified minimum version.
 // An empty minVersion means any version satisfies.
+//
+// Scans every entry rather than deciding on the first name match: a base
+// providing mpi@1.0.0 and mpi@3.0.0 in that order satisfies mpi >= 2.0.0. No
+// shipped caller reaches this today (only tests do), but it is exported, and the
+// first-match form was the same defect as #67's stage-4 half waiting for a
+// caller — so it is fixed here rather than left as a trap.
 func (b BaseCapabilities) HasCapability(name, minVersion string) bool {
-	for _, cap := range b.Provides {
-		if cap.Name == name {
-			if minVersion == "" {
-				return true
-			}
-			return semverGTE(cap.Version, minVersion)
-		}
-	}
-	return false
+	return b.SatisfiesRequirement(Requirement{Name: name, MinVersion: minVersion})
 }
 
 // SatisfiesRequirement reports whether the base satisfies a Requirement.
+//
+// Any provider satisfying r is enough. The previous form returned on the first
+// entry whose NAME matched, so a base providing python@3.9 before python@3.13
+// was reported as failing python >= 3.10 even though a satisfying provider was
+// present — #67's stage-4 half, which could reject a satisfiable profile.
 func (b BaseCapabilities) SatisfiesRequirement(r Requirement) bool {
 	for _, cap := range b.Provides {
-		if cap.Name == r.Name {
-			if r.MinVersion != "" && !semverGTE(cap.Version, r.MinVersion) {
-				return false
-			}
-			if r.MaxVersion != "" && !semverLT(cap.Version, r.MaxVersion) {
-				return false
-			}
+		if cap.Satisfies(r) {
 			return true
 		}
 	}


### PR DESCRIPTION
Closes #67.

## The travels-alone exception, stated as required

The house rule is one repair per PR. This PR carries **two** root causes, which
#67's instruction comment
(https://github.com/scttfrdmn/strata/issues/67#issuecomment-5383141375)
pre-authorised as the first named exception. The rule yields because splitting
produces a **broken intermediate state**, not because the two changes are
related:

- A PR fixing stage 4 alone leaves `TestStage6ProviderSoundness` red on a
  correct tree — stage 6's expectations are stated over the cells stage 4 lets
  through, so `wantReachable` goes 12 → 24 the moment stage 4 stops rejecting.
  The only way to green it is to restate stage 6's constants to describe a state
  that PR does not produce.
- A PR fixing stage 6 alone leaves satisfiable profiles rejected, i.e. the
  user-visible half untouched.

That comment's two `path:line` citations (`spec/layer.go:192-205`,
`internal/resolver/stages.go:266-269`) describe pre-fix line numbers and no
longer point at the code they name; they are correct as of the tree they were
written against.

## What was wrong

| Stage | Site | Behaviour |
|---|---|---|
| 4 | `spec.BaseCapabilities.SatisfiesRequirement` | Decided on the **first** entry whose name matched, so `python@3.9` listed before `python@3.13` was reported as failing `python >= 3.11` — a satisfiable profile rejected. |
| 6 | `stage6TopoSort` | `capProviderIdx[cap.Name] = i` with no version check, so the **last** provider won the dependency edge — a consumer could be ordered ahead of the only layer that satisfies it. |

The two are one disagreement about what satisfies a requirement. They are now
one predicate, `spec.Capability.Satisfies`, which is what stops them drifting
apart again rather than merely realigning them once.

## A third site, disclosed

`BaseCapabilities.HasCapability` had the same first-match shape. It has **no
shipped caller** —

```
$ grep -rn 'HasCapability' --include='*.go' . | grep -v '_test.go' | grep -v 'spec/layer.go'
(no output)
$ grep -rn 'HasCapability' --include='*.go' . | grep -vc '_test.go'
2          # the doc comment and the definition, both in spec/layer.go
```

(The first form published here filtered on `'^./spec/layer.go'`. `grep -rn ...  .`
prints paths without the `./` prefix on this platform, so that filter matched
nothing and the command printed the two `spec/layer.go` lines rather than
nothing. The claim was right and the command did not demonstrate it; the count on
the second line is what makes the empty first line a measurement.)

— but it is exported, so the first-match form was #67's stage-4 half waiting for
a caller. Fixed here rather than left as a trap. It now delegates to
`SatisfiesRequirement`, and the two **inherited** tests that exercise it
(`spec/spec_test.go:292`, `internal/probe/probe_test.go:219`) pass unchanged —
no inherited test is edited by this PR.

## The selection rule, argued rather than assumed

R4 only requires the edge to point at *some* satisfying provider. When two
providers both satisfy, that leaves the choice open, and the candidates are not
equivalent:

- **First satisfying in slice order** — rejected. `cands` arrives in the order
  the profile author listed the layers, so this would leave the dependency edge,
  and therefore mount order, and therefore `environment_id`, a function of an
  author-visible ordering. That is the same order-dependence class as the defect
  being fixed.
- **Highest satisfying version, ties by lowest layer ID** — chosen. A function
  of the capabilities alone, total (so two profiles naming the same layers in
  different orders resolve identically), and the defensible semantic on its own:
  given two providers that both satisfy `>= X`, the newer is the one the user
  asking for `>= X` expects.

The rejected alternative would have closed #67 as stated. That is exactly why it
needs a test of its own — see M3 below.

## Evidence

### Constants restated, with the derivation

| Constant | Was | Now | Why |
|---|---|---|---|
| `wantCells` (stage 4) | 72 | 72 | Domain unchanged. |
| `wantViolations` (stage 4) | 12 | **0** | The 12 cells were a satisfiable set rejected because the first provider of the name did not satisfy. |
| `wantCells` (stage 6) | 24 | 24 | 4! input orders, unchanged. |
| `wantReachable` (stage 6) | 12 | **24** | The masking removed. Stage 4 no longer rejects on provider order, so every input order reaches stage 6. This is the coupling, not a domain change. |
| `wantViolations` (stage 6) | 3 | **0** | The edge is now chosen by version. |

`grep -n 'wantCells\|wantReachable\|wantViolations\|wantDiscriminating' internal/resolver/provider_matrix_test.go`
reproduces these in the reader's tree at this branch's head.

### Two assertions that are not counts

A defect count stops discriminating once it reaches zero — an implementation
that rejects *nothing* also scores zero. So the counts are kept as regression
barriers and two properties carry the weight:

1. **Order-independence** (stage 4): the same provider pair must yield the same
   verdict in either slice order. No fixed point, so it stays falsifiable
   forever. Guarded against vacuity by `wantDiscriminating = 12` — a pair where
   both providers agree asserts nothing, and only 12 of the 36 `(vA,vB,req)`
   combinations have exactly one satisfying provider. That 12 derives to the
   same 12 the old violation count held, which is why the property can *replace*
   the count rather than sit beside it.
2. **`TestStage6SelectsHighestSatisfyingProvider`** (new): pins the selection
   rule. `TestStage6ProviderSoundness` cannot do this job — only `mpi-3`
   satisfies `mpi>=2.0.0` there, so every rule that picks a satisfying provider
   passes it. The new table gives both providers a satisfying version, and keeps
   the `yy-provider` blocking trick because without a prerequisite the consumer
   is the only layer with in-degree and Kahn's algorithm emits it last under
   either rule — the wrong choice would be invisible.

### Mutation probe: each assertion reverted, red sets pre-registered

Patch applied is digest-asserted, the mutant is asserted to **build** before any
verdict is read (a build failure exits 1 exactly as a caught defect does),
restore is `git checkout` and the worktree is asserted clean afterwards, and the
unmutated baseline is asserted green first.

| Mutation | Pre-registered red set | Result |
|---|---|---|
| M1 — stage 4 back to first-name-match | stage-4 table, stage-6 soundness | matched. 12 order-independence errors + `R5 violated in 12 cells, want 0` + `12 cells reached stage 6, want 24` |
| M2 — stage 6 back to `capProviderIdx` last-wins | stage-6 soundness, selection | matched. `R4 violated in 3 of 24 reachable cells, want 0` |
| M3 — selection = **first** satisfying instead of highest | selection **only** | matched. `consumer sorts at 1, before mpi-3 at 3` in 3 of 24 orders |

M3 is the load-bearing one: it is the only probe that reddens anything, and it
reddens **only** the new test. Without that test, shipping the rejected
alternative would have been invisible.

Two harness defects were found and fixed before these results were read, and
both are the kind that make a probe report success over nothing:

- The first run created its worktree at `HEAD` — the **pre-fix** tree — so all
  three mutations failed to apply and the "baseline green" line was measuring a
  different tree entirely. The anchor-count assertion caught it.
- The restore replayed saved text **per edit**, so a mutation touching one file
  twice restored the *intermediate* state; the next mutation then patched a
  half-mutated file. The post-restore clean-tree assertion caught it. Restore is
  now `git checkout`.

I also mis-predicted M1's red set: I expected it to redden the selection test,
and it does not, because both of that table's providers satisfy the constraint
so first-name-match still accepts in every order. The test is insensitive to the
stage-4 half by construction — that insensitivity is what "isolates the
selection rule" means — and the pre-registration was wrong, not the test.

### End to end, offline, both binaries

Built `strata` at `058e6e1` (pre-fix) and at this branch, resolved against a
throwaway `file://` registry carrying `python@3.9.0`, `python@3.13.2` and
`jupyterlab@4.2.0` (which requires `python >= 3.11`), from a profile listing
3.9.0 first:

```
old: rc=1  [stage=stage4 code=UNSATISFIED_REQUIREMENT] unsatisfied requirements for "jupyterlab"
             Requires: python@>=3.11
             Fix: add "python@3.11" to your software list     <- already in the list
new: rc=0  mount_order=1 python-3.9.0 / 2 python-3.13.2 / 3 jupyterlab-4.2.0
```

The pre-fix error also *misdiagnoses* itself: it advises adding a layer that is
already present. The fixture is deliberately outside the repo — shipping a
second `python` in `internal/testregistry` is a separable change and does not
travel with this repair.

And the three in-repo fixture profiles are byte-identical before and after,
excluding two timestamps:

```
$ for p in offline-minimal offline-inline offline-formation; do ...; diff old new; done
offline-minimal:   only probed_at differs
offline-inline:    only probed_at differs
offline-formation: only probed_at differs
```

The timestamp diff is itself the known-positive: it proves the comparison is
sensitive, so "identical apart from it" is a measurement rather than a silent
pass.

## Who is affected

No shipped formation is — `ls cmd/strata/formations/*.yaml | wc -l` is 6 and
none contains two providers of one capability name. The shape is reachable
today from a user profile in two ways, both enumerated in the CHANGELOG entry:
eight recipes ship more than one version
(`ls -d cmd/strata/recipes/*/*/*/ | awk -F/ '{print $5}' | sort | uniq -d`), and
`bcftools` and `samtools` both provide `htslib`
(`grep -l 'name: htslib' cmd/strata/recipes/*/*/*/meta.yaml`). For any lockfile
whose mount order changes, `environment_id` changes with it
(`spec/lockfile_hash.go:99-110`), which is the published lockfile's storage key,
the `strata:environment-id` instance tag, the OCI `image.revision` label and the
Zenodo deposition id — all named in the CHANGELOG.

## Local verification

`gofmt -l .` empty, `go vet ./...` rc=0, `go test -race ./... -count=1` rc=0,
`golangci-lint run` rc=0 / 0 issues.

## Deliberately not in this PR

- `PROPERTIES.md`'s R4/R5 register rows still read `SOUND`/`Basis: none` and now
  have executable evidence to point at. A `Discharged` change travels alone.
- The `runCell` → `runMatrixCell` symbol correction in `boot_matrix_test.go:95`,
  `PROPERTIES.md:2611`, four #148 comments and #152's body.
- An in-repo two-version fixture for the offline-resolve CI job.

